### PR TITLE
feat(ios): add playback progression semantics

### DIFF
--- a/.agents/skills/capacitor-ios-spm/SKILL.md
+++ b/.agents/skills/capacitor-ios-spm/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: capacitor-ios-spm
+description: >
+  Keep Capacitor iOS Swift Package Manager plugins aligned with the official package shape and sync workflow.
+  Trigger: When wiring or debugging Capacitor iOS SPM plugins, CapApp-SPM autoload, package naming, packageClassList, or `UNIMPLEMENTED` plugin issues.
+license: Apache-2.0
+compatibility: opencode
+metadata:
+  author: gentleman-programming
+  version: "1.0"
+---
+
+## When to Use
+
+- When adding or fixing a Capacitor iOS plugin that must work with `npx cap sync ios`
+- When `CapApp-SPM`, `packageClassList`, or `UNIMPLEMENTED` issues appear on iOS
+- When comparing a local plugin package against official Capacitor / Capawesome SPM conventions
+
+## Critical Patterns
+
+- Follow the official Capacitor plugin SPM shape: standard `.library(...)`, no custom `type: .dynamic` unless proven necessary by upstream docs.
+- Treat `ios/App/CapApp-SPM/Package.swift` as CLI-generated — never hand-edit it.
+- The effective package/product naming is whatever `CapApp-SPM` requests; `Package.swift` in the plugin must expose the exact same package/product names.
+- Keep plugin discovery class-based: `@objc(PluginClassName)` + `CAPPlugin, CAPBridgedPlugin` + `identifier`, `jsName`, `pluginMethods`.
+- Verify `ios/App/App/capacitor.config.json` contains the plugin class in `packageClassList` after `npx cap sync ios`.
+- For monorepo local path dependencies, validate `Package.swift` paths from the real consumer entrypoint (`node_modules/...`), not just from the plugin folder itself.
+- Prefer official patterns from `create-capacitor-plugin`, Capacitor docs, and Capawesome plugins before introducing custom packaging behavior.
+- If Xcode shows `Missing package product 'CapApp-SPM'`, inspect the real SwiftPM resolution error first; it is usually a downstream symptom.
+
+## Commands
+
+```bash
+cd apps/capacitor-demo
+npm run cap:sync
+open "ios/App/App.xcodeproj"
+xcodebuild -resolvePackageDependencies -project "apps/capacitor-demo/ios/App/App.xcodeproj"
+```
+
+## Resources
+
+- OpenCode skills docs: use `.opencode/skills/<name>/SKILL.md` or compatible `.agents/skills/<name>/SKILL.md`
+- Capacitor official plugin template: `create-capacitor-plugin`
+- Capacitor plugin docs: `https://capacitorjs.com/docs/plugins/creating-plugins`

--- a/.agents/skills/capacitor-native-test-harness/SKILL.md
+++ b/.agents/skills/capacitor-native-test-harness/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: capacitor-native-test-harness
+description: >
+  Keep the Capacitor demo app usable as a native debugging console for playback and plugin integration work.
+  Trigger: When native Capacitor/Android/iOS behavior changes and the app-side test UI should be updated to make validation easier.
+license: Apache-2.0
+compatibility: opencode
+metadata:
+  author: gentleman-programming
+  version: "1.0"
+---
+
+## When to Use
+
+- When native playback behavior changes and the demo app should expose new controls or signals
+- When a one-click smoke button is no longer enough to validate runtime behavior
+- When logs, snapshots, queue editing, or event visibility need to improve for native debugging
+
+## Critical Patterns
+
+- Treat `apps/capacitor-demo` as a plain HTML/TS native test harness, not a polished product UI.
+- Always preserve both paths: a one-click smoke flow **and** manual step-by-step controls.
+- Prefer separate actions for `setup`, `start sync`, `add`, `play`, `pause`, `stop`, `seekTo`, and `getSnapshot`.
+- Keep raw logs copy-friendly (textarea + copy button) and keep recent events/progress visible without opening Xcode logs.
+- Show a concise snapshot summary plus raw JSON so state and payloads can be inspected quickly.
+- Use direct audio URLs for AVPlayer smoke validation; avoid redirects when testing audible playback.
+- When native behavior changes, update the harness in the same change so validation remains easy for the next iteration.
+- After UI/demo changes, refresh the native host with `npm run build` + `npm run cap:sync` before testing in Xcode.
+
+## Commands
+
+```bash
+cd apps/capacitor-demo
+npm run build
+npm run cap:sync
+open "ios/App/App.xcodeproj"
+```
+
+## Resources
+
+- Demo entry files: `apps/capacitor-demo/index.html`, `apps/capacitor-demo/src/main.ts`
+- Native host: `apps/capacitor-demo/ios/App`

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ TestResults.xml
 # Node / web build
 node_modules/
 dist/
+.atl/
 
 # Android / Gradle build outputs
 .gradle/

--- a/apps/capacitor-demo/index.html
+++ b/apps/capacitor-demo/index.html
@@ -5,41 +5,152 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Legato Capacitor Demo</title>
     <style>
+      :root {
+        color-scheme: light dark;
+      }
+
       main {
-        max-width: 760px;
-        margin: 2rem auto;
+        max-width: 980px;
+        margin: 1.25rem auto 2rem;
+        padding: 0 0.75rem;
         font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
       }
 
-      .actions {
-        display: flex;
-        gap: 0.5rem;
-        flex-wrap: wrap;
+      h1,
+      h2 {
+        margin: 0 0 0.5rem;
       }
 
-      #log {
+      p {
+        margin: 0;
+      }
+
+      .stack {
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      .card {
+        border: 1px solid #d1d5db;
+        border-radius: 10px;
+        padding: 0.85rem;
+        background: color-mix(in srgb, canvas 96%, #94a3b8 4%);
+      }
+
+      .actions,
+      .action-grid {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+      }
+
+      .action-grid button {
+        min-width: 132px;
+      }
+
+      .two-col {
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      @media (min-width: 860px) {
+        .two-col {
+          grid-template-columns: 1fr 1fr;
+        }
+      }
+
+      .inline-fields {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.6rem;
+      }
+
+      .inline-fields label {
+        display: grid;
+        gap: 0.35rem;
+        font-size: 0.9rem;
+      }
+
+      input,
+      textarea,
+      button {
+        font: inherit;
+      }
+
+      input,
+      textarea {
+        border: 1px solid #cbd5e1;
+        border-radius: 8px;
+        padding: 0.5rem 0.6rem;
+        box-sizing: border-box;
+      }
+
+      textarea {
         width: 100%;
-        min-height: 260px;
-        margin-top: 0.75rem;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+        font-size: 0.84rem;
+        line-height: 1.35;
+      }
+
+      button {
+        border: 1px solid #64748b;
+        border-radius: 8px;
+        background: #0f172a;
+        color: #f8fafc;
+        padding: 0.45rem 0.8rem;
+        cursor: pointer;
+      }
+
+      button[disabled] {
+        opacity: 0.45;
+        cursor: not-allowed;
+      }
+
+      #snapshot-summary {
+        margin: 0;
         padding: 0.75rem;
         border: 1px solid #d1d5db;
         border-radius: 8px;
+        min-height: 84px;
+        white-space: pre-wrap;
         font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
-        font-size: 0.85rem;
-        line-height: 1.4;
-        box-sizing: border-box;
+        font-size: 0.83rem;
+      }
+
+      #events {
+        min-height: 140px;
+      }
+
+      #snapshot-json {
+        min-height: 170px;
+      }
+
+      #log {
+        min-height: 220px;
       }
     </style>
   </head>
   <body>
     <main>
       <h1>Legato Capacitor Demo</h1>
