### PR TITLE
fix(ios): dedupe playback progress noise

### DIFF
--- a/native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSPlayerEngine.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSPlayerEngine.swift
@@ -12,7 +12,16 @@ public final class LegatoiOSPlayerEngine: LegatoiOSPlaybackRuntimeObserver {
     private let remoteCommandManager: LegatoiOSRemoteCommandManager
     private let playbackRuntime: LegatoiOSPlaybackRuntime
 
+    private struct ProgressEmissionToken: Equatable {
+        let trackId: String?
+        let currentIndex: Int?
+        let positionMs: Int64
+        let durationMs: Int64?
+        let bufferedPositionMs: Int64?
+    }
+
     private var isSetup = false
+    private var lastProgressEmission: ProgressEmissionToken?
 
     public init(
         queueManager: LegatoiOSQueueManager,
@@ -74,7 +83,9 @@ public final class LegatoiOSPlayerEngine: LegatoiOSPlaybackRuntimeObserver {
 
             snapshotStore.replacePlaybackSnapshot(snapshot)
             publishQueueAndTrack(snapshot)
-            publishState(snapshot.state)
+            if loadingState != currentState {
+                publishState(snapshot.state)
+            }
             publishMetadata(snapshot.currentTrack)
             publishProgress(snapshot)
             refreshSnapshotFromRuntime(publishProgressEvent: true)
@@ -181,6 +192,7 @@ public final class LegatoiOSPlayerEngine: LegatoiOSPlaybackRuntimeObserver {
         nowPlayingManager.clear()
         sessionManager.releaseSession()
         isSetup = false
+        lastProgressEmission = nil
     }
 
     public func playbackRuntimeDidUpdateProgress(_ snapshot: LegatoiOSRuntimeSnapshot) {
@@ -256,6 +268,20 @@ public final class LegatoiOSPlayerEngine: LegatoiOSPlaybackRuntimeObserver {
     }
 
     private func publishProgress(_ snapshot: LegatoiOSPlaybackSnapshot) {
+        let emissionToken = ProgressEmissionToken(
+            trackId: snapshot.currentTrack?.id,
+            currentIndex: snapshot.currentIndex,
+            positionMs: snapshot.positionMs,
+            durationMs: snapshot.durationMs,
+            bufferedPositionMs: snapshot.bufferedPositionMs
+        )
+
+        guard emissionToken != lastProgressEmission else {
+            return
+        }
+
+        lastProgressEmission = emissionToken
+
         let progress = LegatoiOSProgressUpdate(
             positionMs: snapshot.positionMs,
             durationMs: snapshot.durationMs,


### PR DESCRIPTION
Closes #9

## Summary
- suppress identical iOS `playback-progress` emissions so the smoke harness log is easier to read
- avoid one obvious duplicate initial loading-state emission when `load()` does not actually change the canonical state
- preserve the existing buffering/progression/end semantics from the previous iOS milestone

## Changes
| File | Change |
|------|--------|
| `native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSPlayerEngine.swift` | adds a small progress emission dedupe cache and reduces duplicate initial loading noise |

## Test Plan
- [x] Manual let-it-end smoke validation in the iOS demo harness
- [x] Verified the main state sequence remains sane (`loading -> ready -> playing -> buffering -> playing -> ended`)
- [x] Verified final snapshots and `playback-ended` payloads remain coherent
- [x] Verified the log shows fewer redundant `playback-progress` emissions than before

## Notes
- This is a small polish follow-up after the larger iOS playback progression/buffering milestone.
- Some minor initial `loading`/zero-progress noise may still remain, but the heavy duplicate progress chatter was reduced.
