### PR TITLE
feat(native): add background setup groundwork

### DIFF
--- a/apps/capacitor-demo/ios/App/App/Info.plist
+++ b/apps/capacitor-demo/ios/App/App/Info.plist
@@ -47,5 +47,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 </dict>
 </plist>

--- a/native/android/core/README.md
+++ b/native/android/core/README.md
@@ -5,7 +5,8 @@ This directory contains the Android native core and runtime integration seams fo
 Current scope includes:
 - canonical queue/state/snapshot/event behavior,
 - manager scaffolding for session + remote command integration,
-- explicit runtime adapters/seams for playback/session/remote surfaces.
+- explicit runtime adapters/seams for playback/session/remote surfaces,
+- typed interruption + audio-focus policy contract surfaces (Milestone 1 groundwork only).
 
 Out of scope for this pass:
 - full Media3/ExoPlayer runtime binding,
@@ -13,6 +14,11 @@ Out of scope for this pass:
 - production-grade background playback behavior.
 
 The default runtime adapters are intentionally no-op/in-memory and exist to define stable integration boundaries.
+
+## Milestone 1 contract note
+
+Android session interruption/audio-focus surfaces in this module are contract seams only.
+They are intentionally no-op and DO NOT provide full Media3 audio-focus/background parity yet.
 
 ## Gradle module bootstrap
 

--- a/native/android/core/src/main/kotlin/io/legato/core/session/LegatoAndroidSessionManager.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/session/LegatoAndroidSessionManager.kt
@@ -12,6 +12,14 @@ class LegatoAndroidSessionManager(
         runtime.configureSession()
     }
 
+    fun audioFocusPolicy(): LegatoAndroidAudioFocusPolicy {
+        return runtime.audioFocusPolicy()
+    }
+
+    fun onInterruption(signal: LegatoAndroidInterruptionSignal) {
+        runtime.onInterruption(signal)
+    }
+
     fun updatePlaybackState(state: LegatoAndroidPlaybackState) {
         runtime.updatePlaybackState(state)
     }

--- a/native/android/core/src/main/kotlin/io/legato/core/session/LegatoAndroidSessionRuntime.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/session/LegatoAndroidSessionRuntime.kt
@@ -4,6 +4,38 @@ import io.legato.core.core.LegatoAndroidNowPlayingMetadata
 import io.legato.core.core.LegatoAndroidPlaybackState
 import io.legato.core.core.LegatoAndroidProgressUpdate
 
