### PR TITLE
feat(ios): add audible Capacitor smoke playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ La metáfora es perfecta: en música, legato significa tocar notas de forma suav
 
 - 2026-04-19: first successful **Android Capacitor smoke** in a real host app for `@legato/capacitor` minimal flow.
   - See: `specs/milestones/2026-04-19-android-capacitor-smoke.md`
-- 2026-04-19: generated **iOS Capacitor host scaffold** for `apps/capacitor-demo` with local SPM plugin wiring via `CapacitorLegato` (no direct host `LegatoCore` link required).
+- 2026-04-19: generated **iOS Capacitor host scaffold** for `apps/capacitor-demo` with Capacitor-managed SPM plugin wiring (`CapacitorLegato`, no direct host `LegatoCore` link required).

--- a/apps/capacitor-demo/README.md
+++ b/apps/capacitor-demo/README.md
@@ -101,8 +101,8 @@ What this gives us now:
 
 What this does **not** give us yet:
 
-- Automatic `CapacitorLegato` package wiring/linking into the iOS host
-- A completed iOS smoke run
+- Verified iOS smoke execution end-to-end
+- Captured iOS smoke logs/evidence for setup/add/play/pause/getSnapshot
 
 ## Native linking caveats (current seam status)
 
@@ -123,22 +123,21 @@ After creating the Android host, run `npm run cap:sync` (once `dist/` is buildab
 
 `packages/capacitor/ios/Sources/LegatoPlugin/*.swift` imports `LegatoCore`.
 
-The host iOS app must manually add local package `packages/capacitor` and link product `CapacitorLegato`.
-`LegatoCore` then resolves transitively from the plugin package, so the host target should not keep a direct `LegatoCore` linkage.
+The host iOS app should rely on Capacitor-generated `CapApp-SPM` integration (which includes local `@legato/capacitor`).
+The plugin package product name expected by generated SPM integration is `CapacitorLegato`, and `LegatoCore` resolves transitively from that plugin package.
+The host target should not keep a duplicate manual local package reference or direct `LegatoCore` linkage.
 
-See `ios/README.md` for the minimal manual linking checklist before first iOS smoke.
+See `ios/README.md` for the minimal iOS package-integration checklist before first iOS smoke.
 
 ## Future iOS smoke path (first attempt)
 
 1. Ensure iOS host exists (`npm run cap:add:ios`, already done once in repo).
 2. Run `npm run cap:sync` after web asset changes.
 3. Open Xcode project (`npm run cap:open:ios`).
-4. Manually add local Swift package:
-   - `packages/capacitor` (from `ios/App` this is `../../../../packages/capacitor`).
-5. Link `CapacitorLegato` product to the `App` target.
-6. Ensure there is no direct `LegatoCore` product linked to target `App`.
-7. Build/run on simulator/device and trigger **Run minimal flow**.
-8. Capture either:
+4. Ensure `CapApp-SPM` remains the only package wiring for plugin integration in the host target.
+5. Ensure there is no duplicate manual package reference to `packages/capacitor` and no direct `LegatoCore` product linked to target `App`.
+6. Build/run on simulator/device and trigger **Run minimal flow**.
+7. Capture either:
    - successful `setup/add/play/pause/getSnapshot` smoke logs, or
    - concrete compile/runtime error for next iteration.
 

--- a/apps/capacitor-demo/index.html
+++ b/apps/capacitor-demo/index.html
@@ -4,13 +4,42 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Legato Capacitor Demo</title>
+    <style>
+      main {
+        max-width: 760px;
+        margin: 2rem auto;
+        font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+      }
+
+      .actions {
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+      }
+
+      #log {
+        width: 100%;
+        min-height: 260px;
+        margin-top: 0.75rem;
+        padding: 0.75rem;
+        border: 1px solid #d1d5db;
+        border-radius: 8px;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+        font-size: 0.85rem;
+        line-height: 1.4;
+        box-sizing: border-box;
+      }
+    </style>
   </head>
   <body>
     <main>
       <h1>Legato Capacitor Demo</h1>