-      <p>Minimal TS wiring sample for setup/add/play/pause/getSnapshot (native smoke only). The demo now waits briefly after <code>play()</code> so you can validate audible playback.</p>
-      <div class="actions">
-        <button id="run-demo" type="button">Run minimal flow</button>
-        <button id="copy-log" type="button">Copy log</button>
+      <p>Native playback smoke harness for iOS/Capacitor debugging.</p>
+
+      <div class="stack" style="margin-top: 0.8rem">
+        <section class="card stack">
+          <h2>Smoke actions</h2>
+          <div class="actions">
+            <button id="run-smoke" class="native-action" type="button">Run smoke flow</button>
+            <button id="run-end-smoke" class="native-action" type="button">Run let-it-end smoke</button>
+            <button id="copy-log" type="button">Copy raw log</button>
+          </div>
+          <div id="env-status">Detecting platform…</div>
+        </section>
+
+        <section class="card stack">
+          <h2>Raw operation log</h2>
+          <textarea id="log" readonly spellcheck="false" placeholder="Action logs, payloads, and errors..."></textarea>
+        </section>
       </div>
-      <textarea id="log" aria-live="polite" readonly spellcheck="false" placeholder="Logs and JSON snapshots will appear here..."></textarea>
     </main>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/apps/capacitor-demo/src/main.ts
+++ b/apps/capacitor-demo/src/main.ts
@@ -1,46 +1,206 @@
 import { Capacitor } from '@capacitor/core';
-import { Legato, createLegatoSync, type Track } from '@legato/capacitor';
+import { Legato, createLegatoSync, type PlaybackSnapshot, type Track } from '@legato/capacitor';
 
-const button = document.querySelector<HTMLButtonElement>('#run-demo');
+type LegatoSyncController = ReturnType<typeof createLegatoSync>;
+
+const smokeButton = document.querySelector<HTMLButtonElement>('#run-smoke');
+const endSmokeButton = document.querySelector<HTMLButtonElement>('#run-end-smoke');
 const copyButton = document.querySelector<HTMLButtonElement>('#copy-log');
+const envStatusNode = document.querySelector<HTMLDivElement>('#env-status');
 const logNode = document.querySelector<HTMLTextAreaElement>('#log');
 
-if (!button || !copyButton || !logNode) {
+if (!smokeButton || !endSmokeButton || !copyButton || !envStatusNode || !logNode) {
   throw new Error('Demo UI nodes are missing');
 }
 
-const log = (message: string, payload?: unknown) => {
-  const line = payload === undefined ? message : `${message} ${JSON.stringify(payload, null, 2)}`;
-  logNode.value = `${logNode.value}${line}\n`;
+const nativeActionButtons = Array.from(document.querySelectorAll<HTMLButtonElement>('.native-action'));
+const playbackSmokeDelayMs = 1500;
+const endSmokeDelayMs = 6500;
+
+let syncController: LegatoSyncController | null = null;
+
+const formatMs = (value: number | null | undefined): string => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return 'n/a';
+  }
+
+  const totalSeconds = Math.floor(Math.max(0, value) / 1000);
+  const minutes = Math.floor(totalSeconds / 60)
+    .toString()
+    .padStart(2, '0');
+  const seconds = (totalSeconds % 60).toString().padStart(2, '0');
+  return `${minutes}:${seconds} (${value}ms)`;
+};
+
+const summarizeSnapshot = (snapshot: PlaybackSnapshot): string => {
+  const currentTitle = snapshot.currentTrack?.title ?? '(none)';
+  const queueItems = (snapshot.queue as { items?: unknown[]; tracks?: unknown[] }).items
+    ?? (snapshot.queue as { items?: unknown[]; tracks?: unknown[] }).tracks
+    ?? [];
+  const queueLength = queueItems.length;
+  return [
+    `state=${snapshot.state}`,
+    `track=${currentTitle}`,
+    `index=${snapshot.currentIndex ?? 'null'}`,
+    `position=${formatMs(snapshot.position)}`,
+    `duration=${formatMs(snapshot.duration)}`,
+    `buffered=${formatMs(snapshot.bufferedPosition ?? null)}`,
+    `queue=${queueLength}`,
+  ].join(' | ');
+};
+
+const summarizePayload = (payload: unknown): string => {
+  if (payload === undefined) {
+    return '';
+  }
+
+  if (payload instanceof Error) {
+    const details = [
+      `name=${payload.name}`,
+      `message=${payload.message || '(no message)'}`,
+    ];
+
+    const stackLine = payload.stack?.split('\n').slice(0, 2).join(' | ');
+    if (stackLine) {
+      details.push(`stack=${stackLine}`);
+    }
+
+    return details.join(' | ');
+  }
+
+  if (!payload || typeof payload !== 'object') {
+    return String(payload);
+  }
+
+  if ('message' in payload || 'code' in payload) {
+    const maybeError = payload as {
+      message?: unknown;
+      code?: unknown;
+      name?: unknown;
+      stack?: unknown;
+    };
+
+    const details = [
+      `name=${String(maybeError.name ?? 'Error')}`,
+      `message=${String(maybeError.message ?? '(no message)')}`,
+    ];
+
+    if (maybeError.code !== undefined) {
+      details.push(`code=${String(maybeError.code)}`);
+    }
+
+    if (typeof maybeError.stack === 'string' && maybeError.stack) {
+      details.push(`stack=${maybeError.stack.split('\n').slice(0, 2).join(' | ')}`);
+    }
+
+    return details.join(' | ');
+  }
+
+  if ('state' in payload && 'queue' in payload) {
+    return `snapshot { ${summarizeSnapshot(payload as PlaybackSnapshot)} }`;
+  }
+
+  if ('position' in payload || 'duration' in payload || 'bufferedPosition' in payload) {
+    const progress = payload as { position?: number | null; duration?: number | null; bufferedPosition?: number | null };
+    return [
+      `position=${formatMs(progress.position ?? null)}`,
+      `duration=${formatMs(progress.duration ?? null)}`,
+      `buffered=${formatMs(progress.bufferedPosition ?? null)}`,
+    ].join(' | ');
+  }
+
+  if ('track' in payload || 'index' in payload) {
+    const active = payload as { index?: number | null; track?: { title?: string; id?: string } | null };
+    return `index=${active.index ?? 'null'} | track=${active.track?.title ?? active.track?.id ?? '(none)'}`;
+  }
+
+  const compact = JSON.stringify(payload);
+  return compact.length > 220 ? `${compact.slice(0, 220)}…` : compact;
+};
+
+const log = (message: string, payload?: unknown): void => {
+  const prefix = `[${new Date().toLocaleTimeString()}]`;
+  const line = payload === undefined ? message : `${message} ${summarizePayload(payload)}`;
+  logNode.value = `${logNode.value}${prefix} ${line}\n`;
   logNode.scrollTop = logNode.scrollHeight;
 };
 