+enum class LegatoAndroidAudioFocusGainHint {
+    AUDIOFOCUS_GAIN,
+}
+
+data class LegatoAndroidAudioFocusPolicy(
+    val gainHint: LegatoAndroidAudioFocusGainHint,
+    val pauseOnTransientLoss: Boolean,
+    val duckOnTransientCanDuck: Boolean,
+    val resumeAfterGainIfNotUserPaused: Boolean,
+)
+
+sealed interface LegatoAndroidInterruptionSignal {
+    data object AudioFocusLost : LegatoAndroidInterruptionSignal
+
+    data object AudioFocusLostTransient : LegatoAndroidInterruptionSignal
+
+    data object AudioFocusLostTransientCanDuck : LegatoAndroidInterruptionSignal
+
+    data object AudioFocusGained : LegatoAndroidInterruptionSignal
+
+    data object BecomingNoisy : LegatoAndroidInterruptionSignal
+}
+
+object LegatoAndroidSessionDefaults {
+    val MILESTONE1_AUDIO_FOCUS_POLICY = LegatoAndroidAudioFocusPolicy(
+        gainHint = LegatoAndroidAudioFocusGainHint.AUDIOFOCUS_GAIN,
+        pauseOnTransientLoss = true,
+        duckOnTransientCanDuck = true,
+        resumeAfterGainIfNotUserPaused = true,
+    )
+}
+
 /**
  * Seam for Android media session/audio focus runtime integration.
  *
@@ -12,6 +44,10 @@ import io.legato.core.core.LegatoAndroidProgressUpdate
  */
 interface LegatoAndroidSessionRuntime {
     fun configureSession()
+
+    fun audioFocusPolicy(): LegatoAndroidAudioFocusPolicy
+
+    fun onInterruption(signal: LegatoAndroidInterruptionSignal)
 
     fun updatePlaybackState(state: LegatoAndroidPlaybackState)
 
@@ -25,6 +61,13 @@ interface LegatoAndroidSessionRuntime {
 class LegatoAndroidNoopSessionRuntime : LegatoAndroidSessionRuntime {
     override fun configureSession() {
         // Intentionally no-op. Media3/AudioFocus wiring is pending.
+    }
+
+    override fun audioFocusPolicy(): LegatoAndroidAudioFocusPolicy =
+        LegatoAndroidSessionDefaults.MILESTONE1_AUDIO_FOCUS_POLICY
+
+    override fun onInterruption(signal: LegatoAndroidInterruptionSignal) {
+        // Intentionally no-op. Runtime callback handling is pending.
     }
 
     override fun updatePlaybackState(state: LegatoAndroidPlaybackState) {

--- a/native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSPlayerEngine.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSPlayerEngine.swift
@@ -22,6 +22,7 @@ public final class LegatoiOSPlayerEngine: LegatoiOSPlaybackRuntimeObserver {
 
     private var isSetup = false
     private var lastProgressEmission: ProgressEmissionToken?
+    private var sessionSignalListenerID: UUID?
 
     public init(
         queueManager: LegatoiOSQueueManager,
@@ -52,6 +53,7 @@ public final class LegatoiOSPlayerEngine: LegatoiOSPlaybackRuntimeObserver {
             return
         }
 
+        registerSessionSignalListenerIfNeeded()
         sessionManager.configureSession()
         remoteCommandManager.bind(handler: onRemoteCommand)
         playbackRuntime.configure()
@@ -186,6 +188,7 @@ public final class LegatoiOSPlayerEngine: LegatoiOSPlaybackRuntimeObserver {
             return
         }
 
+        removeSessionSignalListenerIfNeeded()
         remoteCommandManager.unbind()
         playbackRuntime.setObserver(nil)
         playbackRuntime.release()
@@ -492,6 +495,65 @@ public final class LegatoiOSPlayerEngine: LegatoiOSPlaybackRuntimeObserver {
 
         eventEmitter.emit(name: .playbackError, payload: .playbackError(error: mapped))
         publishState(next)
+    }
+
+    private func registerSessionSignalListenerIfNeeded() {
+        guard sessionSignalListenerID == nil else {
+            return
+        }
+
+        sessionSignalListenerID = sessionManager.addSignalListener { [weak self] signal in
+            self?.handleSessionSignal(signal)
+        }
+    }
+
+    private func removeSessionSignalListenerIfNeeded() {
+        guard let sessionSignalListenerID else {
+            return
+        }
+
+        sessionManager.removeSignalListener(sessionSignalListenerID)
+        self.sessionSignalListenerID = nil
+    }
+
+    private func handleSessionSignal(_ signal: LegatoiOSSessionSignal) {
+        switch signal {
+        case .outputRouteRemoved, .interruptionBegan:
+            pausePlaybackForSessionSignal()
+        case .interruptionEnded(let shouldResume):
+            if !shouldResume {
+                pausePlaybackForSessionSignal()
+            }
+            // Conservative behavior: interruption end with shouldResume=true does not auto-resume.
+        case .runtimeError(let message):
+            publishSessionRuntimeError(message)
+        }
+    }
+
+    private func pausePlaybackForSessionSignal() {
+        guard isSetup else {
+            return
+        }
+
+        let currentState = snapshotStore.getPlaybackSnapshot().state
+        guard currentState == .playing || currentState == .buffering else {
+            return
+        }
+
+        do {
+            try playbackRuntime.pause()
+        } catch {
+            publishPlatformFailure(error)
+            return
+        }
+
+        transition(event: .pause)
+        refreshSnapshotFromRuntime(publishProgressEvent: true)
+    }
+
+    private func publishSessionRuntimeError(_ message: String) {
+        let mapped = LegatoiOSError(code: .platformError, message: message)
+        eventEmitter.emit(name: .playbackError, payload: .playbackError(error: mapped))
     }
 
     private func performRuntimeOperation(_ operation: () throws -> Void) throws {

--- a/native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSSessionManager.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSSessionManager.swift
@@ -1,10 +1,17 @@
 import Foundation
 
 public final class LegatoiOSSessionManager {
-    private let runtime: LegatoiOSSessionRuntime
+    public typealias SignalListener = (LegatoiOSSessionSignal) -> Void
 
-    public init(runtime: LegatoiOSSessionRuntime = LegatoiOSNoopSessionRuntime()) {
+    private let lock = NSLock()
+    private let runtime: LegatoiOSSessionRuntime
+    private var listeners: [UUID: SignalListener] = [:]
+
+    public init(runtime: LegatoiOSSessionRuntime = LegatoiOSAVAudioSessionRuntime()) {
         self.runtime = runtime
+        self.runtime.onSignal = { [weak self] signal in
+            self?.publish(signal)
+        }
     }
 
     public func configureSession() {
@@ -17,5 +24,31 @@ public final class LegatoiOSSessionManager {
 
     public func releaseSession() {
         runtime.releaseSession()
+    }
+
+    @discardableResult
+    public func addSignalListener(_ listener: @escaping SignalListener) -> UUID {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let id = UUID()
+        listeners[id] = listener
+        return id
+    }
+
+    public func removeSignalListener(_ id: UUID) {
+        lock.lock()
+        defer { lock.unlock() }
+        listeners[id] = nil
+    }
+
+    private func publish(_ signal: LegatoiOSSessionSignal) {
+        lock.lock()
+        let snapshot = listeners.values
+        lock.unlock()
+
+        for listener in snapshot {
+            listener(signal)
+        }
     }
 }

--- a/native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSSessionRuntime.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSSessionRuntime.swift
@@ -1,13 +1,24 @@
+import AVFAudio
 import Foundation
 
+public enum LegatoiOSSessionSignal {
+    case interruptionBegan
+    case interruptionEnded(shouldResume: Bool)
+    case outputRouteRemoved
+    case runtimeError(message: String)
+}
+
 /// Seam for AVAudioSession-facing runtime integration.
-public protocol LegatoiOSSessionRuntime {
+public protocol LegatoiOSSessionRuntime: AnyObject {
+    var onSignal: ((LegatoiOSSessionSignal) -> Void)? { get set }
     func configureSession()
     func updatePlaybackState(_ state: LegatoiOSPlaybackState)
     func releaseSession()
 }
 
 public final class LegatoiOSNoopSessionRuntime: LegatoiOSSessionRuntime {
+    public var onSignal: ((LegatoiOSSessionSignal) -> Void)?
+
     public init() {}
 
     public func configureSession() {
@@ -20,5 +31,142 @@ public final class LegatoiOSNoopSessionRuntime: LegatoiOSSessionRuntime {
 
     public func releaseSession() {
         // Intentionally no-op.
+    }
+}
+
+public final class LegatoiOSAVAudioSessionRuntime: LegatoiOSSessionRuntime {
+    public var onSignal: ((LegatoiOSSessionSignal) -> Void)?
+
+    private let audioSession: AVAudioSession
+    private let notificationCenter: NotificationCenter
+
+    private var isConfigured = false
+    private var isSessionActive = false
+    private var interruptionObserver: NSObjectProtocol?
+    private var routeChangeObserver: NSObjectProtocol?
+
+    public init(
+        audioSession: AVAudioSession = .sharedInstance(),
+        notificationCenter: NotificationCenter = .default
+    ) {
+        self.audioSession = audioSession
+        self.notificationCenter = notificationCenter
+    }
+
+    public func configureSession() {
+        guard !isConfigured else {
+            return
+        }
+
+        do {
+            try audioSession.setCategory(.playback, mode: .default, options: [])
+            registerNotificationsIfNeeded()
+            isConfigured = true
+        } catch {
+            onSignal?(.runtimeError(message: "Failed to configure AVAudioSession: \(error.localizedDescription)"))
+        }
+    }
+
+    public func updatePlaybackState(_ state: LegatoiOSPlaybackState) {
+        switch state {
+        case .loading, .ready, .playing, .paused, .buffering:
+            setSessionActive(true)
+        case .idle, .ended, .error:
+            setSessionActive(false)
+        }
+    }
+
+    public func releaseSession() {
+        removeObservers()
+        setSessionActive(false)
+        isConfigured = false
+    }
+
+    private func setSessionActive(_ shouldBeActive: Bool) {
+        guard shouldBeActive != isSessionActive else {
+            return
+        }
+
+        do {
+            if shouldBeActive {
+                try audioSession.setActive(true)
+            } else {
+                try audioSession.setActive(false, options: [.notifyOthersOnDeactivation])
+            }
+            isSessionActive = shouldBeActive
+        } catch {
+            let action = shouldBeActive ? "activate" : "deactivate"
+            onSignal?(.runtimeError(message: "Failed to \(action) AVAudioSession: \(error.localizedDescription)"))
+        }
+    }
+
+    private func registerNotificationsIfNeeded() {
+        if interruptionObserver == nil {
+            interruptionObserver = notificationCenter.addObserver(
+                forName: AVAudioSession.interruptionNotification,
+                object: audioSession,
+                queue: nil
+            ) { [weak self] notification in
+                self?.handleInterruptionNotification(notification)
+            }
+        }
+
+        if routeChangeObserver == nil {
+            routeChangeObserver = notificationCenter.addObserver(
+                forName: AVAudioSession.routeChangeNotification,
+                object: audioSession,
+                queue: nil
+            ) { [weak self] notification in
+                self?.handleRouteChangeNotification(notification)
+            }
+        }
+    }
+
+    private func handleInterruptionNotification(_ notification: Notification) {
+        guard
+            let typeRaw = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
+            let type = AVAudioSession.InterruptionType(rawValue: typeRaw)
+        else {
+            return
+        }
+
+        switch type {
+        case .began:
+            onSignal?(.interruptionBegan)
+        case .ended:
+            let optionsRaw = notification.userInfo?[AVAudioSessionInterruptionOptionKey] as? UInt ?? 0
+            let options = AVAudioSession.InterruptionOptions(rawValue: optionsRaw)
+            onSignal?(.interruptionEnded(shouldResume: options.contains(.shouldResume)))
+        @unknown default:
+            break
+        }
+    }
+
+    private func handleRouteChangeNotification(_ notification: Notification) {
+        guard
+            let reasonRaw = notification.userInfo?[AVAudioSessionRouteChangeReasonKey] as? UInt,
+            let reason = AVAudioSession.RouteChangeReason(rawValue: reasonRaw)
+        else {
+            return
+        }
+
+        switch reason {
+        case .oldDeviceUnavailable, .noSuitableRouteForCategory:
+            onSignal?(.outputRouteRemoved)
+        default:
+            break
+        }
+    }
+
+    private func removeObservers() {
+        if let interruptionObserver {
+            notificationCenter.removeObserver(interruptionObserver)
+            self.interruptionObserver = nil
+        }
+
+        if let routeChangeObserver {
+            notificationCenter.removeObserver(routeChangeObserver)
+            self.routeChangeObserver = nil
+        }
     }
 }

--- a/packages/capacitor/README.md
+++ b/packages/capacitor/README.md
@@ -18,6 +18,7 @@ It also exports typed event helpers aligned with `@legato/contract`, and `create
 - Native runtime playback wiring (ExoPlayer/AVPlayer) is still pending in core.
 - This binding only bridges the current native core semantics/state/events.
 - Behavior is intentionally minimal and contract-first.
+- Android background playback/service wiring is groundwork-only in Milestone 1 (contract + stub service), not production parity.
 
 ## Local repo integration notes
 
@@ -39,3 +40,29 @@ To keep iOS SPM integration clean and compatible with `npx cap sync ios` generat
 
 - Do not modify `ios/App/CapApp-SPM` generated sources/packages.
 - The plugin package itself provides the standard Capacitor SPM linkage shape (`Capacitor` + `Cordova`) through the `CapacitorLegato` product so `npx cap sync ios` generated wiring can remain the source of truth.
+
+## Native setup CLI (Milestone 1 foundation)
+
+This package now ships a repo-owned CLI entrypoint: `legato`.
+
+Current supported commands:
+
+- `legato native doctor` → inspect required native host setup, no file writes.
+- `legato native configure --dry-run` → print the planned idempotent mutations without applying them.
+- `legato native configure --apply` → apply only safe mutations in the supported repo-owned patch set.
+
+Ownership/safety boundaries:
+
+- The CLI never mutates Capacitor-generated artifacts (for example, `ios/App/CapApp-SPM/**`).
+- `--apply` is intentionally conservative: unsupported file shapes are reported as `SKIP` for manual review.
+
+Android values used by CLI checks/templates are centralized in:
+
+- `src/cli/android-groundwork-contract.mjs`
+
+This contract currently covers:
+- playback service class identity,
+- required Android permissions,
+- baseline audio-focus policy intent.
+
+It exists to reduce drift across CLI and manifest scaffolding while full runtime parity is still pending.

--- a/packages/capacitor/android/src/main/AndroidManifest.xml
+++ b/packages/capacitor/android/src/main/AndroidManifest.xml
@@ -1,1 +1,12 @@
-<manifest />
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <application>
+        <service
+            android:name="io.legato.capacitor.LegatoPlaybackService"
+            android:exported="false"
+            android:foregroundServiceType="mediaPlayback" />
+    </application>
+</manifest>

--- a/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackService.kt
+++ b/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackService.kt
@@ -1,0 +1,21 @@
+package io.legato.capacitor
+
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+
+/**
+ * Milestone 1 groundwork service stub.
+ *
+ * This class intentionally avoids Media3/session/runtime wiring for now and only
+ * exists to anchor manifest + contract identity with a concrete Android Service.
+ */
+class LegatoPlaybackService : Service() {
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // Non-production placeholder: foreground notification + transport runtime are pending.
+        stopSelfResult(startId)
+        return START_NOT_STICKY
+    }
+}

--- a/packages/capacitor/package.json
+++ b/packages/capacitor/package.json
@@ -12,6 +12,9 @@
   },
   "license": "MIT",
   "type": "module",
+  "bin": {
+    "legato": "./src/cli/index.mjs"
+  },
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {

--- a/packages/capacitor/src/cli/android-groundwork-contract.mjs
+++ b/packages/capacitor/src/cli/android-groundwork-contract.mjs
@@ -1,0 +1,22 @@
+export const LEGATO_ANDROID_GROUNDWORK_CONTRACT = {
+  playbackService: {
+    className: 'io.legato.capacitor.LegatoPlaybackService',
+    exported: false,
+    foregroundServiceType: 'mediaPlayback',
+  },
+  requiredPermissions: [
+    'android.permission.FOREGROUND_SERVICE',
+    'android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK',
+    'android.permission.WAKE_LOCK',
+  ],
+  audioFocusPolicy: {
+    gain: 'AUDIOFOCUS_GAIN',
+    onLoss: 'pause-and-mark-interrupted',
+    onTransientLoss: 'pause-and-await-regain',
+    onTransientCanDuck: 'duck-volume-until-regain',
+    onGainAfterInterruption: 'resume-if-user-did-not-manually-pause',
+    intent: 'Milestone 1 groundwork contract only; not full Media3/audio-focus runtime behavior.',
+  },
+};
+
+export const LEGATO_ANDROID_PLAYBACK_SERVICE_CLASS = LEGATO_ANDROID_GROUNDWORK_CONTRACT.playbackService.className;

--- a/packages/capacitor/src/cli/index.mjs
+++ b/packages/capacitor/src/cli/index.mjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+import { runNativeCli } from './native-setup-cli.mjs';
+
+const args = process.argv.slice(2);
+const result = await runNativeCli({
+  args,
+  cwd: process.cwd(),
+  stdout: process.stdout,
+  stderr: process.stderr,
+});
+
+process.exitCode = result.exitCode;

--- a/packages/capacitor/src/cli/native-setup-cli.mjs
+++ b/packages/capacitor/src/cli/native-setup-cli.mjs
@@ -1,0 +1,597 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import {
+  LEGATO_ANDROID_GROUNDWORK_CONTRACT,
+  LEGATO_ANDROID_PLAYBACK_SERVICE_CLASS,
+} from './android-groundwork-contract.mjs';
+
+const SERVICE_CLASS = LEGATO_ANDROID_PLAYBACK_SERVICE_CLASS;
+
+const IOS_PLIST_PATH = 'apps/capacitor-demo/ios/App/App/Info.plist';
+const ANDROID_PLUGIN_MANIFEST_PATH = 'packages/capacitor/android/src/main/AndroidManifest.xml';
+
+const SUPPORTED_PATCH_SET = new Set([IOS_PLIST_PATH, ANDROID_PLUGIN_MANIFEST_PATH]);
+
+const GENERATED_FILE_MARKERS = ['ios/App/CapApp-SPM/'];
+
+/**
+ * @typedef {'ok' | 'missing' | 'misconfigured'} FindingStatus
+ */
+
+/**
+ * @typedef {{
+ *   id: string;
+ *   title: string;
+ *   owner: 'repo-owned';
+ *   file: string;
+ *   status: FindingStatus;
+ *   details: string;
+ *   remediation: string;
+ * }} Finding
+ */
+
+/**
+ * @typedef {{
+ *   ruleId: string;
+ *   file: string;
+ *   kind: 'replace-file' | 'insert-audio-background-mode';
+ *   summary: string;
+ *   safe: boolean;
+ *   reason?: string;
+ *   beforeDigest: string;
+ *   afterDigest?: string;
+ *   apply: (content: string) => string;
+ * }} PlannedChange
+ */
+
+function writeJsonLine(stdout, value) {
+  stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function printUsage(stderr) {
+  stderr.write(
+    [
+      'Usage:',
+      '  legato native doctor [--json]',
+      '  legato native configure --dry-run [--json]',
+      '  legato native configure --apply [--json]',
+      '',
+      'Notes:',
+      '  - configure defaults to no-op unless one of --dry-run/--apply is passed.',
+      '  - apply only touches the repo-owned safe patch set.',
+    ].join('\n'),
+  );
+  stderr.write('\n');
+}
+
+function resolveRepoRoot(cwd) {
+  let current = path.resolve(cwd);
+  const root = path.parse(current).root;
+
+  while (true) {
+    const hasExpectedLayout =
+      existsSync(path.join(current, 'packages', 'capacitor')) &&
+      existsSync(path.join(current, 'apps', 'capacitor-demo'));
+
+    if (hasExpectedLayout) {
+      return current;
+    }
+
+    if (current === root) {
+      return null;
+    }
+
+    current = path.dirname(current);
+  }
+}
+
+function isGeneratedPath(relativePath) {
+  return GENERATED_FILE_MARKERS.some((marker) => relativePath.includes(marker));
+}
+
+function digest(content) {
+  return `${content.length}:${content.split('\n').length}`;
+}
+
+function findAll(content, pattern) {
+  return [...content.matchAll(pattern)].map((m) => m[0]);
+}
+
+function buildAndroidManifestTemplate() {
+  const permissionLines = LEGATO_ANDROID_GROUNDWORK_CONTRACT.requiredPermissions.map(
+    (permission) => `    <uses-permission android:name="${permission}" />`,
+  );
+
+  return [
+    '<?xml version="1.0" encoding="utf-8"?>',
+    '<manifest xmlns:android="http://schemas.android.com/apk/res/android">',
+    ...permissionLines,
+    '    <application>',
+    `        <service android:name="${SERVICE_CLASS}" android:exported="${LEGATO_ANDROID_GROUNDWORK_CONTRACT.playbackService.exported}" android:foregroundServiceType="${LEGATO_ANDROID_GROUNDWORK_CONTRACT.playbackService.foregroundServiceType}" />`,
+    '    </application>',
+    '</manifest>',
+    '',
+  ].join('\n');
+}
+
+function inspectIosBackgroundMode(content) {
+  const keyRegex = /<key>\s*UIBackgroundModes\s*<\/key>/;
+  const keyMatch = keyRegex.exec(content);
+  if (!keyMatch) {
+    return {
+      status: 'missing',
+      details: 'Info.plist is missing UIBackgroundModes.',
+      remediation: 'Add UIBackgroundModes with an array containing audio.',
+      desired: 'missing-key',
+    };
+  }
+
+  const tail = content.slice(keyMatch.index + keyMatch[0].length);
+  const arrayRegex = /<array>[\s\S]*?<\/array>/;
+  const arrayMatch = arrayRegex.exec(tail);
+  if (!arrayMatch) {
+    return {
+      status: 'misconfigured',
+      details: 'UIBackgroundModes key exists but does not declare an array value.',
+      remediation: 'Convert UIBackgroundModes to an array and include audio.',
+      desired: 'invalid-shape',
+    };
+  }
+
+  const hasAudio = /<string>\s*audio\s*<\/string>/.test(arrayMatch[0]);
+  if (!hasAudio) {
+    return {
+      status: 'missing',
+      details: 'UIBackgroundModes is present but audio is missing.',
+      remediation: 'Add <string>audio</string> inside UIBackgroundModes array.',
+      desired: 'missing-audio',
+    };
+  }
+
+  return {
+    status: 'ok',
+    details: 'Info.plist includes UIBackgroundModes/audio.',
+    remediation: 'No changes required.',
+    desired: 'ok',
+  };
+}
+
+function planIosBackgroundMode(content, file) {
+  const inspection = inspectIosBackgroundMode(content);
+  if (inspection.status === 'ok') {
+    return [];
+  }
+
+  if (inspection.desired === 'invalid-shape') {
+    return [
+      {
+        ruleId: 'ios.background-audio',
+        file,
+        kind: 'insert-audio-background-mode',
+        summary: 'UIBackgroundModes exists with unsupported shape; manual patch required.',
+        safe: false,
+        reason: 'Unsupported plist structure for safe idempotent mutation.',
+        beforeDigest: digest(content),
+        apply: (currentContent) => currentContent,
+      },
+    ];
+  }
+
+  if (inspection.desired === 'missing-key') {
+    if (!content.includes('</dict>')) {
+      return [
+        {
+          ruleId: 'ios.background-audio',
+          file,
+          kind: 'insert-audio-background-mode',
+          summary: 'Cannot inject UIBackgroundModes because </dict> was not found.',
+          safe: false,
+          reason: 'Unsupported plist format.',
+          beforeDigest: digest(content),
+          apply: (currentContent) => currentContent,
+        },
+      ];
+    }
+
+    const insertion = ['\t<key>UIBackgroundModes</key>', '\t<array>', '\t\t<string>audio</string>', '\t</array>']
+      .join('\n');
+    const next = content.replace('</dict>', `${insertion}\n</dict>`);
+
+    return [
+      {
+        ruleId: 'ios.background-audio',
+        file,
+        kind: 'insert-audio-background-mode',
+        summary: 'Add UIBackgroundModes/audio to Info.plist.',
+        safe: true,
+        beforeDigest: digest(content),
+        afterDigest: digest(next),
+        apply: () => next,
+      },
+    ];
+  }
+
+  const keyRegex = /<key>\s*UIBackgroundModes\s*<\/key>[\s\S]*?<array>([\s\S]*?)<\/array>/;
+  const match = keyRegex.exec(content);
+  if (!match) {
+    return [
+      {
+        ruleId: 'ios.background-audio',
+        file,
+        kind: 'insert-audio-background-mode',
+        summary: 'Cannot safely locate UIBackgroundModes array for insertion.',
+        safe: false,
+        reason: 'Could not match expected plist key/array layout.',
+        beforeDigest: digest(content),
+        apply: (currentContent) => currentContent,
+      },
+    ];
+  }
+
+  const full = match[0];
+  const withAudio = full.replace('</array>', '\n\t\t<string>audio</string>\n\t</array>');
+  const next = content.replace(full, withAudio);
+
+  return [
+    {
+      ruleId: 'ios.background-audio',
+      file,
+      kind: 'insert-audio-background-mode',
+      summary: 'Append audio to existing UIBackgroundModes array.',
+      safe: true,
+      beforeDigest: digest(content),
+      afterDigest: digest(next),
+      apply: () => next,
+    },
+  ];
+}
+
+function inspectAndroidPluginManifest(content) {
+  const permissionMatches = new Map();
+  for (const permission of LEGATO_ANDROID_GROUNDWORK_CONTRACT.requiredPermissions) {
+    const escapedPermission = permission.replaceAll('.', '\\.');
+    const count = findAll(
+      content,
+      new RegExp(`<uses-permission[^>]*android:name="${escapedPermission}"[^>]*\\/>`, 'g'),
+    ).length;
+    permissionMatches.set(permission, count);
+  }
+
+  const serviceDeclarations = findAll(
+    content,
+    new RegExp(`<service[^>]*android:name=\"${SERVICE_CLASS.replaceAll('.', '\\.')}\"[^>]*(?:>|/>)`, 'g'),
+  );
+
+  const missing = [];
+  for (const [permission, count] of permissionMatches.entries()) {
+    if (count === 0) {
+      missing.push(permission);
+    }
+  }
+  if (serviceDeclarations.length === 0) {
+    missing.push(`service:${SERVICE_CLASS}`);
+  } else {
+    const hasExpectedExported = serviceDeclarations.some((service) =>
+      service.includes(`android:exported="${LEGATO_ANDROID_GROUNDWORK_CONTRACT.playbackService.exported}"`),
+    );
+    const hasExpectedForegroundServiceType = serviceDeclarations.some((service) =>
+      service.includes(
+        `android:foregroundServiceType="${LEGATO_ANDROID_GROUNDWORK_CONTRACT.playbackService.foregroundServiceType}"`,
+      ),
+    );
+
+    if (!hasExpectedExported) {
+      missing.push(`service-exported:${LEGATO_ANDROID_GROUNDWORK_CONTRACT.playbackService.exported}`);
+    }
+    if (!hasExpectedForegroundServiceType) {
+      missing.push(
+        `service-foregroundServiceType:${LEGATO_ANDROID_GROUNDWORK_CONTRACT.playbackService.foregroundServiceType}`,
+      );
+    }
+  }
+
+  if (missing.length === 0) {
+    return {
+      status: 'ok',
+      details: 'Android plugin manifest includes required service and permissions.',
+      remediation: 'No changes required.',
+      missing,
+    };
+  }
+
+  return {
+    status: 'missing',
+    details: `Android plugin manifest missing: ${missing.join(', ')}.`,
+    remediation:
+      'Add required foreground-service permissions and the contract playback service declaration in packages/capacitor/android/src/main/AndroidManifest.xml.',
+    missing,
+  };
+}
+
+function planAndroidPluginManifest(content, file) {
+  const inspection = inspectAndroidPluginManifest(content);
+  if (inspection.status === 'ok') {
+    return [];
+  }
+
+  const normalized = content.trim();
+  const isBootstrapEmpty =
+    normalized === '<manifest />' ||
+    normalized === '<?xml version="1.0" encoding="utf-8"?>\n<manifest />';
+
+  if (!isBootstrapEmpty) {
+    return [
+      {
+        ruleId: 'android.plugin-service-and-permissions',
+        file,
+        kind: 'replace-file',
+        summary: 'Manifest has custom shape; review and patch manually.',
+        safe: false,
+        reason: 'Only bootstrap-empty manifest replacement is currently supported.',
+        beforeDigest: digest(content),
+        apply: (currentContent) => currentContent,
+      },
+    ];
+  }
+
+  const next = buildAndroidManifestTemplate();
+  return [
+    {
+      ruleId: 'android.plugin-service-and-permissions',
+      file,
+      kind: 'replace-file',
+      summary: 'Replace bootstrap-empty plugin AndroidManifest.xml with required declarations.',
+      safe: true,
+      beforeDigest: digest(content),
+      afterDigest: digest(next),
+      apply: () => next,
+    },
+  ];
+}
+
+function getFileContent(repoRoot, relativePath) {
+  const absolutePath = path.join(repoRoot, relativePath);
+  if (!existsSync(absolutePath)) {
+    return {
+      absolutePath,
+      content: null,
+      missing: true,
+    };
+  }
+
+  return {
+    absolutePath,
+    content: readFileSync(absolutePath, 'utf-8'),
+    missing: false,
+  };
+}
+
+function evaluateRules(repoRoot) {
+  const iosFile = getFileContent(repoRoot, IOS_PLIST_PATH);
+  const androidFile = getFileContent(repoRoot, ANDROID_PLUGIN_MANIFEST_PATH);
+
+  /** @type {Finding[]} */
+  const findings = [];
+  /** @type {PlannedChange[]} */
+  const plannedChanges = [];
+
+  if (iosFile.missing || iosFile.content == null) {
+    findings.push({
+      id: 'ios.background-audio',
+      title: 'iOS Info.plist background audio mode',
+      owner: 'repo-owned',
+      file: IOS_PLIST_PATH,
+      status: 'missing',
+      details: 'Info.plist file was not found.',
+      remediation: 'Ensure apps/capacitor-demo iOS host exists and rerun doctor.',
+    });
+  } else {
+    const iosInspection = inspectIosBackgroundMode(iosFile.content);
+    findings.push({
+      id: 'ios.background-audio',
+      title: 'iOS Info.plist background audio mode',
+      owner: 'repo-owned',
+      file: IOS_PLIST_PATH,
+      status: iosInspection.status,
+      details: iosInspection.details,
+      remediation: iosInspection.remediation,
+    });
+    plannedChanges.push(...planIosBackgroundMode(iosFile.content, IOS_PLIST_PATH));
+  }
+
+  if (androidFile.missing || androidFile.content == null) {
+    findings.push({
+      id: 'android.plugin-service-and-permissions',
+      title: 'Android plugin service and permissions',
+      owner: 'repo-owned',
+      file: ANDROID_PLUGIN_MANIFEST_PATH,
+      status: 'missing',
+      details: 'Android plugin AndroidManifest.xml was not found.',
+      remediation: 'Ensure packages/capacitor Android sources exist and rerun doctor.',
+    });
+  } else {
+    const androidInspection = inspectAndroidPluginManifest(androidFile.content);
+    findings.push({
+      id: 'android.plugin-service-and-permissions',
+      title: 'Android plugin service and permissions',
+      owner: 'repo-owned',
+      file: ANDROID_PLUGIN_MANIFEST_PATH,
+      status: androidInspection.status,
+      details: androidInspection.details,
+      remediation: androidInspection.remediation,
+    });
+    plannedChanges.push(...planAndroidPluginManifest(androidFile.content, ANDROID_PLUGIN_MANIFEST_PATH));
+  }
+
+  return { findings, plannedChanges };
+}
+
+function printDoctor(stdout, findings) {
+  stdout.write('Legato Native Doctor\n');
+  stdout.write('====================\n');
+  for (const finding of findings) {
+    const symbol = finding.status === 'ok' ? '✓' : finding.status === 'missing' ? '✗' : '!';
+    stdout.write(`${symbol} ${finding.id}\n`);
+    stdout.write(`  file: ${finding.file}\n`);
+    stdout.write(`  status: ${finding.status}\n`);
+    stdout.write(`  details: ${finding.details}\n`);
+    stdout.write(`  remediation: ${finding.remediation}\n`);
+  }
+}
+
+function printPlan(stdout, plannedChanges, mode) {
+  stdout.write(`Legato Native Configure (${mode})\n`);
+  stdout.write('===============================\n');
+
+  if (plannedChanges.length === 0) {
+    stdout.write('No changes planned.\n');
+    return;
+  }
+
+  for (const change of plannedChanges) {
+    const state = change.safe ? 'SAFE' : 'SKIP';
+    stdout.write(`- [${state}] ${change.ruleId}\n`);
+    stdout.write(`  file: ${change.file}\n`);
+    stdout.write(`  kind: ${change.kind}\n`);
+    stdout.write(`  summary: ${change.summary}\n`);
+    if (!change.safe && change.reason) {
+      stdout.write(`  reason: ${change.reason}\n`);
+    }
+  }
+}
+
+function applyPlannedChanges(repoRoot, plannedChanges) {
+  const applied = [];
+  const skipped = [];
+
+  for (const change of plannedChanges) {
+    if (!change.safe) {
+      skipped.push({ ...change, skipReason: change.reason ?? 'Unsafe patch.' });
+      continue;
+    }
+
+    if (!SUPPORTED_PATCH_SET.has(change.file)) {
+      skipped.push({ ...change, skipReason: 'Not in supported patch set.' });
+      continue;
+    }
+
+    if (isGeneratedPath(change.file)) {
+      skipped.push({ ...change, skipReason: 'Target is Capacitor-generated artifact.' });
+      continue;
+    }
+
+    const absolutePath = path.join(repoRoot, change.file);
+    const before = readFileSync(absolutePath, 'utf-8');
+    const after = change.apply(before);
+    if (before === after) {
+      skipped.push({ ...change, skipReason: 'No-op after re-check (already idempotent).' });
+      continue;
+    }
+
+    writeFileSync(absolutePath, after, 'utf-8');
+    applied.push(change);
+  }
+
+  return { applied, skipped };
+}
+
+export async function runNativeCli({ args, cwd, stdout, stderr }) {
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+    printUsage(stderr);
+    return { exitCode: 1 };
+  }
+
+  if (args[0] !== 'native') {
+    stderr.write(`Unknown command group: ${args[0]}\n`);
+    printUsage(stderr);
+    return { exitCode: 1 };
+  }
+
+  const command = args[1];
+  const flags = new Set(args.slice(2));
+  const json = flags.has('--json');
+
+  const repoRoot = resolveRepoRoot(cwd);
+  if (!repoRoot) {
+    stderr.write('Could not resolve Legato repository root from current directory.\n');
+    return { exitCode: 1 };
+  }
+
+  if (command === 'doctor') {
+    const { findings } = evaluateRules(repoRoot);
+    const hasFailure = findings.some((finding) => finding.status !== 'ok');
+
+    if (json) {
+      writeJsonLine(stdout, {
+        command: 'native doctor',
+        repoRoot,
+        findings,
+        exitCode: hasFailure ? 1 : 0,
+      });
+    } else {
+      printDoctor(stdout, findings);
+      stdout.write(hasFailure ? '\nResult: gaps detected.\n' : '\nResult: all checks passed.\n');
+    }
+
+    return { exitCode: hasFailure ? 1 : 0 };
+  }
+
+  if (command === 'configure') {
+    const dryRun = flags.has('--dry-run');
+    const apply = flags.has('--apply');
+
+    if ((dryRun && apply) || (!dryRun && !apply)) {
+      stderr.write('configure requires exactly one mode: --dry-run or --apply\n');
+      return { exitCode: 1 };
+    }
+
+    const { findings, plannedChanges } = evaluateRules(repoRoot);
+    const pendingChanges = plannedChanges.filter((change) => {
+      const targetFinding = findings.find((finding) => finding.file === change.file);
+      return targetFinding ? targetFinding.status !== 'ok' : true;
+    });
+
+    if (dryRun) {
+      if (json) {
+        writeJsonLine(stdout, {
+          command: 'native configure --dry-run',
+          repoRoot,
+          findings,
+          plannedChanges: pendingChanges.map(({ apply: _apply, ...rest }) => rest),
+          exitCode: 0,
+        });
+      } else {
+        printPlan(stdout, pendingChanges, '--dry-run');
+      }
+
+      return { exitCode: 0 };
+    }
+
+    const { applied, skipped } = applyPlannedChanges(repoRoot, pendingChanges);
+    const hasUnsafeRemaining = skipped.some((entry) => entry.skipReason !== 'No-op after re-check (already idempotent).');
+    const exitCode = hasUnsafeRemaining ? 1 : 0;
+
+    if (json) {
+      writeJsonLine(stdout, {
+        command: 'native configure --apply',
+        repoRoot,
+        findings,
+        applied: applied.map(({ apply: _apply, ...rest }) => rest),
+        skipped: skipped.map(({ apply: _apply, ...rest }) => rest),
+        exitCode,
+      });
+    } else {
+      printPlan(stdout, pendingChanges, '--apply');
+      stdout.write(`\nApplied: ${applied.length}, Skipped: ${skipped.length}\n`);
+      for (const entry of skipped) {
+        stdout.write(`- SKIP ${entry.ruleId}: ${entry.skipReason}\n`);
+      }
+    }
+
+    return { exitCode };
+  }
+
+  stderr.write(`Unknown native command: ${command ?? '(missing)'}\n`);
+  printUsage(stderr);
+  return { exitCode: 1 };
+}


### PR DESCRIPTION
Closes #11

## Summary
- add conservative iOS session/interruption groundwork using AVAudioSession-backed session runtime and signal handling in the player engine
- add Android Milestone 1 groundwork contracts, manifest/service alignment, and typed session seams without claiming full background playback parity yet
- ship a repo-owned native setup CLI with `doctor`, `configure --dry-run`, and conservative `configure --apply` for safe native configuration changes

## Changes
| File | Change |
|------|--------|
| `native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSSessionRuntime.swift` | adds concrete AVAudioSession-backed session runtime and session signals |
| `native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSSessionManager.swift` | exposes session signal listener APIs and uses the real runtime by default |
| `native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSPlayerEngine.swift` | integrates interruption/route-removal signals conservatively into playback behavior and keeps progress/state semantics coherent |
| `native/android/core/src/main/kotlin/io/legato/core/session/LegatoAndroidSessionRuntime.kt` | adds typed Android focus/interruption groundwork contracts with noop runtime behavior |
| `native/android/core/src/main/kotlin/io/legato/core/session/LegatoAndroidSessionManager.kt` | exposes Android session/focus signal seam through the manager |
| `packages/capacitor/android/src/main/AndroidManifest.xml` | aligns plugin manifest with Android groundwork service/permission contract |
| `packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackService.kt` | adds concrete non-production playback service stub matching the manifest contract |
| `packages/capacitor/src/cli/index.mjs` | package CLI entrypoint |
| `packages/capacitor/src/cli/native-setup-cli.mjs` | implements `legato native doctor`, `configure --dry-run`, and conservative `configure --apply` |
| `packages/capacitor/src/cli/android-groundwork-contract.mjs` | centralizes Android service/permission/focus contract values for CLI alignment |
| `packages/capacitor/package.json` | exposes the `legato` bin command |
| `apps/capacitor-demo/ios/App/App/Info.plist` | enables iOS background audio mode for the demo host |
| `native/android/core/README.md`, `packages/capacitor/README.md` | document Milestone 1 scope, groundwork-only Android status, and CLI safety model |

## Test Plan
- [x] Manual iOS smoke validation already completed for playback progression/buffering/end semantics before this batch
- [x] Verified `legato native doctor --json` reports iOS and Android requirements correctly
- [x] Verified `legato native configure --dry-run --json` produces planned changes without mutation
- [x] Verified `legato native configure --apply --json` applies only safe/idempotent repo-owned changes (`Info.plist`, plugin AndroidManifest)
- [x] Re-ran `legato native doctor --json` after apply and confirmed both checks return `ok`
- [ ] iOS interruption/route-removal runtime behavior still requires device/manual validation of real system events

## Notes
- This PR intentionally does NOT implement full Android background playback parity (Media3/audio focus runtime/service lifecycle) yet; it only establishes the contracts and scaffolding for that next step.
- CLI ownership boundaries remain strict: no edits to Capacitor-generated files like `ios/App/CapApp-SPM/**`.