-      <p>Minimal TS wiring sample for setup/add/play/pause/getSnapshot (native smoke only).</p>
-      <button id="run-demo" type="button">Run minimal flow</button>
-      <pre id="log" aria-live="polite"></pre>
+      <p>Minimal TS wiring sample for setup/add/play/pause/getSnapshot (native smoke only). The demo now waits briefly after <code>play()</code> so you can validate audible playback.</p>
+      <div class="actions">
+        <button id="run-demo" type="button">Run minimal flow</button>
+        <button id="copy-log" type="button">Copy log</button>
+      </div>
+      <textarea id="log" aria-live="polite" readonly spellcheck="false" placeholder="Logs and JSON snapshots will appear here..."></textarea>
     </main>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/apps/capacitor-demo/ios/App/App.xcodeproj/project.pbxproj
+++ b/apps/capacitor-demo/ios/App/App.xcodeproj/project.pbxproj
@@ -15,7 +15,6 @@
 		504EC30F1FED79650016851F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30E1FED79650016851F /* Assets.xcassets */; };
 		504EC3121FED79650016851F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
 		50B271D11FEDC1A000F3C39B /* public in Resources */ = {isa = PBXBuildFile; fileRef = 50B271D01FEDC1A000F3C39B /* public */; };
-		C4D0A0B82F95CB48009938D7 /* CapacitorLegato in Frameworks */ = {isa = PBXBuildFile; productRef = C4D0A0B72F95CB48009938D7 /* CapacitorLegato */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -36,7 +35,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C4D0A0B82F95CB48009938D7 /* CapacitorLegato in Frameworks */,
 				4D22ABE92AF431CB00220026 /* CapApp-SPM in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -94,7 +92,6 @@
 			name = App;
 			packageProductDependencies = (
 				4D22ABE82AF431CB00220026 /* CapApp-SPM */,
-				C4D0A0B72F95CB48009938D7 /* CapacitorLegato */,
 			);
 			productName = App;
 			productReference = 504EC3041FED79650016851F /* App.app */;
@@ -127,7 +124,6 @@
 			mainGroup = 504EC2FB1FED79650016851F;
 			packageReferences = (
 				D4C12C0A2AAA248700AAC8A2 /* XCLocalSwiftPackageReference "CapApp-SPM" */,
-				C4D0A0B62F95CB48009938D7 /* XCLocalSwiftPackageReference "../../../../packages/capacitor" */,
 			);
 			productRefGroup = 504EC3051FED79650016851F /* Products */;
 			projectDirPath = "";
@@ -301,6 +297,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 3CD8C2Y85H;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -323,6 +320,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 3CD8C2Y85H;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -362,10 +360,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		C4D0A0B62F95CB48009938D7 /* XCLocalSwiftPackageReference "../../../../packages/capacitor" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../../../../packages/capacitor;
-		};
 		D4C12C0A2AAA248700AAC8A2 /* XCLocalSwiftPackageReference "CapApp-SPM" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = "CapApp-SPM";
@@ -377,10 +371,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = D4C12C0A2AAA248700AAC8A2 /* XCLocalSwiftPackageReference "CapApp-SPM" */;
 			productName = "CapApp-SPM";
-		};
-		C4D0A0B72F95CB48009938D7 /* CapacitorLegato */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = CapacitorLegato;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/apps/capacitor-demo/ios/App/CapApp-SPM/Package.swift
+++ b/apps/capacitor-demo/ios/App/CapApp-SPM/Package.swift
@@ -11,14 +11,16 @@ let package = Package(
             targets: ["CapApp-SPM"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.3.1")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.3.1"),
+        .package(name: "LegatoCapacitor", path: "../../../node_modules/@legato/capacitor")
     ],
     targets: [
         .target(
             name: "CapApp-SPM",
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
-                .product(name: "Cordova", package: "capacitor-swift-pm")
+                .product(name: "Cordova", package: "capacitor-swift-pm"),
+                .product(name: "LegatoCapacitor", package: "LegatoCapacitor")
             ]
         )
     ]