-const copyLog = async () => {
-  const text = logNode.value.trim();
+const setRunning = (running: boolean): void => {
+  nativeActionButtons.forEach((button) => {
+    button.disabled = running;
+  });
+};
 
-  if (!text) {
-    log('No log output to copy yet.');
+const runNativeAction = async (name: string, action: () => Promise<void>): Promise<void> => {
+  setRunning(true);
+  log(`${name} started`);
+  try {
+    await action();
+    log(`${name} finished`);
+  } catch (error) {
+    log(`${name} failed:`, error);
+  } finally {
+    setRunning(false);
+  }
+};
+
+const startSync = async (): Promise<void> => {
+  if (syncController) {
+    log('sync already active');
+    return;
+  }
+
+  syncController = createLegatoSync({
+    onSnapshot: (snapshot) => {
+      log('sync snapshot', snapshot);
+    },
+    onEvent: (eventName, payload) => {
+      log(`event:${eventName}`, payload);
+    },
+  });
+
+  const initial = await syncController.start();
+  log('sync.start() initial snapshot', initial);
+};
+
+const stopSync = async (): Promise<void> => {
+  if (!syncController) {
+    log('sync is not active');
+    return;
+  }
+
+  await syncController.stop();
+  syncController = null;
+  log('sync.stop() done');
+};
+
+const copyText = async (text: string, emptyMessage: string, successMessage: string): Promise<void> => {
+  const trimmed = text.trim();
+
+  if (!trimmed) {
+    log(emptyMessage);
     return;
   }
 
   try {
-    await navigator.clipboard.writeText(logNode.value);
-    log('Copied log to clipboard.');
+    await navigator.clipboard.writeText(text);
+    log(successMessage);
   } catch {
-    logNode.focus();
-    logNode.select();
-    log('Clipboard API unavailable. Log text selected — press Cmd/Ctrl+C.');
+    log('Clipboard API unavailable. Copy manually from the visible text area.');
   }
+};
+
+const copyLog = async () => {
+  await copyText(logNode.value, 'No log output to copy yet.', 'Copied raw log to clipboard.');
 };
 
 const platform = Capacitor.getPlatform();
 const isNative = Capacitor.isNativePlatform();
-const playbackSmokeDelayMs = 1500;
 
 const demoTracks: Track[] = [
   {
     id: 'track-demo-1',
-    url: 'https://samplelib.com/lib/preview/mp3/sample-3s.mp3',
+    url: 'https://samplelib.com/mp3/sample-3s.mp3',
     title: 'Demo Track 1 (3s sample)',
     artist: 'Samplelib',
     duration: 3000,
@@ -48,7 +208,7 @@ const demoTracks: Track[] = [
   },
   {
     id: 'track-demo-2',
-    url: 'https://samplelib.com/lib/preview/mp3/sample-6s.mp3',
+    url: 'https://samplelib.com/mp3/sample-6s.mp3',
     title: 'Demo Track 2 (6s sample)',
     artist: 'Samplelib',
     duration: 6000,
@@ -56,53 +216,71 @@ const demoTracks: Track[] = [
   },
 ];
 
-const runMinimalFlow = async () => {
+const runSmokeFlow = async (): Promise<void> => {
   logNode.value = '';
   log('Starting Legato minimal flow...');
   log('platform:', platform);
   log('isNativePlatform:', isNative);
 
-  if (!isNative) {
-    log('Smoke path is native-only. Open the app from Android Studio/Xcode after cap sync.');
-    return;
-  }
+  await Legato.setup();
+  log('setup() ok');
 
-  const sync = createLegatoSync({
-    onSnapshot: (snapshot) => log('sync snapshot:', snapshot),
-    onEvent: (eventName, payload) => log(`event:${eventName}`, payload),
-  });
+  await startSync();
 
-  try {
-    await Legato.setup();
-    log('setup() ok');
+  const afterAdd = await Legato.add({ tracks: demoTracks, startIndex: 0 });
+  log('add() snapshot', afterAdd);
 
-    const initial = await sync.start();
-    log('sync.start() initial snapshot:', initial);
+  await Legato.play();
+  log('play() ok');
 
-    const afterAdd = await Legato.add({ tracks: demoTracks, startIndex: 0 });
-    log('add() snapshot:', afterAdd);
+  log(`waiting ${playbackSmokeDelayMs}ms before pause() to validate audible playback...`);
+  await new Promise((resolve) => setTimeout(resolve, playbackSmokeDelayMs));
 
-    await Legato.play();
-    log('play() ok');
+  await Legato.pause();
+  log('pause() ok');
 
-    log(`waiting ${playbackSmokeDelayMs}ms before pause() to validate audible playback...`);
-    await new Promise((resolve) => setTimeout(resolve, playbackSmokeDelayMs));
+  const finalSnapshot = await Legato.getSnapshot();
+  log('getSnapshot() final snapshot', finalSnapshot);
 
-    await Legato.pause();
-    log('pause() ok');
-
-    const snapshot = await Legato.getSnapshot();
-    log('getSnapshot() final snapshot:', snapshot);
-  } catch (error) {
-    log('Flow failed:', error);
-  } finally {
-    await sync.stop();
-    log('sync.stop() done');
-  }
+  await stopSync();
 };
 
-button.addEventListener('click', () => {
-  void runMinimalFlow();
+const runLetItEndSmokeFlow = async (): Promise<void> => {
+  logNode.value = '';
+  log('Starting Legato let-it-end flow...');
+  log('platform:', platform);
+  log('isNativePlatform:', isNative);
+
+  await Legato.setup();
+  log('setup() ok');
+
+  await startSync();
+
+  const afterAdd = await Legato.add({ tracks: demoTracks, startIndex: 0 });
+  log('add() snapshot', afterAdd);
+
+  await Legato.play();
+  log(`play() ok, wait ${endSmokeDelayMs}ms for track end...`);
+
+  await new Promise((resolve) => setTimeout(resolve, endSmokeDelayMs));
+
+  const finalSnapshot = await Legato.getSnapshot();
+  log('final snapshot after end wait', finalSnapshot);
+
+  await stopSync();
+};
+
+envStatusNode.textContent = `platform=${platform} | native=${isNative}`;
+log('Legato smoke harness ready.');
+log('platform:', platform);
+log('isNativePlatform:', isNative);
+
+smokeButton.addEventListener('click', () => {
+  void runNativeAction('run smoke flow', runSmokeFlow);
+});
+
+endSmokeButton.addEventListener('click', () => {
+  void runNativeAction('run let-it-end smoke flow', runLetItEndSmokeFlow);
 });
 
 copyButton.addEventListener('click', () => {
@@ -110,6 +288,8 @@ copyButton.addEventListener('click', () => {
 });
 
 if (!isNative) {
-  button.disabled = true;
-  log('Native bridge not available in browser preview.');
+  nativeActionButtons.forEach((button) => {
+    button.disabled = true;
+  });
+  log('Native bridge not available in browser preview. Open from Xcode/Android Studio.');
 }

--- a/native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSPlayerEngine.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSPlayerEngine.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public final class LegatoiOSPlayerEngine {
+public final class LegatoiOSPlayerEngine: LegatoiOSPlaybackRuntimeObserver {
     private let queueManager: LegatoiOSQueueManager
     private let eventEmitter: LegatoiOSEventEmitter
     private let snapshotStore: LegatoiOSSnapshotStore
@@ -46,6 +46,7 @@ public final class LegatoiOSPlayerEngine {
         sessionManager.configureSession()
         remoteCommandManager.bind(handler: onRemoteCommand)
         playbackRuntime.configure()
+        playbackRuntime.setObserver(self)
         isSetup = true
     }
 
@@ -60,10 +61,9 @@ public final class LegatoiOSPlayerEngine {
             let currentTrack = queueManager.getCurrentTrack()
             let currentState = snapshotStore.getPlaybackSnapshot().state
             let loadingState = stateMachine.reduce(current: currentState, event: .prepare)
-            let readyState = stateMachine.reduce(current: loadingState, event: .prepared)
 
             let snapshot = LegatoiOSPlaybackSnapshot(
-                state: readyState,
+                state: loadingState,
                 currentTrack: currentTrack,
                 currentIndex: runtimeSnapshot.currentIndex ?? queueSnapshot.currentIndex,
                 positionMs: runtimeSnapshot.progress.positionMs,
@@ -77,6 +77,7 @@ public final class LegatoiOSPlayerEngine {
             publishState(snapshot.state)
             publishMetadata(snapshot.currentTrack)
             publishProgress(snapshot)
+            refreshSnapshotFromRuntime(publishProgressEvent: true)
         } catch {
             publishPlatformFailure(error)
             throw error
@@ -88,7 +89,7 @@ public final class LegatoiOSPlayerEngine {
         try performRuntimeOperation {
             try playbackRuntime.play()
         }
-        transition(event: .play)
+        refreshSnapshotFromRuntime(publishProgressEvent: true)
     }
 
     public func pause() throws {
@@ -96,7 +97,7 @@ public final class LegatoiOSPlayerEngine {
         try performRuntimeOperation {
             try playbackRuntime.pause()
         }
-        transition(event: .pause)
+        refreshSnapshotFromRuntime(publishProgressEvent: true)
     }
 
     public func stop() throws {
@@ -104,20 +105,7 @@ public final class LegatoiOSPlayerEngine {
         try performRuntimeOperation {
             try playbackRuntime.stop(resetPosition: true)
         }
-        transition(event: .stop)
-        let runtimeSnapshot = playbackRuntime.snapshot()
-        snapshotStore.updatePlaybackSnapshot {
-            LegatoiOSPlaybackSnapshot(
-                state: $0.state,
-                currentTrack: $0.currentTrack,
-                currentIndex: $0.currentIndex,
-                positionMs: runtimeSnapshot.progress.positionMs,
-                durationMs: runtimeSnapshot.progress.durationMs ?? $0.durationMs,
-                bufferedPositionMs: runtimeSnapshot.progress.bufferedPositionMs,
-                queue: $0.queue
-            )
-        }
-        publishProgress(snapshotStore.getPlaybackSnapshot())
+        refreshSnapshotFromRuntime(publishProgressEvent: true)
     }
 
     public func seek(to positionMs: Int64) throws {
@@ -125,19 +113,7 @@ public final class LegatoiOSPlayerEngine {
         try performRuntimeOperation {
             try playbackRuntime.seek(to: positionMs)
         }
-        let runtimeSnapshot = playbackRuntime.snapshot()
-        snapshotStore.updatePlaybackSnapshot {
-            LegatoiOSPlaybackSnapshot(
-                state: $0.state,
-                currentTrack: $0.currentTrack,
-                currentIndex: $0.currentIndex,
-                positionMs: runtimeSnapshot.progress.positionMs,
-                durationMs: runtimeSnapshot.progress.durationMs ?? $0.durationMs,
-                bufferedPositionMs: runtimeSnapshot.progress.bufferedPositionMs,
-                queue: $0.queue
-            )
-        }
-        publishProgress(snapshotStore.getPlaybackSnapshot())
+        refreshSnapshotFromRuntime(publishProgressEvent: true)
     }
 
     public func skipToNext() throws {
@@ -152,17 +128,12 @@ public final class LegatoiOSPlayerEngine {
 
         let runtimeSnapshot = playbackRuntime.snapshot()
         let track = queueManager.getCurrentTrack()
-        snapshotStore.updatePlaybackSnapshot {
-            LegatoiOSPlaybackSnapshot(
-                state: $0.state,
-                currentTrack: track,
-                currentIndex: runtimeSnapshot.currentIndex ?? movedIndex,
-                positionMs: runtimeSnapshot.progress.positionMs,
-                durationMs: runtimeSnapshot.progress.durationMs ?? track?.durationMs,
-                bufferedPositionMs: runtimeSnapshot.progress.bufferedPositionMs,
-                queue: queueManager.getQueueSnapshot()
-            )
-        }
+        applyRuntimeSnapshot(
+            runtimeSnapshot,
+            currentTrackOverride: track,
+            currentIndexFallback: movedIndex,
+            queueOverride: queueManager.getQueueSnapshot()
+        )
 
         let snapshot = snapshotStore.getPlaybackSnapshot()
         publishQueueAndTrack(snapshot)
@@ -182,17 +153,12 @@ public final class LegatoiOSPlayerEngine {
 
         let runtimeSnapshot = playbackRuntime.snapshot()
         let track = queueManager.getCurrentTrack()
-        snapshotStore.updatePlaybackSnapshot {
-            LegatoiOSPlaybackSnapshot(
-                state: $0.state,
-                currentTrack: track,
-                currentIndex: runtimeSnapshot.currentIndex ?? movedIndex,
-                positionMs: runtimeSnapshot.progress.positionMs,
-                durationMs: runtimeSnapshot.progress.durationMs ?? track?.durationMs,
-                bufferedPositionMs: runtimeSnapshot.progress.bufferedPositionMs,
-                queue: queueManager.getQueueSnapshot()
-            )
-        }
+        applyRuntimeSnapshot(
+            runtimeSnapshot,
+            currentTrackOverride: track,
+            currentIndexFallback: movedIndex,
+            queueOverride: queueManager.getQueueSnapshot()
+        )
 
         let snapshot = snapshotStore.getPlaybackSnapshot()
         publishQueueAndTrack(snapshot)
@@ -210,10 +176,33 @@ public final class LegatoiOSPlayerEngine {
         }
 
         remoteCommandManager.unbind()
+        playbackRuntime.setObserver(nil)
         playbackRuntime.release()
         nowPlayingManager.clear()
         sessionManager.releaseSession()
         isSetup = false
+    }
+
+    public func playbackRuntimeDidUpdateProgress(_ snapshot: LegatoiOSRuntimeSnapshot) {
+        guard isSetup else {
+            return
+        }
+
+        applyRuntimeSnapshot(snapshot)
+        publishProgress(snapshotStore.getPlaybackSnapshot())
+    }
+
+    public func playbackRuntimeDidReachTrackEnd(_ snapshot: LegatoiOSRuntimeSnapshot) {
+        guard isSetup else {
+            return
+        }
+
+        applyRuntimeSnapshot(snapshot)
+        transition(event: .trackEnded)
+
+        let endedSnapshot = snapshotStore.getPlaybackSnapshot()
+        publishProgress(endedSnapshot)
+        eventEmitter.emit(name: .playbackEnded, payload: .playbackEnded(snapshot: endedSnapshot))
     }
 
     private func toRuntimeTrackSource(_ track: LegatoiOSTrack) -> LegatoiOSRuntimeTrackSource {
@@ -228,11 +217,12 @@ public final class LegatoiOSPlayerEngine {
         }
     }
 
-    private func transition(event: LegatoiOSStateInput) {
+    @discardableResult
+    private func transition(event: LegatoiOSStateInput) -> Bool {
         let previous = snapshotStore.getPlaybackSnapshot()
         let next = stateMachine.reduce(current: previous.state, event: event)
         guard next != previous.state else {
-            return
+            return false
         }
 
         snapshotStore.updatePlaybackSnapshot {
@@ -248,6 +238,7 @@ public final class LegatoiOSPlayerEngine {
         }
 
         publishState(next)
+        return true
     }
 
     private func publishQueueAndTrack(_ snapshot: LegatoiOSPlaybackSnapshot) {
@@ -295,6 +286,165 @@ public final class LegatoiOSPlayerEngine {
         }
 
         nowPlayingManager.updateMetadata(metadata)
+    }
+
+    private func refreshSnapshotFromRuntime(publishProgressEvent: Bool) {
+        applyRuntimeSnapshot(playbackRuntime.snapshot())
+        if publishProgressEvent {
+            publishProgress(snapshotStore.getPlaybackSnapshot())
+        }
+    }
+
+    private func applyRuntimeSnapshot(
+        _ runtimeSnapshot: LegatoiOSRuntimeSnapshot,
+        currentTrackOverride: LegatoiOSTrack? = nil,
+        currentIndexFallback: Int? = nil,
+        queueOverride: LegatoiOSQueueSnapshot? = nil
+    ) {
+        let previousSnapshot = snapshotStore.getPlaybackSnapshot()
+        if let stateHint = runtimeSnapshot.stateHint,
+           shouldApplyRuntimeStateHint(stateHint, runtimeSnapshot: runtimeSnapshot, previousSnapshot: previousSnapshot) {
+            applyRuntimeStateHint(stateHint)
+        }
+
+        snapshotStore.updatePlaybackSnapshot { previous in
+            let resolvedTrack = currentTrackOverride ?? previous.currentTrack
+            let resolvedDuration = runtimeSnapshot.progress.durationMs ?? resolvedTrack?.durationMs ?? previous.durationMs
+            let normalizedPosition = normalizedPositionMs(
+                runtimeSnapshot.progress.positionMs,
+                durationMs: resolvedDuration,
+                stateHint: runtimeSnapshot.stateHint
+            )
+            let normalizedBufferedPosition = normalizedBufferedPositionMs(
+                runtimeSnapshot.progress.bufferedPositionMs,
+                durationMs: resolvedDuration,
+                positionMs: normalizedPosition,
+                stateHint: runtimeSnapshot.stateHint
+            )
+            return LegatoiOSPlaybackSnapshot(
+                state: previous.state,
+                currentTrack: resolvedTrack,
+                currentIndex: runtimeSnapshot.currentIndex ?? currentIndexFallback ?? previous.currentIndex,
+                positionMs: normalizedPosition,
+                durationMs: resolvedDuration,
+                bufferedPositionMs: normalizedBufferedPosition,
+                queue: queueOverride ?? previous.queue
+            )
+        }
+    }
+
+    private func shouldApplyRuntimeStateHint(
+        _ stateHint: LegatoiOSPlaybackState,
+        runtimeSnapshot: LegatoiOSRuntimeSnapshot,
+        previousSnapshot: LegatoiOSPlaybackSnapshot
+    ) -> Bool {
+        if stateHint == previousSnapshot.state {
+            return false
+        }
+
+        guard previousSnapshot.state == .ended,
+              stateHint != .ended
+        else {
+            return true
+        }
+
+        let runtimeIndex = runtimeSnapshot.currentIndex ?? previousSnapshot.currentIndex
+        guard runtimeIndex == previousSnapshot.currentIndex else {
+            return true
+        }
+
+        let positionMs = max(0, runtimeSnapshot.progress.positionMs)
+        if let durationMs = runtimeSnapshot.progress.durationMs ?? previousSnapshot.durationMs,
+           positionMs >= max(0, durationMs) {
+            return false
+        }
+
+        return positionMs < previousSnapshot.positionMs
+    }
+
+    private func applyRuntimeStateHint(_ stateHint: LegatoiOSPlaybackState) {
+        let currentState = snapshotStore.getPlaybackSnapshot().state
+
+        switch stateHint {
+        case .idle:
+            transition(event: .reset)
+        case .loading:
+            transition(event: .prepare)
+        case .ready:
+            transition(event: .prepared)
+        case .playing:
+            if !transition(event: .play) {
+                if currentState == .loading || currentState == .idle {
+                    transition(event: .prepared)
+                    transition(event: .play)
+                }
+            }
+        case .paused:
+            if !transition(event: .pause) {
+                if currentState == .loading || currentState == .idle {
+                    transition(event: .prepared)
+                    transition(event: .play)
+                    transition(event: .pause)
+                }
+            }
+        case .buffering:
+            if !transition(event: .bufferingStarted) {
+                if currentState == .loading || currentState == .idle {
+                    transition(event: .prepared)
+                    transition(event: .play)
+                    transition(event: .bufferingStarted)
+                }
+            }
+        case .ended:
+            if !transition(event: .trackEnded) {
+                transition(event: .prepared)
+                transition(event: .play)
+                transition(event: .trackEnded)
+            }
+        case .error:
+            transition(event: .fail)
+        }
+    }
+
+    private func normalizedPositionMs(
+        _ positionMs: Int64,
+        durationMs: Int64?,
+        stateHint: LegatoiOSPlaybackState?
+    ) -> Int64 {
+        let normalizedPosition = max(0, positionMs)
+        guard let durationMs else {
+            return normalizedPosition
+        }
+
+        let clampedDuration = max(0, durationMs)
+        if stateHint == .ended {
+            return clampedDuration
+        }
+
+        return min(normalizedPosition, clampedDuration)
+    }
+
+    private func normalizedBufferedPositionMs(
+        _ bufferedPositionMs: Int64?,
+        durationMs: Int64?,
+        positionMs: Int64,
+        stateHint: LegatoiOSPlaybackState?
+    ) -> Int64? {
+        if stateHint == .ended {
+            return durationMs.map { max(0, $0) }
+        }
+
+        guard let bufferedPositionMs else {
+            return nil
+        }
+
+        var normalized = max(0, bufferedPositionMs)
+        if let durationMs {
+            normalized = min(normalized, max(0, durationMs))
+        }
+
+        normalized = max(normalized, positionMs)
+        return normalized
     }
 
     private func publishPlatformFailure(_ error: Error) {

--- a/native/ios/LegatoCore/Sources/LegatoCore/Runtime/LegatoiOSPlaybackRuntime.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCore/Runtime/LegatoiOSPlaybackRuntime.swift
@@ -7,6 +7,7 @@ import Foundation
 /// Legato state/event semantics outside the platform adapter.
 public protocol LegatoiOSPlaybackRuntime {
     func configure()
+    func setObserver(_ observer: LegatoiOSPlaybackRuntimeObserver?)
     func replaceQueue(items: [LegatoiOSRuntimeTrackSource], startIndex: Int?) throws
     func selectIndex(_ index: Int) throws
     func play() throws
@@ -15,6 +16,11 @@ public protocol LegatoiOSPlaybackRuntime {
     func seek(to positionMs: Int64) throws
     func snapshot() -> LegatoiOSRuntimeSnapshot
     func release()
+}
+
+public protocol LegatoiOSPlaybackRuntimeObserver: AnyObject {
+    func playbackRuntimeDidUpdateProgress(_ snapshot: LegatoiOSRuntimeSnapshot)
+    func playbackRuntimeDidReachTrackEnd(_ snapshot: LegatoiOSRuntimeSnapshot)
 }
 
 public struct LegatoiOSRuntimeTrackSource {
@@ -51,7 +57,7 @@ public struct LegatoiOSRuntimeSnapshot {
     public init(
         stateHint: LegatoiOSPlaybackState? = nil,
         currentIndex: Int? = nil,
-        progress: LegatoiOSRuntimeProgress = LegatoiOSRuntimeProgress(positionMs: 0, durationMs: nil, bufferedPositionMs: 0)
+        progress: LegatoiOSRuntimeProgress = LegatoiOSRuntimeProgress(positionMs: 0, durationMs: nil, bufferedPositionMs: nil)
     ) {
         self.stateHint = stateHint
         self.currentIndex = currentIndex
@@ -65,12 +71,16 @@ public struct LegatoiOSRuntimeSnapshot {
 public final class LegatoiOSNoopPlaybackRuntime: LegatoiOSPlaybackRuntime {
     private var currentIndex: Int?
     private var trackCount: Int = 0
-    private var progress = LegatoiOSRuntimeProgress(positionMs: 0, durationMs: nil, bufferedPositionMs: 0)
+    private var progress = LegatoiOSRuntimeProgress(positionMs: 0, durationMs: nil, bufferedPositionMs: nil)
 
     public init() {}
 
     public func configure() {
         // Intentionally no-op. AVPlayer object graph wiring is pending.
+    }
+
+    public func setObserver(_ observer: LegatoiOSPlaybackRuntimeObserver?) {
+        // Intentionally no-op.
     }
 
     public func replaceQueue(items: [LegatoiOSRuntimeTrackSource], startIndex: Int?) throws {
@@ -82,7 +92,7 @@ public final class LegatoiOSNoopPlaybackRuntime: LegatoiOSPlaybackRuntime {
         } else {
             currentIndex = 0
         }
-        progress = LegatoiOSRuntimeProgress(positionMs: 0, durationMs: nil, bufferedPositionMs: 0)
+        progress = LegatoiOSRuntimeProgress(positionMs: 0, durationMs: nil, bufferedPositionMs: nil)
     }
 
     public func selectIndex(_ index: Int) throws {
@@ -90,7 +100,7 @@ public final class LegatoiOSNoopPlaybackRuntime: LegatoiOSPlaybackRuntime {
             return
         }
         currentIndex = index
-        progress = LegatoiOSRuntimeProgress(positionMs: 0, durationMs: nil, bufferedPositionMs: 0)
+        progress = LegatoiOSRuntimeProgress(positionMs: 0, durationMs: nil, bufferedPositionMs: nil)
     }
 
     public func play() throws {
@@ -103,7 +113,7 @@ public final class LegatoiOSNoopPlaybackRuntime: LegatoiOSPlaybackRuntime {
 
     public func stop(resetPosition: Bool) throws {
         if resetPosition {
-            progress = LegatoiOSRuntimeProgress(positionMs: 0, durationMs: nil, bufferedPositionMs: 0)
+            progress = LegatoiOSRuntimeProgress(positionMs: 0, durationMs: nil, bufferedPositionMs: nil)
         }
     }
 
@@ -118,7 +128,7 @@ public final class LegatoiOSNoopPlaybackRuntime: LegatoiOSPlaybackRuntime {
     public func release() {
         currentIndex = nil
         trackCount = 0
-        progress = LegatoiOSRuntimeProgress(positionMs: 0, durationMs: nil, bufferedPositionMs: 0)
+        progress = LegatoiOSRuntimeProgress(positionMs: 0, durationMs: nil, bufferedPositionMs: nil)
     }
 }
 
@@ -132,13 +142,27 @@ public final class LegatoiOSAVPlayerPlaybackRuntime: LegatoiOSPlaybackRuntime {
     private let player: AVPlayer
     private var trackSources: [LegatoiOSRuntimeTrackSource] = []
     private var currentIndex: Int?
+    private weak var observer: LegatoiOSPlaybackRuntimeObserver?
+    private var periodicTimeObserverToken: Any?
+    private var playbackEndedObserverToken: NSObjectProtocol?
+    private var timeControlStatusObservation: NSKeyValueObservation?
+    private var currentItemObservation: NSKeyValueObservation?
+    private var currentItemStatusObservation: NSKeyValueObservation?
+    private var didEmitEndForCurrentItem = false
+    private var didReceivePlayForCurrentItem = false
 
     public init(player: AVPlayer = AVPlayer()) {
         self.player = player
     }
 
     public func configure() {
-        // Runtime initialization is completed at init time.
+        installPeriodicTimeObserverIfNeeded()
+        installPlaybackEndedObserverIfNeeded()
+        installPlayerSignalObserversIfNeeded()
+    }
+
+    public func setObserver(_ observer: LegatoiOSPlaybackRuntimeObserver?) {
+        self.observer = observer
     }
 
     public func replaceQueue(items: [LegatoiOSRuntimeTrackSource], startIndex: Int?) throws {
@@ -147,6 +171,9 @@ public final class LegatoiOSAVPlayerPlaybackRuntime: LegatoiOSPlaybackRuntime {
         guard !items.isEmpty else {
             currentIndex = nil
             player.replaceCurrentItem(with: nil)
+            didEmitEndForCurrentItem = false
+            didReceivePlayForCurrentItem = false
+            publishSnapshotUpdate()
             return
         }
 
@@ -172,6 +199,7 @@ public final class LegatoiOSAVPlayerPlaybackRuntime: LegatoiOSPlaybackRuntime {
         guard player.currentItem != nil else {
             throw LegatoiOSError(code: .playbackFailed, message: "No active AVPlayer item to play")
         }
+        didReceivePlayForCurrentItem = true
         player.play()
     }
 
@@ -186,6 +214,8 @@ public final class LegatoiOSAVPlayerPlaybackRuntime: LegatoiOSPlaybackRuntime {
         }
 
         player.seek(to: .zero)
+        didEmitEndForCurrentItem = false
+        didReceivePlayForCurrentItem = false
     }
 
     public func seek(to positionMs: Int64) throws {
@@ -193,16 +223,24 @@ public final class LegatoiOSAVPlayerPlaybackRuntime: LegatoiOSPlaybackRuntime {
         let seconds = Double(clamped) / 1000
         let target = CMTime(seconds: seconds, preferredTimescale: 1000)
         player.seek(to: target)
+        didEmitEndForCurrentItem = false
     }
 
     public func snapshot() -> LegatoiOSRuntimeSnapshot {
         let item = player.currentItem
         let duration = durationMs(for: item)
-        let bufferedPosition = bufferedPositionMs(for: item)
-        let position = positionMs(for: item)
+        let rawPosition = positionMs(for: item)
+        let position = normalizedPositionMs(rawPosition, durationMs: duration)
+        let stateHint = stateHint(for: item)
+        let bufferedPosition = normalizedBufferedPositionMs(
+            bufferedPositionMs(for: item),
+            stateHint: stateHint,
+            durationMs: duration,
+            positionMs: position
+        )
 
         return LegatoiOSRuntimeSnapshot(
-            stateHint: stateHint(),
+            stateHint: stateHint,
             currentIndex: currentIndex,
             progress: LegatoiOSRuntimeProgress(
                 positionMs: position,
@@ -213,10 +251,30 @@ public final class LegatoiOSAVPlayerPlaybackRuntime: LegatoiOSPlaybackRuntime {
     }
 
     public func release() {
+        if let periodicTimeObserverToken {
+            player.removeTimeObserver(periodicTimeObserverToken)
+            self.periodicTimeObserverToken = nil
+        }
+
+        if let playbackEndedObserverToken {
+            NotificationCenter.default.removeObserver(playbackEndedObserverToken)
+            self.playbackEndedObserverToken = nil
+        }
+
+        timeControlStatusObservation?.invalidate()
+        timeControlStatusObservation = nil
+        currentItemObservation?.invalidate()
+        currentItemObservation = nil
+        currentItemStatusObservation?.invalidate()
+        currentItemStatusObservation = nil
+
+        observer = nil
         player.pause()
         player.replaceCurrentItem(with: nil)
         trackSources = []
         currentIndex = nil
+        didEmitEndForCurrentItem = false
+        didReceivePlayForCurrentItem = false
     }
 
     private func loadItem(at index: Int) throws {
@@ -236,11 +294,115 @@ public final class LegatoiOSAVPlayerPlaybackRuntime: LegatoiOSPlaybackRuntime {
 
         player.replaceCurrentItem(with: item)
         currentIndex = index
+        didEmitEndForCurrentItem = false
+        didReceivePlayForCurrentItem = false
+        publishSnapshotUpdate()
     }
 
-    private func stateHint() -> LegatoiOSPlaybackState? {
-        guard player.currentItem != nil else {
+    private func installPeriodicTimeObserverIfNeeded() {
+        guard periodicTimeObserverToken == nil else {
+            return
+        }
+
+        let interval = CMTime(seconds: 0.25, preferredTimescale: 1000)
+        periodicTimeObserverToken = player.addPeriodicTimeObserver(
+            forInterval: interval,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self, self.player.timeControlStatus == .playing else {
+                return
+            }
+
+            self.publishProgressUpdate()
+        }
+    }
+
+    private func installPlaybackEndedObserverIfNeeded() {
+        guard playbackEndedObserverToken == nil else {
+            return
+        }
+
+        playbackEndedObserverToken = NotificationCenter.default.addObserver(
+            forName: .AVPlayerItemDidPlayToEndTime,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let self,
+                  let endedItem = notification.object as? AVPlayerItem,
+                  let currentItem = self.player.currentItem,
+                  endedItem === currentItem,
+                  !self.didEmitEndForCurrentItem
+            else {
+                return
+            }
+
+            self.didEmitEndForCurrentItem = true
+            let snapshot = self.snapshot()
+            self.observer?.playbackRuntimeDidReachTrackEnd(snapshot)
+            self.publishSnapshotUpdate()
+        }
+    }
+
+    private func installPlayerSignalObserversIfNeeded() {
+        guard timeControlStatusObservation == nil,
+              currentItemObservation == nil
+        else {
+            return
+        }
+
+        timeControlStatusObservation = player.observe(\AVPlayer.timeControlStatus, options: [.initial, .new]) { [weak self] _, _ in
+            self?.publishSnapshotUpdate()
+        }
+
+        currentItemObservation = player.observe(\AVPlayer.currentItem, options: [.initial, .new]) { [weak self] player, _ in
+            guard let self else {
+                return
+            }
+
+            self.observeCurrentItemStatus(player.currentItem)
+            self.publishSnapshotUpdate()
+        }
+    }
+
+    private func observeCurrentItemStatus(_ item: AVPlayerItem?) {
+        currentItemStatusObservation?.invalidate()
+        currentItemStatusObservation = nil
+
+        guard let item else {
+            return
+        }
+
+        currentItemStatusObservation = item.observe(\AVPlayerItem.status, options: [.initial, .new]) { [weak self] _, _ in
+            self?.publishSnapshotUpdate()
+        }
+    }
+
+    private func publishProgressUpdate() {
+        observer?.playbackRuntimeDidUpdateProgress(snapshot())
+    }
+
+    private func publishSnapshotUpdate() {
+        observer?.playbackRuntimeDidUpdateProgress(snapshot())
+    }
+
+    private func stateHint(for item: AVPlayerItem?) -> LegatoiOSPlaybackState? {
+        guard let item else {
             return .idle
+        }
+
+        switch item.status {
+        case .unknown:
+            return .loading
+        case .failed:
+            return .error
+        case .readyToPlay:
+            break
+        @unknown default:
+            return .error
+        }
+
+        if didEmitEndForCurrentItem || isAtTrackEnd(item) {
+            return .ended
         }
 
         if player.timeControlStatus == .playing {
@@ -251,7 +413,11 @@ public final class LegatoiOSAVPlayerPlaybackRuntime: LegatoiOSPlaybackRuntime {
             return .buffering
         }
 
-        return .paused
+        if didReceivePlayForCurrentItem {
+            return .paused
+        }
+
+        return .ready
     }
 
     private func positionMs(for item: AVPlayerItem?) -> Int64 {
@@ -278,6 +444,45 @@ public final class LegatoiOSAVPlayerPlaybackRuntime: LegatoiOSPlaybackRuntime {
         }
 
         return milliseconds(from: CMTimeAdd(loaded.start, loaded.duration))
+    }
+
+    private func normalizedPositionMs(_ positionMs: Int64, durationMs: Int64?) -> Int64 {
+        guard let durationMs else {
+            return max(0, positionMs)
+        }
+
+        return min(max(0, positionMs), max(0, durationMs))
+    }
+
+    private func normalizedBufferedPositionMs(
+        _ bufferedPositionMs: Int64?,
+        stateHint: LegatoiOSPlaybackState?,
+        durationMs: Int64?,
+        positionMs: Int64
+    ) -> Int64? {
+        if stateHint == .ended {
+            return durationMs
+        }
+
+        guard let bufferedPositionMs else {
+            return nil
+        }
+
+        var normalized = max(0, bufferedPositionMs)
+        if let durationMs {
+            normalized = min(normalized, max(0, durationMs))
+        }
+        normalized = max(normalized, positionMs)
+        return normalized
+    }
+
+    private func isAtTrackEnd(_ item: AVPlayerItem) -> Bool {
+        guard let durationMs = durationMs(for: item), durationMs > 0 else {
+            return false
+        }
+
+        let positionMs = positionMs(for: item)
+        return positionMs >= durationMs
     }
 
     private func milliseconds(from time: CMTime) -> Int64? {


### PR DESCRIPTION
Closes #7

## Summary
- add runtime-driven iOS playback progression, end-of-track handling, and buffering/readiness semantics on top of the audible AVPlayer MVP
- normalize emitted end snapshots so `position`, `duration`, and buffered progress remain coherent during smoke validation
- keep the Capacitor demo harness minimal and copy-friendly while preserving let-it-end smoke coverage for native regressions

## Changes
| File | Change |
|------|--------|
| `native/ios/LegatoCore/Sources/LegatoCore/Runtime/LegatoiOSPlaybackRuntime.swift` | adds AVPlayer observer-driven progress/end/readiness signals and runtime state hints |
| `native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSPlayerEngine.swift` | reconciles runtime signals into canonical states, emits progress/end events, normalizes end snapshots, and de-bounces state flapping |
| `apps/capacitor-demo/src/main.ts` | simplifies the smoke harness UI/logging and adds let-it-end smoke coverage with compact copy-friendly logs |
| `apps/capacitor-demo/index.html` | reduces the visible demo UI to smoke-focused controls and raw log output |
| `.agents/skills/capacitor-ios-spm/SKILL.md` | adds project OpenCode skill for Capacitor iOS SPM/autoload troubleshooting |
| `.agents/skills/capacitor-native-test-harness/SKILL.md` | adds project OpenCode skill for keeping the demo useful as a native debugging harness |
| `.gitignore` | keeps generated `.atl/` artifacts ignored from git |

## Test Plan
- [x] Manual iOS smoke validation in Xcode with the simplified demo harness
- [x] Verified continuous `playback-progress` updates while the track is playing
- [x] Verified remote startup/buffering semantics now show `loading/ready/buffering/playing` instead of purely optimistic states
- [x] Verified let-it-end smoke reaches `playback-ended` with normalized final snapshot (`state=ended`, `position=duration`, sane buffered progress)
- [x] Verified the previous heavy `ready -> playing` flapping was reduced substantially

## Notes
- This milestone keeps scope focused on foreground playback semantics; background audio, interruptions, and remote-command behavior are still future work.
- Some minor duplicate `playback-progress` emissions can still occur near the end of playback, but the major semantic/state issues are resolved.