--- a/apps/capacitor-demo/ios/README.md
+++ b/apps/capacitor-demo/ios/README.md
@@ -12,19 +12,17 @@ npx cap add ios
 - Capacitor iOS shell files are in place.
 - Plugin class list includes `LegatoPlugin` in `App/App/capacitor.config.json`.
 
-## Manual wiring still required (critical)
+## Wiring model (current)
 
-`@legato/capacitor` now provides a Swift package manifest, but this host still needs an explicit Xcode package link for the plugin package.
+This host should rely on Capacitor CLI-generated SPM integration only (`App/CapApp-SPM/Package.swift`).
 
 Before the first real iOS smoke attempt, do this in Xcode:
 
 1. Open `ios/App/App.xcodeproj`.
-2. Add local package dependency pointing to:
-   - `../../../../packages/capacitor` (relative to `ios/App`), or equivalent absolute path.
-3. Ensure product `CapacitorLegato` is linked to target `App` (Frameworks/Libraries).
-4. If present, remove direct `LegatoCore` target linkage; `LegatoCore` is transitive through `CapacitorLegato`.
+2. Confirm target `App` links `CapApp-SPM` only (no extra manual local package reference to `../../../../packages/capacitor`).
+3. If present, remove direct `LegatoCore` target linkage; `LegatoCore` must remain transitive via the plugin package.
 
 ## Notes
 
-- Capacitor CLI-managed SPM package (`CapApp-SPM`) remains as generated; the plugin package link is an additional local dependency in the Xcode project.
-- Treat current state as **host prep complete with plugin-package wiring via `CapacitorLegato`**.
+- Capacitor CLI-managed SPM package (`CapApp-SPM`) remains as generated and owns plugin package inclusion.
+- The plugin package product expected by generated SPM integration is `CapacitorLegato`.

--- a/apps/capacitor-demo/src/main.ts
+++ b/apps/capacitor-demo/src/main.ts
@@ -2,41 +2,62 @@ import { Capacitor } from '@capacitor/core';
 import { Legato, createLegatoSync, type Track } from '@legato/capacitor';
 
 const button = document.querySelector<HTMLButtonElement>('#run-demo');
-const logNode = document.querySelector<HTMLPreElement>('#log');
+const copyButton = document.querySelector<HTMLButtonElement>('#copy-log');
+const logNode = document.querySelector<HTMLTextAreaElement>('#log');
 
-if (!button || !logNode) {
+if (!button || !copyButton || !logNode) {
   throw new Error('Demo UI nodes are missing');
 }
 
 const log = (message: string, payload?: unknown) => {
   const line = payload === undefined ? message : `${message} ${JSON.stringify(payload, null, 2)}`;
-  logNode.textContent = `${logNode.textContent}${line}\n`;
+  logNode.value = `${logNode.value}${line}\n`;
+  logNode.scrollTop = logNode.scrollHeight;
+};
+
+const copyLog = async () => {
+  const text = logNode.value.trim();
+
+  if (!text) {
+    log('No log output to copy yet.');
+    return;
+  }
+
+  try {
+    await navigator.clipboard.writeText(logNode.value);
+    log('Copied log to clipboard.');
+  } catch {
+    logNode.focus();
+    logNode.select();
+    log('Clipboard API unavailable. Log text selected — press Cmd/Ctrl+C.');
+  }
 };
 
 const platform = Capacitor.getPlatform();
 const isNative = Capacitor.isNativePlatform();
+const playbackSmokeDelayMs = 1500;
 
 const demoTracks: Track[] = [
   {
     id: 'track-demo-1',
-    url: 'https://example.com/audio/track-1.mp3',
-    title: 'Demo Track 1',
-    artist: 'Legato',
-    duration: 120000,
+    url: 'https://samplelib.com/lib/preview/mp3/sample-3s.mp3',
+    title: 'Demo Track 1 (3s sample)',
+    artist: 'Samplelib',
+    duration: 3000,
     type: 'progressive',
   },
   {
     id: 'track-demo-2',
-    url: 'https://example.com/audio/track-2.mp3',
-    title: 'Demo Track 2',
-    artist: 'Legato',
-    duration: 180000,
+    url: 'https://samplelib.com/lib/preview/mp3/sample-6s.mp3',
+    title: 'Demo Track 2 (6s sample)',
+    artist: 'Samplelib',
+    duration: 6000,
     type: 'progressive',
   },
 ];
 
 const runMinimalFlow = async () => {
-  logNode.textContent = '';
+  logNode.value = '';
   log('Starting Legato minimal flow...');
   log('platform:', platform);
   log('isNativePlatform:', isNative);
@@ -64,6 +85,9 @@ const runMinimalFlow = async () => {
     await Legato.play();
     log('play() ok');
 
+    log(`waiting ${playbackSmokeDelayMs}ms before pause() to validate audible playback...`);
+    await new Promise((resolve) => setTimeout(resolve, playbackSmokeDelayMs));
+
     await Legato.pause();
     log('pause() ok');
 
@@ -79,6 +103,10 @@ const runMinimalFlow = async () => {
 
 button.addEventListener('click', () => {
   void runMinimalFlow();
+});
+
+copyButton.addEventListener('click', () => {
+  void copyLog();
 });
 
 if (!isNative) {

--- a/native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSCoreComposition.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSCoreComposition.swift
@@ -22,7 +22,7 @@ public struct LegatoiOSCoreDependencies {
         sessionManager: LegatoiOSSessionManager = LegatoiOSSessionManager(),
         nowPlayingManager: LegatoiOSNowPlayingManager = LegatoiOSNowPlayingManager(),
         remoteCommandManager: LegatoiOSRemoteCommandManager = LegatoiOSRemoteCommandManager(),
-        playbackRuntime: LegatoiOSPlaybackRuntime = LegatoiOSNoopPlaybackRuntime()
+        playbackRuntime: LegatoiOSPlaybackRuntime = LegatoiOSAVPlayerPlaybackRuntime()
     ) {
         self.queueManager = queueManager
         self.eventEmitter = eventEmitter

--- a/native/ios/LegatoCore/Sources/LegatoCore/Runtime/LegatoiOSPlaybackRuntime.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCore/Runtime/LegatoiOSPlaybackRuntime.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 
 /// Runtime seam for AVPlayer-backed integration.
@@ -58,7 +59,7 @@ public struct LegatoiOSRuntimeSnapshot {
     }
 }
 
-/// Minimal in-memory runtime until AVPlayer wiring is introduced.
+/// Minimal in-memory fallback runtime.
 ///
 /// This intentionally does not play audio. It only keeps deterministic runtime-facing state.
 public final class LegatoiOSNoopPlaybackRuntime: LegatoiOSPlaybackRuntime {
@@ -118,5 +119,177 @@ public final class LegatoiOSNoopPlaybackRuntime: LegatoiOSPlaybackRuntime {
         currentIndex = nil
         trackCount = 0
         progress = LegatoiOSRuntimeProgress(positionMs: 0, durationMs: nil, bufferedPositionMs: 0)
+    }
+}
+
+/// AVPlayer-backed runtime for foreground audible playback.
+///
+/// This adapter intentionally keeps scope minimal for MVP:
+/// - single active AVPlayerItem selected by index
+/// - no background playback behavior
+/// - no interruptions/remote command orchestration
+public final class LegatoiOSAVPlayerPlaybackRuntime: LegatoiOSPlaybackRuntime {
+    private let player: AVPlayer
+    private var trackSources: [LegatoiOSRuntimeTrackSource] = []
+    private var currentIndex: Int?
+
+    public init(player: AVPlayer = AVPlayer()) {
+        self.player = player
+    }
+
+    public func configure() {
+        // Runtime initialization is completed at init time.
+    }
+
+    public func replaceQueue(items: [LegatoiOSRuntimeTrackSource], startIndex: Int?) throws {
+        trackSources = items
+
+        guard !items.isEmpty else {
+            currentIndex = nil
+            player.replaceCurrentItem(with: nil)
+            return
+        }
+
+        let nextIndex: Int
+        if let startIndex, items.indices.contains(startIndex) {
+            nextIndex = startIndex
+        } else {
+            nextIndex = 0
+        }
+
+        try loadItem(at: nextIndex)
+    }
+
+    public func selectIndex(_ index: Int) throws {
+        guard trackSources.indices.contains(index) else {
+            return
+        }
+
+        try loadItem(at: index)
+    }
+
+    public func play() throws {
+        guard player.currentItem != nil else {
+            throw LegatoiOSError(code: .playbackFailed, message: "No active AVPlayer item to play")
+        }
+        player.play()
+    }
+
+    public func pause() throws {
+        player.pause()
+    }
+
+    public func stop(resetPosition: Bool) throws {
+        player.pause()
+        guard resetPosition else {
+            return
+        }
+
+        player.seek(to: .zero)
+    }
+
+    public func seek(to positionMs: Int64) throws {
+        let clamped = max(0, positionMs)
+        let seconds = Double(clamped) / 1000
+        let target = CMTime(seconds: seconds, preferredTimescale: 1000)
+        player.seek(to: target)
+    }
+
+    public func snapshot() -> LegatoiOSRuntimeSnapshot {
+        let item = player.currentItem
+        let duration = durationMs(for: item)
+        let bufferedPosition = bufferedPositionMs(for: item)
+        let position = positionMs(for: item)
+
+        return LegatoiOSRuntimeSnapshot(
+            stateHint: stateHint(),
+            currentIndex: currentIndex,
+            progress: LegatoiOSRuntimeProgress(
+                positionMs: position,
+                durationMs: duration,
+                bufferedPositionMs: bufferedPosition
+            )
+        )
+    }
+
+    public func release() {
+        player.pause()
+        player.replaceCurrentItem(with: nil)
+        trackSources = []
+        currentIndex = nil
+    }
+
+    private func loadItem(at index: Int) throws {
+        guard trackSources.indices.contains(index) else {
+            throw LegatoiOSError(code: .invalidIndex, message: "Requested runtime index is out of bounds")
+        }
+
+        let source = trackSources[index]
+        guard let url = URL(string: source.url), url.scheme != nil else {
+            throw LegatoiOSError(code: .invalidURL, message: "Track URL is invalid: \(source.url)")
+        }
+
+        // Keep the audible-playback MVP on public AVFoundation APIs only.
+        // Demo smoke URLs currently do not require custom headers.
+        let asset = AVURLAsset(url: url)
+        let item = AVPlayerItem(asset: asset)
+
+        player.replaceCurrentItem(with: item)
+        currentIndex = index
+    }
+
+    private func stateHint() -> LegatoiOSPlaybackState? {
+        guard player.currentItem != nil else {
+            return .idle
+        }
+
+        if player.timeControlStatus == .playing {
+            return .playing
+        }
+
+        if player.timeControlStatus == .waitingToPlayAtSpecifiedRate {
+            return .buffering
+        }
+
+        return .paused
+    }
+
+    private func positionMs(for item: AVPlayerItem?) -> Int64 {
+        guard item != nil else {
+            return 0
+        }
+
+        return milliseconds(from: player.currentTime()) ?? 0
+    }
+
+    private func durationMs(for item: AVPlayerItem?) -> Int64? {
+        guard let item else {
+            return nil
+        }
+
+        return milliseconds(from: item.duration)
+    }
+
+    private func bufferedPositionMs(for item: AVPlayerItem?) -> Int64? {
+        guard let item,
+              let loaded = item.loadedTimeRanges.first?.timeRangeValue
+        else {
+            return nil
+        }
+
+        return milliseconds(from: CMTimeAdd(loaded.start, loaded.duration))
+    }
+
+    private func milliseconds(from time: CMTime) -> Int64? {
+        guard time.isValid else {
+            return nil
+        }
+
+        let seconds = CMTimeGetSeconds(time)
+        guard seconds.isFinite, !seconds.isNaN else {
+            return nil
+        }
+
+        return Int64(max(0, seconds * 1000))
     }
 }

--- a/packages/capacitor/CapacitorLegato.podspec
+++ b/packages/capacitor/CapacitorLegato.podspec
@@ -1,12 +1,20 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
 Pod::Spec.new do |s|
   s.name = 'CapacitorLegato'
-  s.version = '0.1.0'
-  s.summary = 'Capacitor binding MVP for Legato.'
-  s.license = 'MIT'
-  s.homepage = 'https://github.com/legato/legato'
-  s.author = 'Legato'
-  s.source = { :git => 'https://github.com/legato/legato.git', :tag => s.version.to_s }
-  s.source_files = 'ios/Sources/**/*.{swift,h,m}'
-  s.ios.deployment_target = '14.0'
+  s.version = package['version']
+  s.summary = package['description']
+  s.license = package['license']
+  s.homepage = package['homepage'] || 'https://github.com/legato/legato'
+  s.author = package['author'] || 'Legato'
+  s.source = {
+    :git => 'https://github.com/legato/legato.git',
+    :tag => "#{package['name']}@#{package['version']}"
+  }
+  s.source_files = 'ios/Sources/**/*.{swift,h,m,c,cc,mm,cpp}'
+  s.ios.deployment_target = '15.0'
   s.dependency 'Capacitor'
+  s.swift_version = '5.9'
 end

--- a/packages/capacitor/Package.swift
+++ b/packages/capacitor/Package.swift
@@ -2,25 +2,26 @@
 import PackageDescription
 
 let package = Package(
-    name: "CapacitorLegato",
+    name: "LegatoCapacitor",
     platforms: [
         .iOS(.v15)
     ],
     products: [
         .library(
-            name: "CapacitorLegato",
+            name: "LegatoCapacitor",
             targets: ["LegatoPlugin"]
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.3.1"),
-        .package(path: "../../native/ios/LegatoCore")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
+        .package(path: "../../../../../native/ios/LegatoCore")
     ],
     targets: [
         .target(
             name: "LegatoPlugin",
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
+                .product(name: "Cordova", package: "capacitor-swift-pm"),
                 .product(name: "LegatoCore", package: "LegatoCore")
             ],
             path: "ios/Sources/LegatoPlugin"

--- a/packages/capacitor/README.md
+++ b/packages/capacitor/README.md
@@ -29,8 +29,13 @@ It also exports typed event helpers aligned with `@legato/contract`, and `create
 
 This package now includes a root `Package.swift` for Capacitor iOS SPM hosts.
 
-- Package product: `CapacitorLegato`
+- Package name/product: `CapacitorLegato`
 - Plugin target: `LegatoPlugin`
-- Transitive native dependency: `LegatoCore` (resolved from `../../native/ios/LegatoCore` for local monorepo usage)
+- Transitive native dependency: `LegatoCore` (resolved via relative local-monorepo path in `Package.swift`)
 
-When adding this package to an iOS host app in Xcode, link product `CapacitorLegato` to the app target.
+When this package is consumed by Capacitor-generated iOS SPM integration, the expected product name is `CapacitorLegato`.
+
+To keep iOS SPM integration clean and compatible with `npx cap sync ios` generated files:
+
+- Do not modify `ios/App/CapApp-SPM` generated sources/packages.
+- The plugin package itself provides the standard Capacitor SPM linkage shape (`Capacitor` + `Cordova`) through the `CapacitorLegato` product so `npx cap sync ios` generated wiring can remain the source of truth.

--- a/packages/capacitor/ios/Sources/LegatoPlugin/LegatoPlugin.swift
+++ b/packages/capacitor/ios/Sources/LegatoPlugin/LegatoPlugin.swift
@@ -59,13 +59,15 @@ public final class LegatoPlugin: CAPPlugin, CAPBridgedPlugin {
             let tracks = rawTracks.compactMap { $0 as? [String: Any] }.map(LegatoCapacitorMapper.track)
             let mappedTracks = try core.trackMapper.mapContractTracks(tracks)
 
-            let queueSnapshot: LegatoiOSQueueSnapshot
             if let startIndex = call.getInt("startIndex") {
                 let mergedItems = core.queueManager.getQueueSnapshot().items + mappedTracks
-                queueSnapshot = try core.queueManager.replaceQueue(mergedItems, startIndex: startIndex)
-            } else {
-                queueSnapshot = core.queueManager.addToQueue(mappedTracks)
+                try core.playerEngine.load(tracks: mergedItems, startIndex: startIndex)
+                let snapshot = core.playerEngine.snapshot()
+                call.resolve(["snapshot": LegatoCapacitorMapper.snapshotToDictionary(snapshot)])
+                return
             }
+
+            let queueSnapshot = core.queueManager.addToQueue(mappedTracks)
 
             let previous = core.snapshotStore.getPlaybackSnapshot()
             let next = snapshotWithQueue(previous: previous, queue: queueSnapshot)

--- a/packages/capacitor/package.json
+++ b/packages/capacitor/package.json
@@ -3,6 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "description": "Capacitor binding MVP for Legato.",
+  "author": "Legato",
+  "homepage": "https://github.com/legato/legato",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/legato/legato.git",
+    "directory": "packages/capacitor"
+  },
   "license": "MIT",
   "type": "module",
   "main": "./src/index.ts",


### PR DESCRIPTION
Closes #5

## Summary
- add an AVPlayer-backed iOS playback runtime and route Capacitor `add(startIndex)` through the canonical engine load path
- align the Legato Capacitor iOS package with the official Capacitor SPM shape so `npx cap sync ios` works cleanly without app-level hacks
- improve the Capacitor demo with copy-friendly logs, direct audio URLs, and a short play delay to validate audible playback

## Changes
| File | Change |
|------|--------|
| `native/ios/LegatoCore/Sources/LegatoCore/Runtime/LegatoiOSPlaybackRuntime.swift` | adds AVPlayer-backed runtime behavior for foreground audible playback MVP |
| `native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSCoreComposition.swift` | wires the real iOS playback runtime into core composition |
| `packages/capacitor/ios/Sources/LegatoPlugin/LegatoPlugin.swift` | routes `add(startIndex)` through `playerEngine.load(...)` and preserves plugin bridge behavior |
| `packages/capacitor/Package.swift` | aligns plugin packaging with Capacitor's official SPM shape and local LegatoCore dependency path |
| `packages/capacitor/CapacitorLegato.podspec` | keeps package metadata aligned with the plugin packaging shape |
| `packages/capacitor/package.json` | includes updated package metadata/files for Capacitor plugin distribution |
| `apps/capacitor-demo/src/main.ts` | switches demo tracks to direct audio URLs, improves copyable logs, and waits briefly after play() |
| `apps/capacitor-demo/index.html` | adds copy-friendly log UI and updates smoke instructions |
| `apps/capacitor-demo/ios/App/CapApp-SPM/Package.swift` | reflects regenerated Capacitor-managed SPM integration after sync |
| `apps/capacitor-demo/ios/App/App.xcodeproj/project.pbxproj` | keeps iOS host package wiring in sync with the clean SPM integration path |
| `README.md`, `apps/capacitor-demo/README.md`, `apps/capacitor-demo/ios/README.md`, `packages/capacitor/README.md` | document the iOS SPM/autoload findings and audible smoke workflow |

## Test Plan
- [x] Ran `npx cap sync ios` for the Capacitor demo workflow
- [x] Opened the iOS demo in Xcode and verified plugin autoload no longer returns `UNIMPLEMENTED`
- [x] Validated `setup`, `add`, `play`, `pause`, and `getSnapshot` from the demo UI
- [x] Confirmed audible playback works on iOS using direct MP3 URLs
- [x] Confirmed queue/state/progress snapshots and events are emitted coherently in the demo log

## Notes
- The crucial autoload fix was returning the plugin package to Capacitor's official SPM shape; app-level anchor hacks were intentionally avoided.
- This milestone validates foreground audible playback only; background audio, interruptions, and remote command handling remain future work.
