### PR TITLE
feat(android): add background playback parity

### DIFF
--- a/apps/capacitor-demo/README.md
+++ b/apps/capacitor-demo/README.md
@@ -36,6 +36,30 @@ Validate native bridge + snapshot/event plumbing for the minimal flow in `src/ma
 
 This is a **native smoke** (Android/iOS host), not a browser-only check.
 
+## Android parity v1 validation
+
+Harness now supports both one-click smoke and manual controls for:
+
+- `setup`, `sync.start`, `sync.stop`
+- `add`, `play`, `pause`, `stop`, `seekTo`, `getSnapshot`
+- copy-friendly recent events + raw log + snapshot summary/json
+
+Use direct samplelib MP3 URLs from the default fixtures (no redirect links) to keep playback behavior deterministic during native checks.
+
+Before opening Android Studio/Xcode after harness changes, ALWAYS refresh native hosts:
+
+```bash
+npm run build
+npm run cap:sync
+```
+
+Manual parity checklist to close milestone validation:
+
+1. Background continuity: playback keeps running with app backgrounded and foreground notification remains active.
+2. Focus loss pauses playback.
+3. Focus regain does not auto-resume (explicit play required).
+4. `stop()` + idle tears down foreground service/notification.
+
 ## Quick smoke checklist (manual, lightweight)
 
 > Commands below are from `apps/capacitor-demo`.

--- a/apps/capacitor-demo/android/app/src/test/java/com/getcapacitor/myapp/HarnessValidationContractTest.java
+++ b/apps/capacitor-demo/android/app/src/test/java/com/getcapacitor/myapp/HarnessValidationContractTest.java
@@ -1,0 +1,93 @@
+package com.getcapacitor.myapp;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import org.junit.Test;
+
+public class HarnessValidationContractTest {
+
+    private static final String[] HARNESS_CONTROL_IDS = new String[] {
+            "id=\"action-setup\"",
+            "id=\"action-sync-start\"",
+            "id=\"action-sync-stop\"",
+            "id=\"action-add\"",
+            "id=\"action-play\"",
+            "id=\"action-pause\"",
+            "id=\"action-stop\"",
+            "id=\"action-seek\"",
+            "id=\"action-snapshot\"",
+            "id=\"copy-events\""
+    };
+
+    @Test
+    public void indexHtml_exposesManualControlsAndValidationChecklist() throws Exception {
+        String html = readRepoFile("apps/capacitor-demo/index.html");
+
+        for (String control : HARNESS_CONTROL_IDS) {
+            assertTrue("Missing control marker in index.html: " + control, html.contains(control));
+        }
+
+        assertTrue("Missing Android lifecycle checklist section", html.contains("Android lifecycle validation checklist"));
+        assertTrue("Missing focus-loss checklist item", html.contains("Focus loss pauses playback"));
+        assertTrue("Missing no-auto-resume checklist item", html.contains("Focus regain does not auto-resume"));
+        assertTrue("Missing service teardown checklist item", html.contains("stop+idle tears down foreground service"));
+        assertTrue("Missing recent events node", html.contains("id=\"events\""));
+        assertTrue("Missing snapshot summary node", html.contains("id=\"snapshot-summary\""));
+        assertTrue("Missing snapshot JSON node", html.contains("id=\"snapshot-json\""));
+    }
+
+    @Test
+    public void mainTs_usesDirectAudioUrlsAndAndroidFocusedLogging() throws Exception {
+        String mainTs = readRepoFile("apps/capacitor-demo/src/main.ts");
+
+        assertTrue("Smoke defaults should avoid redirect URLs", !mainTs.contains("soundhelix.com") && !mainTs.contains("redirect"));
+        assertTrue("Expected direct samplelib URL for smoke fixture", mainTs.contains("https://samplelib.com/mp3/sample-3s.mp3"));
+        assertTrue("Expected explicit background instructions logger", mainTs.contains("Background check:"));
+        assertTrue("Expected Android parity snapshot logging", mainTs.contains("snapshot summary"));
+        assertTrue("Expected recent events rendering helper", mainTs.contains("renderRecentEvents"));
+    }
+
+    @Test
+    public void readme_includesBuildAndSyncValidationReminder() throws Exception {
+        String readme = readRepoFile("apps/capacitor-demo/README.md");
+
+        assertTrue("README should include Android parity validation heading", readme.contains("Android parity v1 validation"));
+        assertTrue("README should include build reminder", readme.contains("npm run build"));
+        assertTrue("README should include cap sync reminder", readme.contains("npm run cap:sync"));
+    }
+
+    private static String readRepoFile(String relativePath) throws IOException {
+        Path repoRoot = locateRepoRoot();
+        Path target = repoRoot.resolve(relativePath);
+        byte[] bytes = Files.readAllBytes(target);
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    private static Path locateRepoRoot() {
+        Path cwd = Path.of(System.getProperty("user.dir", ".")).toAbsolutePath();
+
+        Optional<Path> match = climb(cwd);
+        if (match.isPresent()) {
+            return match.get();
+        }
+
+        throw new IllegalStateException("Unable to locate repository root from " + cwd);
+    }
+
+    private static Optional<Path> climb(Path start) {
+        Path cursor = start;
+        while (cursor != null) {
+            Path marker = cursor.resolve("apps/capacitor-demo/index.html");
+            if (Files.exists(marker)) {
+                return Optional.of(cursor);
+            }
+            cursor = cursor.getParent();
+        }
+        return Optional.empty();
+    }
+}

--- a/apps/capacitor-demo/index.html
+++ b/apps/capacitor-demo/index.html
@@ -133,22 +133,67 @@
   <body>
     <main>
       <h1>Legato Capacitor Demo</h1>
-      <p>Native playback smoke harness for iOS/Capacitor debugging.</p>
+      <p>Native playback validation harness for iOS + Android parity debugging.</p>
 
       <div class="stack" style="margin-top: 0.8rem">
         <section class="card stack">
           <h2>Smoke actions</h2>
           <div class="actions">
-            <button id="run-smoke" class="native-action" type="button">Run smoke flow</button>
+            <button id="run-smoke" class="native-action" type="button">Run smoke flow (setup/add/play/pause/snapshot)</button>
             <button id="run-end-smoke" class="native-action" type="button">Run let-it-end smoke</button>
             <button id="copy-log" type="button">Copy raw log</button>
+            <button id="copy-events" type="button">Copy recent events</button>
           </div>
           <div id="env-status">Detecting platform…</div>
         </section>
 
         <section class="card stack">
+          <h2>Manual native controls</h2>
+          <p>Use these when validating background/lifecycle behavior step-by-step.</p>
+          <div class="action-grid">
+            <button id="action-setup" class="native-action" type="button">setup()</button>
+            <button id="action-sync-start" class="native-action" type="button">sync.start()</button>
+            <button id="action-sync-stop" class="native-action" type="button">sync.stop()</button>
+            <button id="action-add" class="native-action" type="button">add()</button>
+            <button id="action-play" class="native-action" type="button">play()</button>
+            <button id="action-pause" class="native-action" type="button">pause()</button>
+            <button id="action-stop" class="native-action" type="button">stop()</button>
+            <button id="action-seek" class="native-action" type="button">seekTo()</button>
+            <button id="action-snapshot" class="native-action" type="button">getSnapshot()</button>
+          </div>
+          <div class="inline-fields">
+            <label>
+              Seek target (ms)
+              <input id="seek-ms" type="number" min="0" step="250" value="1200" />
+            </label>
+          </div>
+        </section>
+
+        <section class="card stack">
+          <h2>Snapshot summary</h2>
+          <pre id="snapshot-summary">No snapshot captured yet.</pre>
+          <textarea id="snapshot-json" readonly spellcheck="false" placeholder="Latest snapshot JSON payload..."></textarea>
+        </section>
+
+        <section class="card stack">
+          <h2>Recent events/progress (copy-friendly)</h2>
+          <textarea id="events" readonly spellcheck="false" placeholder="Recent sync events and operation results..."></textarea>
+        </section>
+
+        <section class="card stack">
           <h2>Raw operation log</h2>
           <textarea id="log" readonly spellcheck="false" placeholder="Action logs, payloads, and errors..."></textarea>
+        </section>
+
+        <section class="card stack">
+          <h2>Android lifecycle validation checklist</h2>
+          <ul>
+            <li>Background continuity: start playback, background app, verify audio keeps running and service notification stays visible.</li>
+            <li>Focus loss pauses playback: trigger interruption/noisy route change and verify state becomes paused.</li>
+            <li>Focus regain does not auto-resume: after focus returns, playback must remain paused until explicit play().</li>
+            <li>stop+idle tears down foreground service: run stop() and verify foreground notification/service are removed.</li>
+          </ul>
+          <p>After harness updates: run <code>npm run build</code> and <code>npm run cap:sync</code> before Android Studio/Xcode validation.</p>
         </section>
       </div>
     </main>

--- a/apps/capacitor-demo/src/main.ts
+++ b/apps/capacitor-demo/src/main.ts
@@ -5,19 +5,78 @@ type LegatoSyncController = ReturnType<typeof createLegatoSync>;
 
 const smokeButton = document.querySelector<HTMLButtonElement>('#run-smoke');
 const endSmokeButton = document.querySelector<HTMLButtonElement>('#run-end-smoke');
-const copyButton = document.querySelector<HTMLButtonElement>('#copy-log');
+const copyLogButton = document.querySelector<HTMLButtonElement>('#copy-log');
+const copyEventsButton = document.querySelector<HTMLButtonElement>('#copy-events');
+const setupButton = document.querySelector<HTMLButtonElement>('#action-setup');
+const syncStartButton = document.querySelector<HTMLButtonElement>('#action-sync-start');
+const syncStopButton = document.querySelector<HTMLButtonElement>('#action-sync-stop');
+const addButton = document.querySelector<HTMLButtonElement>('#action-add');
+const playButton = document.querySelector<HTMLButtonElement>('#action-play');
+const pauseButton = document.querySelector<HTMLButtonElement>('#action-pause');
+const stopButton = document.querySelector<HTMLButtonElement>('#action-stop');
+const seekButton = document.querySelector<HTMLButtonElement>('#action-seek');
+const snapshotButton = document.querySelector<HTMLButtonElement>('#action-snapshot');
+const seekInput = document.querySelector<HTMLInputElement>('#seek-ms');
 const envStatusNode = document.querySelector<HTMLDivElement>('#env-status');
 const logNode = document.querySelector<HTMLTextAreaElement>('#log');
+const eventsNode = document.querySelector<HTMLTextAreaElement>('#events');
+const snapshotSummaryNode = document.querySelector<HTMLPreElement>('#snapshot-summary');
+const snapshotJsonNode = document.querySelector<HTMLTextAreaElement>('#snapshot-json');
 
-if (!smokeButton || !endSmokeButton || !copyButton || !envStatusNode || !logNode) {
+if (
+  !smokeButton
+  || !endSmokeButton
+  || !copyLogButton
+  || !copyEventsButton
+  || !setupButton
+  || !syncStartButton
+  || !syncStopButton
+  || !addButton
+  || !playButton
+  || !pauseButton
+  || !stopButton
+  || !seekButton
+  || !snapshotButton
+  || !seekInput
+  || !envStatusNode
+  || !logNode
+  || !eventsNode
+  || !snapshotSummaryNode
+  || !snapshotJsonNode
+) {
   throw new Error('Demo UI nodes are missing');
 }
 
 const nativeActionButtons = Array.from(document.querySelectorAll<HTMLButtonElement>('.native-action'));
 const playbackSmokeDelayMs = 1500;
 const endSmokeDelayMs = 6500;
+const recentEventsLimit = 24;
+
+const platform = Capacitor.getPlatform();
+const isNative = Capacitor.isNativePlatform();
 
 let syncController: LegatoSyncController | null = null;
+let latestSnapshot: PlaybackSnapshot | null = null;
+let recentEvents: string[] = [];
+
+const demoTracks: Track[] = [
+  {
+    id: 'track-demo-1',
+    url: 'https://samplelib.com/mp3/sample-3s.mp3',
+    title: 'Demo Track 1 (3s sample)',
+    artist: 'Samplelib',
+    duration: 3000,
+    type: 'progressive',
+  },
+  {
+    id: 'track-demo-2',
+    url: 'https://samplelib.com/mp3/sample-6s.mp3',
+    title: 'Demo Track 2 (6s sample)',
+    artist: 'Samplelib',
+    duration: 6000,
+    type: 'progressive',
+  },
+];
 
 const formatMs = (value: number | null | undefined): string => {
   if (typeof value !== 'number' || Number.isNaN(value)) {
@@ -46,6 +105,7 @@ const summarizeSnapshot = (snapshot: PlaybackSnapshot): string => {
     `duration=${formatMs(snapshot.duration)}`,
     `buffered=${formatMs(snapshot.bufferedPosition ?? null)}`,
     `queue=${queueLength}`,
+    `error=${snapshot.error ? JSON.stringify(snapshot.error) : 'none'}`,
   ].join(' | ');
 };
 
@@ -109,11 +169,6 @@ const summarizePayload = (payload: unknown): string => {
     ].join(' | ');
   }
 
-  if ('track' in payload || 'index' in payload) {
-    const active = payload as { index?: number | null; track?: { title?: string; id?: string } | null };
-    return `index=${active.index ?? 'null'} | track=${active.track?.title ?? active.track?.id ?? '(none)'}`;
-  }
-
   const compact = JSON.stringify(payload);
   return compact.length > 220 ? `${compact.slice(0, 220)}…` : compact;
 };
@@ -123,6 +178,24 @@ const log = (message: string, payload?: unknown): void => {
   const line = payload === undefined ? message : `${message} ${summarizePayload(payload)}`;
   logNode.value = `${logNode.value}${prefix} ${line}\n`;
   logNode.scrollTop = logNode.scrollHeight;
+};
+
+const renderRecentEvents = (): void => {
+  eventsNode.value = recentEvents.join('\n');
+  eventsNode.scrollTop = eventsNode.scrollHeight;
+};
+
+const addRecentEvent = (message: string): void => {
+  const prefix = `[${new Date().toLocaleTimeString()}]`;
+  recentEvents = [...recentEvents.slice(-recentEventsLimit + 1), `${prefix} ${message}`];
+  renderRecentEvents();
+};
+
+const updateSnapshotViews = (snapshot: PlaybackSnapshot): void => {
+  latestSnapshot = snapshot;
+  snapshotSummaryNode.textContent = summarizeSnapshot(snapshot);
+  snapshotJsonNode.value = JSON.stringify(snapshot, null, 2);
+  addRecentEvent(`snapshot summary ${summarizeSnapshot(snapshot)}`);
 };
 
 const setRunning = (running: boolean): void => {
@@ -137,8 +210,10 @@ const runNativeAction = async (name: string, action: () => Promise<void>): Promi
   try {
     await action();
     log(`${name} finished`);
+    addRecentEvent(`${name} finished`);
   } catch (error) {
     log(`${name} failed:`, error);
+    addRecentEvent(`${name} failed ${summarizePayload(error)}`);
   } finally {
     setRunning(false);
   }
@@ -147,25 +222,31 @@ const runNativeAction = async (name: string, action: () => Promise<void>): Promi
 const startSync = async (): Promise<void> => {
   if (syncController) {
     log('sync already active');
+    addRecentEvent('sync already active');
     return;
   }
 
   syncController = createLegatoSync({
     onSnapshot: (snapshot) => {
+      updateSnapshotViews(snapshot);
       log('sync snapshot', snapshot);
     },
     onEvent: (eventName, payload) => {
+      const details = summarizePayload(payload);
       log(`event:${eventName}`, payload);
+      addRecentEvent(`event:${eventName}${details ? ` | ${details}` : ''}`);
     },
   });
 
   const initial = await syncController.start();
+  updateSnapshotViews(initial);
   log('sync.start() initial snapshot', initial);
 };
 
 const stopSync = async (): Promise<void> => {
   if (!syncController) {
     log('sync is not active');
+    addRecentEvent('sync is not active');
     return;
   }
 
@@ -190,90 +271,92 @@ const copyText = async (text: string, emptyMessage: string, successMessage: stri
   }
 };
 
-const copyLog = async () => {
-  await copyText(logNode.value, 'No log output to copy yet.', 'Copied raw log to clipboard.');
-};
-
-const platform = Capacitor.getPlatform();
-const isNative = Capacitor.isNativePlatform();
-
-const demoTracks: Track[] = [
-  {
-    id: 'track-demo-1',
-    url: 'https://samplelib.com/mp3/sample-3s.mp3',
-    title: 'Demo Track 1 (3s sample)',
-    artist: 'Samplelib',
-    duration: 3000,
-    type: 'progressive',
-  },
-  {
-    id: 'track-demo-2',
-    url: 'https://samplelib.com/mp3/sample-6s.mp3',
-    title: 'Demo Track 2 (6s sample)',
-    artist: 'Samplelib',
-    duration: 6000,
-    type: 'progressive',
-  },
-];
-
-const runSmokeFlow = async (): Promise<void> => {
-  logNode.value = '';
-  log('Starting Legato minimal flow...');
-  log('platform:', platform);
-  log('isNativePlatform:', isNative);
-
+const setupAction = async (): Promise<void> => {
   await Legato.setup();
   log('setup() ok');
+};
 
-  await startSync();
-
+const addAction = async (): Promise<void> => {
   const afterAdd = await Legato.add({ tracks: demoTracks, startIndex: 0 });
+  updateSnapshotViews(afterAdd);
   log('add() snapshot', afterAdd);
+};
 
+const playAction = async (): Promise<void> => {
   await Legato.play();
   log('play() ok');
+};
+
+const pauseAction = async (): Promise<void> => {
+  await Legato.pause();
+  log('pause() ok');
+};
+
+const stopAction = async (): Promise<void> => {
+  await Legato.stop();
+  log('stop() ok');
+};
+
+const seekAction = async (): Promise<void> => {
+  const value = Number(seekInput.value);
+  const targetMs = Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+  await Legato.seekTo({ position: targetMs });
+  log(`seekTo(${targetMs}) ok`);
+};
+
+const snapshotAction = async (): Promise<void> => {
+  const snapshot = await Legato.getSnapshot();
+  updateSnapshotViews(snapshot);
+  log('getSnapshot() snapshot', snapshot);
+};
+
+const clearFlows = (): void => {
+  logNode.value = '';
+  recentEvents = [];
+  renderRecentEvents();
+};
+
+const runSmokeFlow = async (): Promise<void> => {
+  clearFlows();
+  log('Starting Legato smoke flow...');
+  log('platform:', platform);
+  log('isNativePlatform:', isNative);
+  log('Background check: start play(), send app to background, verify playback continues and notification remains active.');
+
+  await setupAction();
+  await startSync();
+  await addAction();
+  await playAction();
 
   log(`waiting ${playbackSmokeDelayMs}ms before pause() to validate audible playback...`);
   await new Promise((resolve) => setTimeout(resolve, playbackSmokeDelayMs));
 
-  await Legato.pause();
-  log('pause() ok');
-
-  const finalSnapshot = await Legato.getSnapshot();
-  log('getSnapshot() final snapshot', finalSnapshot);
-
-  await stopSync();
+  await pauseAction();
+  await snapshotAction();
 };
 
 const runLetItEndSmokeFlow = async (): Promise<void> => {
-  logNode.value = '';
+  clearFlows();
   log('Starting Legato let-it-end flow...');
   log('platform:', platform);
   log('isNativePlatform:', isNative);
+  log('Background check: keep app in background and watch for playback-ended event plus service teardown after stop/idle.');
 
-  await Legato.setup();
-  log('setup() ok');
-
+  await setupAction();
   await startSync();
-
-  const afterAdd = await Legato.add({ tracks: demoTracks, startIndex: 0 });
-  log('add() snapshot', afterAdd);
-
-  await Legato.play();
+  await addAction();
+  await playAction();
   log(`play() ok, wait ${endSmokeDelayMs}ms for track end...`);
 
   await new Promise((resolve) => setTimeout(resolve, endSmokeDelayMs));
-
-  const finalSnapshot = await Legato.getSnapshot();
-  log('final snapshot after end wait', finalSnapshot);
-
-  await stopSync();
+  await snapshotAction();
 };
 
 envStatusNode.textContent = `platform=${platform} | native=${isNative}`;
-log('Legato smoke harness ready.');
+log('Legato parity harness ready.');
 log('platform:', platform);
 log('isNativePlatform:', isNative);
+log('Use smoke buttons for quick pass/fail and manual controls for lifecycle/focus deep checks.');
 
 smokeButton.addEventListener('click', () => {
   void runNativeAction('run smoke flow', runSmokeFlow);
@@ -283,8 +366,48 @@ endSmokeButton.addEventListener('click', () => {
   void runNativeAction('run let-it-end smoke flow', runLetItEndSmokeFlow);
 });
 
-copyButton.addEventListener('click', () => {
-  void copyLog();
+setupButton.addEventListener('click', () => {
+  void runNativeAction('manual setup()', setupAction);
+});
+
+syncStartButton.addEventListener('click', () => {
+  void runNativeAction('manual sync.start()', startSync);
+});
+
+syncStopButton.addEventListener('click', () => {
+  void runNativeAction('manual sync.stop()', stopSync);
+});
+
+addButton.addEventListener('click', () => {
+  void runNativeAction('manual add()', addAction);
+});
+
+playButton.addEventListener('click', () => {
+  void runNativeAction('manual play()', playAction);
+});
+
+pauseButton.addEventListener('click', () => {
+  void runNativeAction('manual pause()', pauseAction);
+});
+
+stopButton.addEventListener('click', () => {
+  void runNativeAction('manual stop()', stopAction);
+});
+
+seekButton.addEventListener('click', () => {
+  void runNativeAction('manual seekTo()', seekAction);
+});
+
+snapshotButton.addEventListener('click', () => {
+  void runNativeAction('manual getSnapshot()', snapshotAction);
+});
+
+copyLogButton.addEventListener('click', () => {
+  void copyText(logNode.value, 'No log output to copy yet.', 'Copied raw log to clipboard.');
+});
+
+copyEventsButton.addEventListener('click', () => {
+  void copyText(eventsNode.value, 'No recent events to copy yet.', 'Copied recent events to clipboard.');
 });
 
 if (!isNative) {
@@ -292,4 +415,8 @@ if (!isNative) {
     button.disabled = true;
   });
   log('Native bridge not available in browser preview. Open from Xcode/Android Studio.');
+}
+
+if (latestSnapshot == null) {
+  snapshotSummaryNode.textContent = 'No snapshot captured yet.';
 }

--- a/native/android/core/build.gradle
+++ b/native/android/core/build.gradle
@@ -22,5 +22,9 @@ android {
 }
 
 dependencies {
-    // Intentionally empty: current core sources are self-contained Kotlin models/services.
+    implementation 'androidx.media3:media3-common:1.4.1'
+    implementation 'androidx.media3:media3-exoplayer:1.4.1'
+
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1'
 }

--- a/native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidCoreComposition.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidCoreComposition.kt
@@ -5,8 +5,9 @@ import io.legato.core.events.LegatoAndroidEventEmitter
 import io.legato.core.mapping.LegatoAndroidTrackMapper
 import io.legato.core.queue.LegatoAndroidQueueManager
 import io.legato.core.remote.LegatoAndroidRemoteCommandManager
-import io.legato.core.runtime.LegatoAndroidNoopPlaybackRuntime
+import io.legato.core.runtime.LegatoAndroidMedia3PlaybackRuntime
 import io.legato.core.runtime.LegatoAndroidPlaybackRuntime
+import io.legato.core.session.LegatoAndroidAudioFocusSessionRuntime
 import io.legato.core.session.LegatoAndroidSessionManager
 import io.legato.core.snapshot.LegatoAndroidSnapshotStore
 import io.legato.core.state.LegatoAndroidStateMachine
@@ -18,9 +19,10 @@ data class LegatoAndroidCoreDependencies(
     val trackMapper: LegatoAndroidTrackMapper = LegatoAndroidTrackMapper(),
     val errorMapper: LegatoAndroidErrorMapper = LegatoAndroidErrorMapper(),
     val stateMachine: LegatoAndroidStateMachine = LegatoAndroidStateMachine(),
-    val sessionManager: LegatoAndroidSessionManager = LegatoAndroidSessionManager(),
+    val sessionManager: LegatoAndroidSessionManager =
+        LegatoAndroidSessionManager(runtime = LegatoAndroidAudioFocusSessionRuntime()),
     val remoteCommandManager: LegatoAndroidRemoteCommandManager = LegatoAndroidRemoteCommandManager(),
-    val playbackRuntime: LegatoAndroidPlaybackRuntime = LegatoAndroidNoopPlaybackRuntime(),
+    val playbackRuntime: LegatoAndroidPlaybackRuntime = LegatoAndroidMedia3PlaybackRuntime(),
 )
 
 data class LegatoAndroidCoreComponents(

--- a/native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidModels.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidModels.kt
@@ -11,6 +11,17 @@ enum class LegatoAndroidPlaybackState(val wireValue: String) {
     ERROR("error"),
 }
 
+enum class LegatoAndroidPauseOrigin {
+    USER,
+    INTERRUPTION,
+}
+
+enum class LegatoAndroidServiceMode {
+    OFF,
+    PLAYBACK_ACTIVE,
+    RESUME_PENDING_INTERRUPTION,
+}
+
 enum class LegatoAndroidTrackType(val wireValue: String) {
     FILE("file"),
     PROGRESSIVE("progressive"),

--- a/native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidPlayerEngine.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidPlayerEngine.kt
@@ -6,7 +6,10 @@ import io.legato.core.mapping.LegatoAndroidTrackMapper
 import io.legato.core.queue.LegatoAndroidQueueManager
 import io.legato.core.remote.LegatoAndroidRemoteCommandManager
 import io.legato.core.runtime.LegatoAndroidPlaybackRuntime
+import io.legato.core.runtime.LegatoAndroidPlaybackRuntimeListener
+import io.legato.core.runtime.LegatoAndroidRuntimeProgress
 import io.legato.core.runtime.LegatoAndroidRuntimeTrackSource
+import io.legato.core.session.LegatoAndroidInterruptionSignal
 import io.legato.core.session.LegatoAndroidSessionManager
 import io.legato.core.snapshot.LegatoAndroidSnapshotStore
 import io.legato.core.state.LegatoAndroidStateMachine
@@ -23,6 +26,7 @@ class LegatoAndroidPlayerEngine(
     private val playbackRuntime: LegatoAndroidPlaybackRuntime,
 ) {
     private var isSetup: Boolean = false
+    private var pauseOrigin: LegatoAndroidPauseOrigin = LegatoAndroidPauseOrigin.USER
 
     suspend fun setup() {
         if (isSetup) {
@@ -30,7 +34,9 @@ class LegatoAndroidPlayerEngine(
         }
 
         sessionManager.configureSession()
+        sessionManager.setInterruptionListener(::onInterruption)
         remoteCommandManager.bind(::onRemoteCommand)
+        playbackRuntime.setListener(runtimeListener)
         playbackRuntime.configure()
         isSetup = true
     }
@@ -71,6 +77,7 @@ class LegatoAndroidPlayerEngine(
         if (!runRuntimeOperation {
             playbackRuntime.play()
         }) return
+        pauseOrigin = LegatoAndroidPauseOrigin.USER
         transitionTo(LegatoAndroidStateMachine.LegatoAndroidStateInput.PLAY)
     }
 
@@ -79,6 +86,7 @@ class LegatoAndroidPlayerEngine(
         if (!runRuntimeOperation {
             playbackRuntime.pause()
         }) return
+        pauseOrigin = LegatoAndroidPauseOrigin.USER
         transitionTo(LegatoAndroidStateMachine.LegatoAndroidStateInput.PAUSE)
     }
 
@@ -87,6 +95,7 @@ class LegatoAndroidPlayerEngine(
         if (!runRuntimeOperation {
             playbackRuntime.stop(resetPosition = true)
         }) return
+        pauseOrigin = LegatoAndroidPauseOrigin.USER
         transitionTo(LegatoAndroidStateMachine.LegatoAndroidStateInput.STOP)
         val runtimeSnapshot = playbackRuntime.snapshot()
         snapshotStore.updatePlaybackSnapshot {
@@ -172,15 +181,66 @@ class LegatoAndroidPlayerEngine(
 
     fun getSnapshot(): LegatoAndroidPlaybackSnapshot = snapshotStore.getPlaybackSnapshot()
 
+    fun getPauseOrigin(): LegatoAndroidPauseOrigin = pauseOrigin
+
+    fun getServiceMode(): LegatoAndroidServiceMode {
+        val state = snapshotStore.getPlaybackSnapshot().state
+        return when {
+            state == LegatoAndroidPlaybackState.PLAYING || state == LegatoAndroidPlaybackState.BUFFERING ->
+                LegatoAndroidServiceMode.PLAYBACK_ACTIVE
+
+            state == LegatoAndroidPlaybackState.PAUSED && pauseOrigin == LegatoAndroidPauseOrigin.INTERRUPTION ->
+                LegatoAndroidServiceMode.RESUME_PENDING_INTERRUPTION
+
+            else -> LegatoAndroidServiceMode.OFF
+        }
+    }
+
     fun release() {
         if (!isSetup) {
             return
         }
 
         remoteCommandManager.unbind()
+        playbackRuntime.setListener(null)
         playbackRuntime.release()
+        sessionManager.setInterruptionListener(null)
         sessionManager.releaseSession()
         isSetup = false
+    }
+
+    private val runtimeListener = object : LegatoAndroidPlaybackRuntimeListener {
+        override fun onProgress(progress: LegatoAndroidRuntimeProgress) {
+            snapshotStore.updatePlaybackSnapshot { snapshot ->
+                snapshot.copy(
+                    positionMs = progress.positionMs,
+                    durationMs = progress.durationMs ?: snapshot.durationMs,
+                    bufferedPositionMs = progress.bufferedPositionMs,
+                )
+            }
+            publishProgress(snapshotStore.getPlaybackSnapshot())
+        }
+
+        override fun onBuffering(isBuffering: Boolean) {
+            val input = if (isBuffering) {
+                LegatoAndroidStateMachine.LegatoAndroidStateInput.BUFFERING_STARTED
+            } else {
+                LegatoAndroidStateMachine.LegatoAndroidStateInput.BUFFERING_ENDED
+            }
+            transitionTo(input)
+        }
+
+        override fun onEnded() {
+            transitionTo(LegatoAndroidStateMachine.LegatoAndroidStateInput.TRACK_ENDED)
+            eventEmitter.emit(
+                name = LegatoAndroidEventName.PLAYBACK_ENDED,
+                payload = LegatoAndroidEventPayload.PlaybackEnded(snapshotStore.getPlaybackSnapshot()),
+            )
+        }
+
+        override fun onFatalError(error: Throwable) {
+            publishPlatformFailure(error)
+        }
     }
 
     private fun toRuntimeTrackSource(track: LegatoAndroidTrack): LegatoAndroidRuntimeTrackSource =
@@ -283,6 +343,33 @@ class LegatoAndroidPlayerEngine(
             payload = LegatoAndroidEventPayload.PlaybackError(mappedError),
         )
         publishState(nextState)
+    }
+
+    private fun onInterruption(signal: LegatoAndroidInterruptionSignal) {
+        when (signal) {
+            LegatoAndroidInterruptionSignal.AudioFocusGained -> {
+                // v1 policy: no automatic resume.
+            }
+
+            LegatoAndroidInterruptionSignal.AudioFocusLost,
+            LegatoAndroidInterruptionSignal.AudioFocusLostTransient,
+            LegatoAndroidInterruptionSignal.AudioFocusLostTransientCanDuck,
+            LegatoAndroidInterruptionSignal.BecomingNoisy,
+            -> pauseForInterruption()
+        }
+    }
+
+    private fun pauseForInterruption() {
+        val state = snapshotStore.getPlaybackSnapshot().state
+        if (state != LegatoAndroidPlaybackState.PLAYING && state != LegatoAndroidPlaybackState.BUFFERING) {
+            return
+        }
+
+        runRuntimeOperation {
+            playbackRuntime.pause()
+        }
+        pauseOrigin = LegatoAndroidPauseOrigin.INTERRUPTION
+        transitionTo(LegatoAndroidStateMachine.LegatoAndroidStateInput.PAUSE)
     }
 
     private fun onRemoteCommand(command: LegatoAndroidRemoteCommand) {

--- a/native/android/core/src/main/kotlin/io/legato/core/runtime/LegatoAndroidMedia3PlaybackRuntime.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/runtime/LegatoAndroidMedia3PlaybackRuntime.kt
@@ -1,0 +1,145 @@
+package io.legato.core.runtime
+
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import io.legato.core.core.LegatoAndroidPlaybackState
+
+class LegatoAndroidMedia3PlaybackRuntime(
+    private val player: Player? = null,
+) : LegatoAndroidPlaybackRuntime {
+    private var listener: LegatoAndroidPlaybackRuntimeListener? = null
+    private var runtimeSnapshot: LegatoAndroidRuntimeSnapshot = LegatoAndroidRuntimeSnapshot()
+
+    override fun configure() {
+        player?.addListener(
+            object : Player.Listener {
+                override fun onPlaybackStateChanged(playbackState: Int) {
+                    when (playbackState) {
+                        Player.STATE_BUFFERING -> dispatchBuffering(true)
+                        Player.STATE_ENDED -> dispatchEnded()
+                    }
+                }
+
+                override fun onIsLoadingChanged(isLoading: Boolean) {
+                    dispatchBuffering(isLoading)
+                }
+
+                override fun onPlayerError(error: androidx.media3.common.PlaybackException) {
+                    dispatchFatalError(error)
+                }
+
+                override fun onEvents(player: Player, events: Player.Events) {
+                    if (events.contains(Player.EVENT_POSITION_DISCONTINUITY) || events.contains(Player.EVENT_PLAYBACK_STATE_CHANGED)) {
+                        dispatchProgress(
+                            positionMs = player.currentPosition,
+                            durationMs = player.duration.takeIf { it >= 0L },
+                            bufferedPositionMs = player.bufferedPosition,
+                        )
+                    }
+                }
+            },
+        )
+    }
+
+    override fun setListener(listener: LegatoAndroidPlaybackRuntimeListener?) {
+        this.listener = listener
+    }
+
+    override fun replaceQueue(items: List<LegatoAndroidRuntimeTrackSource>, startIndex: Int?) {
+        val selectedIndex = when {
+            items.isEmpty() -> null
+            startIndex == null -> 0
+            startIndex in items.indices -> startIndex
+            else -> 0
+        }
+
+        player?.setMediaItems(
+            items.map { source -> MediaItem.fromUri(source.url) },
+            selectedIndex ?: 0,
+            0L,
+        )
+
+        runtimeSnapshot = runtimeSnapshot.copy(
+            currentIndex = selectedIndex,
+            progress = runtimeSnapshot.progress.copy(positionMs = 0L, bufferedPositionMs = 0L),
+            stateHint = LegatoAndroidPlaybackState.READY,
+            isBufferingHint = false,
+        )
+    }
+
+    override fun selectIndex(index: Int) {
+        player?.seekToDefaultPosition(index)
+        runtimeSnapshot = runtimeSnapshot.copy(
+            currentIndex = index,
+            progress = runtimeSnapshot.progress.copy(positionMs = 0L, bufferedPositionMs = 0L),
+        )
+    }
+
+    override fun play() {
+        player?.play()
+    }
+
+    override fun pause() {
+        player?.pause()
+    }
+
+    override fun stop(resetPosition: Boolean) {
+        player?.stop()
+        if (resetPosition) {
+            runtimeSnapshot = runtimeSnapshot.copy(
+                progress = runtimeSnapshot.progress.copy(positionMs = 0L, bufferedPositionMs = 0L),
+                isBufferingHint = false,
+            )
+        }
+    }
+
+    override fun seekTo(positionMs: Long) {
+        val safePositionMs = positionMs.coerceAtLeast(0L)
+        player?.seekTo(safePositionMs)
+        runtimeSnapshot = runtimeSnapshot.copy(
+            progress = runtimeSnapshot.progress.copy(positionMs = safePositionMs),
+        )
+    }
+
+    override fun snapshot(): LegatoAndroidRuntimeSnapshot = runtimeSnapshot
+
+    override fun release() {
+        listener = null
+        player?.release()
+    }
+
+    fun dispatchProgress(positionMs: Long, durationMs: Long?, bufferedPositionMs: Long?) {
+        val progress = LegatoAndroidRuntimeProgress(
+            positionMs = positionMs.coerceAtLeast(0L),
+            durationMs = durationMs?.takeIf { it >= 0L },
+            bufferedPositionMs = bufferedPositionMs?.coerceAtLeast(0L),
+        )
+
+        runtimeSnapshot = runtimeSnapshot.copy(progress = progress)
+        listener?.onProgress(progress)
+    }
+
+    fun dispatchBuffering(isBuffering: Boolean) {
+        runtimeSnapshot = runtimeSnapshot.copy(
+            stateHint = if (isBuffering) LegatoAndroidPlaybackState.BUFFERING else runtimeSnapshot.stateHint,
+            isBufferingHint = isBuffering,
+        )
+        listener?.onBuffering(isBuffering)
+    }
+
+    fun dispatchEnded() {
+        runtimeSnapshot = runtimeSnapshot.copy(
+            stateHint = LegatoAndroidPlaybackState.ENDED,
+            isBufferingHint = false,
+        )
+        listener?.onEnded()
+    }
+
+    fun dispatchFatalError(error: Throwable) {
+        runtimeSnapshot = runtimeSnapshot.copy(
+            stateHint = LegatoAndroidPlaybackState.ERROR,
+            isBufferingHint = false,
+        )
+        listener?.onFatalError(error)
+    }
+}

--- a/native/android/core/src/main/kotlin/io/legato/core/runtime/LegatoAndroidPlaybackRuntime.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/runtime/LegatoAndroidPlaybackRuntime.kt
@@ -12,6 +12,8 @@ import io.legato.core.core.LegatoAndroidTrackType
 interface LegatoAndroidPlaybackRuntime {
     fun configure()
 
+    fun setListener(listener: LegatoAndroidPlaybackRuntimeListener?)
+
     fun replaceQueue(items: List<LegatoAndroidRuntimeTrackSource>, startIndex: Int?)
 
     fun selectIndex(index: Int)
@@ -27,6 +29,16 @@ interface LegatoAndroidPlaybackRuntime {
     fun snapshot(): LegatoAndroidRuntimeSnapshot
 
     fun release()
+}
+
+interface LegatoAndroidPlaybackRuntimeListener {
+    fun onProgress(progress: LegatoAndroidRuntimeProgress)
+
+    fun onBuffering(isBuffering: Boolean)
+
+    fun onEnded()
+
+    fun onFatalError(error: Throwable)
 }
 
 data class LegatoAndroidRuntimeTrackSource(
@@ -45,6 +57,7 @@ data class LegatoAndroidRuntimeProgress(
 data class LegatoAndroidRuntimeSnapshot(
     val stateHint: LegatoAndroidPlaybackState? = null,
     val currentIndex: Int? = null,
+    val isBufferingHint: Boolean = false,
     val progress: LegatoAndroidRuntimeProgress = LegatoAndroidRuntimeProgress(
         positionMs = 0L,
         durationMs = null,
@@ -58,12 +71,17 @@ data class LegatoAndroidRuntimeSnapshot(
  * This is intentionally NOT real playback: it only keeps deterministic runtime-facing state.
  */
 class LegatoAndroidNoopPlaybackRuntime : LegatoAndroidPlaybackRuntime {
+    private var listener: LegatoAndroidPlaybackRuntimeListener? = null
     private var currentIndex: Int? = null
     private var trackCount: Int = 0
     private var progress = LegatoAndroidRuntimeProgress(positionMs = 0L, durationMs = null, bufferedPositionMs = 0L)
 
     override fun configure() {
         // Intentionally no-op. Real implementation should initialize Media3 player/session objects.
+    }
+
+    override fun setListener(listener: LegatoAndroidPlaybackRuntimeListener?) {
+        this.listener = listener
     }
 
     override fun replaceQueue(items: List<LegatoAndroidRuntimeTrackSource>, startIndex: Int?) {
@@ -109,6 +127,7 @@ class LegatoAndroidNoopPlaybackRuntime : LegatoAndroidPlaybackRuntime {
     )
 
     override fun release() {
+        listener = null
         currentIndex = null
         trackCount = 0
         progress = LegatoAndroidRuntimeProgress(positionMs = 0L, durationMs = null, bufferedPositionMs = 0L)

--- a/native/android/core/src/main/kotlin/io/legato/core/session/LegatoAndroidSessionManager.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/session/LegatoAndroidSessionManager.kt
@@ -20,6 +20,10 @@ class LegatoAndroidSessionManager(
         runtime.onInterruption(signal)
     }
 
+    fun setInterruptionListener(listener: ((LegatoAndroidInterruptionSignal) -> Unit)?) {
+        runtime.setInterruptionListener(listener)
+    }
+
     fun updatePlaybackState(state: LegatoAndroidPlaybackState) {
         runtime.updatePlaybackState(state)
     }

--- a/native/android/core/src/main/kotlin/io/legato/core/session/LegatoAndroidSessionRuntime.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/session/LegatoAndroidSessionRuntime.kt
@@ -32,7 +32,7 @@ object LegatoAndroidSessionDefaults {
         gainHint = LegatoAndroidAudioFocusGainHint.AUDIOFOCUS_GAIN,
         pauseOnTransientLoss = true,
         duckOnTransientCanDuck = true,
-        resumeAfterGainIfNotUserPaused = true,
+        resumeAfterGainIfNotUserPaused = false,
     )
 }
 
@@ -47,6 +47,8 @@ interface LegatoAndroidSessionRuntime {
 
     fun audioFocusPolicy(): LegatoAndroidAudioFocusPolicy
 
+    fun setInterruptionListener(listener: ((LegatoAndroidInterruptionSignal) -> Unit)?)
+
     fun onInterruption(signal: LegatoAndroidInterruptionSignal)
 
     fun updatePlaybackState(state: LegatoAndroidPlaybackState)
@@ -59,12 +61,18 @@ interface LegatoAndroidSessionRuntime {
 }
 
 class LegatoAndroidNoopSessionRuntime : LegatoAndroidSessionRuntime {
+    private var interruptionListener: ((LegatoAndroidInterruptionSignal) -> Unit)? = null
+
     override fun configureSession() {
         // Intentionally no-op. Media3/AudioFocus wiring is pending.
     }
 
     override fun audioFocusPolicy(): LegatoAndroidAudioFocusPolicy =
         LegatoAndroidSessionDefaults.MILESTONE1_AUDIO_FOCUS_POLICY
+
+    override fun setInterruptionListener(listener: ((LegatoAndroidInterruptionSignal) -> Unit)?) {
+        interruptionListener = listener
+    }
 
     override fun onInterruption(signal: LegatoAndroidInterruptionSignal) {
         // Intentionally no-op. Runtime callback handling is pending.
@@ -83,6 +91,60 @@ class LegatoAndroidNoopSessionRuntime : LegatoAndroidSessionRuntime {
     }
 
     override fun releaseSession() {
+        interruptionListener = null
         // Intentionally no-op.
+    }
+}
+
+class LegatoAndroidAudioFocusSessionRuntime : LegatoAndroidSessionRuntime {
+    private var interruptionListener: ((LegatoAndroidInterruptionSignal) -> Unit)? = null
+
+    override fun configureSession() {
+        // Session wiring hooks are intentionally deferred to plugin/service integration batch.
+    }
+
+    override fun audioFocusPolicy(): LegatoAndroidAudioFocusPolicy =
+        LegatoAndroidSessionDefaults.MILESTONE1_AUDIO_FOCUS_POLICY
+
+    override fun setInterruptionListener(listener: ((LegatoAndroidInterruptionSignal) -> Unit)?) {
+        interruptionListener = listener
+    }
+
+    override fun onInterruption(signal: LegatoAndroidInterruptionSignal) {
+        interruptionListener?.invoke(signal)
+    }
+
+    override fun updatePlaybackState(state: LegatoAndroidPlaybackState) {
+        // Runtime-backed media session publication is deferred.
+    }
+
+    override fun updateNowPlayingMetadata(metadata: LegatoAndroidNowPlayingMetadata?) {
+        // Runtime-backed metadata publication is deferred.
+    }
+
+    override fun updateProgress(progress: LegatoAndroidProgressUpdate) {
+        // Runtime-backed progress publication is deferred.
+    }
+
+    override fun releaseSession() {
+        interruptionListener = null
+    }
+
+    fun dispatchAudioFocusChange(focusChange: Int) {
+        val signal = when (focusChange) {
+            android.media.AudioManager.AUDIOFOCUS_GAIN -> LegatoAndroidInterruptionSignal.AudioFocusGained
+            android.media.AudioManager.AUDIOFOCUS_LOSS -> LegatoAndroidInterruptionSignal.AudioFocusLost
+            android.media.AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> LegatoAndroidInterruptionSignal.AudioFocusLostTransient
+            android.media.AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> LegatoAndroidInterruptionSignal.AudioFocusLostTransientCanDuck
+            else -> null
+        }
+
+        if (signal != null) {
+            interruptionListener?.invoke(signal)
+        }
+    }
+
+    fun dispatchBecomingNoisy() {
+        interruptionListener?.invoke(LegatoAndroidInterruptionSignal.BecomingNoisy)
     }
 }

--- a/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineInterruptionPolicyTest.kt
+++ b/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineInterruptionPolicyTest.kt
@@ -1,0 +1,271 @@
+package io.legato.core.core
+
+import io.legato.core.events.LegatoAndroidEventEmitter
+import io.legato.core.queue.LegatoAndroidQueueManager
+import io.legato.core.remote.LegatoAndroidRemoteCommandManager
+import io.legato.core.remote.LegatoAndroidRemoteCommandRuntime
+import io.legato.core.runtime.LegatoAndroidPlaybackRuntime
+import io.legato.core.runtime.LegatoAndroidPlaybackRuntimeListener
+import io.legato.core.runtime.LegatoAndroidRuntimeSnapshot
+import io.legato.core.runtime.LegatoAndroidRuntimeTrackSource
+import io.legato.core.session.LegatoAndroidAudioFocusGainHint
+import io.legato.core.session.LegatoAndroidInterruptionSignal
+import io.legato.core.session.LegatoAndroidSessionDefaults
+import io.legato.core.session.LegatoAndroidSessionManager
+import io.legato.core.session.LegatoAndroidSessionRuntime
+import io.legato.core.snapshot.LegatoAndroidSnapshotStore
+import io.legato.core.state.LegatoAndroidStateMachine
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LegatoAndroidPlayerEngineInterruptionPolicyTest {
+    @Test
+    fun `milestone focus policy disables auto-resume on focus gain`() {
+        val policy = LegatoAndroidSessionDefaults.MILESTONE1_AUDIO_FOCUS_POLICY
+
+        assertEquals(LegatoAndroidAudioFocusGainHint.AUDIOFOCUS_GAIN, policy.gainHint)
+        assertFalse(policy.resumeAfterGainIfNotUserPaused)
+    }
+
+    @Test
+    fun `audio focus loss transitions canonical state to paused and projects resume pending mode`() = runBlocking {
+        val playbackRuntime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val eventEmitter = LegatoAndroidEventEmitter()
+        val engine = LegatoAndroidPlayerEngine(
+            queueManager = LegatoAndroidQueueManager(),
+            eventEmitter = eventEmitter,
+            snapshotStore = LegatoAndroidSnapshotStore(),
+            trackMapper = io.legato.core.mapping.LegatoAndroidTrackMapper(),
+            errorMapper = io.legato.core.errors.LegatoAndroidErrorMapper(),
+            stateMachine = LegatoAndroidStateMachine(),
+            sessionManager = LegatoAndroidSessionManager(sessionRuntime),
+            remoteCommandManager = LegatoAndroidRemoteCommandManager(object : LegatoAndroidRemoteCommandRuntime {
+                override fun bind(listener: (LegatoAndroidRemoteCommand) -> Unit) = Unit
+                override fun updatePlaybackState(state: LegatoAndroidPlaybackState) = Unit
+                override fun unbind() = Unit
+            }),
+            playbackRuntime = playbackRuntime,
+        )
+
+        engine.setup()
+        engine.load(
+            tracks = listOf(
+                LegatoAndroidTrack(
+                    id = "track-1",
+                    url = "https://example.com/audio.mp3",
+                    durationMs = 120_000L,
+                ),
+            ),
+        )
+        engine.play()
+
+        sessionRuntime.emit(LegatoAndroidInterruptionSignal.AudioFocusLostTransient)
+
+        assertEquals(LegatoAndroidPlaybackState.PAUSED, engine.getSnapshot().state)
+        assertEquals(LegatoAndroidPauseOrigin.INTERRUPTION, engine.getPauseOrigin())
+        assertEquals(LegatoAndroidServiceMode.RESUME_PENDING_INTERRUPTION, engine.getServiceMode())
+    }
+
+    @Test
+    fun `focus regain does not auto-resume playback`() = runBlocking {
+        val playbackRuntime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val engine = buildEngine(playbackRuntime, sessionRuntime)
+
+        engine.setup()
+        engine.load(
+            tracks = listOf(
+                LegatoAndroidTrack(
+                    id = "track-1",
+                    url = "https://example.com/audio.mp3",
+                ),
+            ),
+        )
+        engine.play()
+        sessionRuntime.emit(LegatoAndroidInterruptionSignal.AudioFocusLost)
+        val playCallsAfterLoss = playbackRuntime.playCallCount
+
+        sessionRuntime.emit(LegatoAndroidInterruptionSignal.AudioFocusGained)
+
+        assertEquals(playCallsAfterLoss, playbackRuntime.playCallCount)
+        assertEquals(LegatoAndroidPlaybackState.PAUSED, engine.getSnapshot().state)
+    }
+
+    @Test
+    fun `runtime ended callback transitions state and emits playback-ended event`() = runBlocking {
+        val playbackRuntime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val eventEmitter = LegatoAndroidEventEmitter()
+        val events = mutableListOf<LegatoAndroidEvent>()
+        eventEmitter.addListener { event -> events += event }
+        val engine = buildEngine(playbackRuntime, sessionRuntime, eventEmitter)
+
+        engine.setup()
+        engine.load(tracks = listOf(LegatoAndroidTrack(id = "track-1", url = "https://example.com/audio.mp3")))
+        engine.play()
+
+        playbackRuntime.emitEnded()
+
+        assertEquals(LegatoAndroidPlaybackState.ENDED, engine.getSnapshot().state)
+        assertTrue(events.any { it.name == LegatoAndroidEventName.PLAYBACK_ENDED })
+    }
+
+    @Test
+    fun `runtime fatal error callback transitions state and emits playback error`() = runBlocking {
+        val playbackRuntime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val eventEmitter = LegatoAndroidEventEmitter()
+        val events = mutableListOf<LegatoAndroidEvent>()
+        eventEmitter.addListener { event -> events += event }
+        val engine = buildEngine(playbackRuntime, sessionRuntime, eventEmitter)
+
+        engine.setup()
+        engine.load(tracks = listOf(LegatoAndroidTrack(id = "track-1", url = "https://example.com/audio.mp3")))
+        engine.play()
+
+        playbackRuntime.emitFatalError(IllegalStateException("boom"))
+
+        assertEquals(LegatoAndroidPlaybackState.ERROR, engine.getSnapshot().state)
+        val errorPayloads = events
+            .filter { it.name == LegatoAndroidEventName.PLAYBACK_ERROR }
+            .mapNotNull { it.payload as? LegatoAndroidEventPayload.PlaybackError }
+        assertTrue(errorPayloads.any { it.error.message == "boom" })
+    }
+
+    @Test
+    fun `runtime progress and buffering callbacks update canonical snapshot`() = runBlocking {
+        val playbackRuntime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val engine = buildEngine(playbackRuntime, sessionRuntime)
+
+        engine.setup()
+        engine.load(tracks = listOf(LegatoAndroidTrack(id = "track-1", url = "https://example.com/audio.mp3")))
+        engine.play()
+
+        playbackRuntime.emitBuffering(true)
+        assertEquals(LegatoAndroidPlaybackState.BUFFERING, engine.getSnapshot().state)
+
+        playbackRuntime.emitProgress(positionMs = 5_000L, durationMs = 120_000L, bufferedPositionMs = 20_000L)
+        val snapshot = engine.getSnapshot()
+        assertEquals(5_000L, snapshot.positionMs)
+        assertEquals(120_000L, snapshot.durationMs)
+        assertEquals(20_000L, snapshot.bufferedPositionMs)
+
+        playbackRuntime.emitBuffering(false)
+        assertEquals(LegatoAndroidPlaybackState.PLAYING, engine.getSnapshot().state)
+    }
+
+    private fun buildEngine(
+        playbackRuntime: RecordingPlaybackRuntime,
+        sessionRuntime: RecordingSessionRuntime,
+        eventEmitter: LegatoAndroidEventEmitter = LegatoAndroidEventEmitter(),
+    ): LegatoAndroidPlayerEngine = LegatoAndroidPlayerEngine(
+        queueManager = LegatoAndroidQueueManager(),
+        eventEmitter = eventEmitter,
+        snapshotStore = LegatoAndroidSnapshotStore(),
+        trackMapper = io.legato.core.mapping.LegatoAndroidTrackMapper(),
+        errorMapper = io.legato.core.errors.LegatoAndroidErrorMapper(),
+        stateMachine = LegatoAndroidStateMachine(),
+        sessionManager = LegatoAndroidSessionManager(sessionRuntime),
+        remoteCommandManager = LegatoAndroidRemoteCommandManager(object : LegatoAndroidRemoteCommandRuntime {
+            override fun bind(listener: (LegatoAndroidRemoteCommand) -> Unit) = Unit
+            override fun updatePlaybackState(state: LegatoAndroidPlaybackState) = Unit
+            override fun unbind() = Unit
+        }),
+        playbackRuntime = playbackRuntime,
+    )
+}
+
+private class RecordingPlaybackRuntime : LegatoAndroidPlaybackRuntime {
+    private var listener: LegatoAndroidPlaybackRuntimeListener? = null
+    private var snapshot = LegatoAndroidRuntimeSnapshot()
+
+    var playCallCount: Int = 0
+        private set
+
+    override fun configure() = Unit
+
+    override fun setListener(listener: LegatoAndroidPlaybackRuntimeListener?) {
+        this.listener = listener
+    }
+
+    override fun replaceQueue(items: List<LegatoAndroidRuntimeTrackSource>, startIndex: Int?) {
+        snapshot = snapshot.copy(currentIndex = if (items.isEmpty()) null else 0)
+    }
+
+    override fun selectIndex(index: Int) {
+        snapshot = snapshot.copy(currentIndex = index)
+    }
+
+    override fun play() {
+        playCallCount += 1
+    }
+
+    override fun pause() = Unit
+
+    override fun stop(resetPosition: Boolean) = Unit
+
+    override fun seekTo(positionMs: Long) {
+        snapshot = snapshot.copy(progress = snapshot.progress.copy(positionMs = positionMs))
+    }
+
+    override fun snapshot(): LegatoAndroidRuntimeSnapshot = snapshot
+
+    override fun release() {
+        listener = null
+    }
+
+    fun emitEnded() {
+        listener?.onEnded()
+    }
+
+    fun emitFatalError(error: Throwable) {
+        listener?.onFatalError(error)
+    }
+
+    fun emitProgress(positionMs: Long, durationMs: Long?, bufferedPositionMs: Long?) {
+        listener?.onProgress(
+            io.legato.core.runtime.LegatoAndroidRuntimeProgress(
+                positionMs = positionMs,
+                durationMs = durationMs,
+                bufferedPositionMs = bufferedPositionMs,
+            ),
+        )
+    }
+
+    fun emitBuffering(isBuffering: Boolean) {
+        listener?.onBuffering(isBuffering)
+    }
+}
+
+private class RecordingSessionRuntime : LegatoAndroidSessionRuntime {
+    private var listener: ((LegatoAndroidInterruptionSignal) -> Unit)? = null
+
+    override fun configureSession() = Unit
+
+    override fun audioFocusPolicy() = LegatoAndroidSessionDefaults.MILESTONE1_AUDIO_FOCUS_POLICY
+
+    override fun setInterruptionListener(listener: ((LegatoAndroidInterruptionSignal) -> Unit)?) {
+        this.listener = listener
+    }
+
+    override fun onInterruption(signal: LegatoAndroidInterruptionSignal) = Unit
+
+    override fun updatePlaybackState(state: LegatoAndroidPlaybackState) = Unit
+
+    override fun updateNowPlayingMetadata(metadata: LegatoAndroidNowPlayingMetadata?) = Unit
+
+    override fun updateProgress(progress: LegatoAndroidProgressUpdate) = Unit
+
+    override fun releaseSession() {
+        listener = null
+    }
+
+    fun emit(signal: LegatoAndroidInterruptionSignal) {
+        listener?.invoke(signal)
+    }
+}

--- a/native/android/core/src/test/kotlin/io/legato/core/runtime/LegatoAndroidMedia3PlaybackRuntimeTest.kt
+++ b/native/android/core/src/test/kotlin/io/legato/core/runtime/LegatoAndroidMedia3PlaybackRuntimeTest.kt
@@ -1,0 +1,55 @@
+package io.legato.core.runtime
+
+import io.legato.core.core.LegatoAndroidPlaybackState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LegatoAndroidMedia3PlaybackRuntimeTest {
+    @Test
+    fun `dispatch progress updates snapshot and emits callback`() {
+        val runtime = LegatoAndroidMedia3PlaybackRuntime()
+        val listener = RecordingListener()
+        runtime.setListener(listener)
+
+        runtime.dispatchProgress(positionMs = 2_000L, durationMs = 120_000L, bufferedPositionMs = 8_000L)
+
+        val snapshot = runtime.snapshot()
+        assertEquals(2_000L, snapshot.progress.positionMs)
+        assertEquals(120_000L, snapshot.progress.durationMs)
+        assertEquals(8_000L, snapshot.progress.bufferedPositionMs)
+        assertEquals(1, listener.progressCalls)
+    }
+
+    @Test
+    fun `dispatch buffering toggles buffering state and emits callback`() {
+        val runtime = LegatoAndroidMedia3PlaybackRuntime()
+        val listener = RecordingListener()
+        runtime.setListener(listener)
+
+        runtime.dispatchBuffering(isBuffering = true)
+        assertEquals(LegatoAndroidPlaybackState.BUFFERING, runtime.snapshot().stateHint)
+        assertTrue(listener.lastBuffering)
+
+        runtime.dispatchBuffering(isBuffering = false)
+        assertFalse(listener.lastBuffering)
+    }
+}
+
+private class RecordingListener : LegatoAndroidPlaybackRuntimeListener {
+    var progressCalls: Int = 0
+    var lastBuffering: Boolean = false
+
+    override fun onProgress(progress: LegatoAndroidRuntimeProgress) {
+        progressCalls += 1
+    }
+
+    override fun onBuffering(isBuffering: Boolean) {
+        lastBuffering = isBuffering
+    }
+
+    override fun onEnded() = Unit
+
+    override fun onFatalError(error: Throwable) = Unit
+}

--- a/native/android/core/src/test/kotlin/io/legato/core/session/LegatoAndroidAudioFocusSessionRuntimeTest.kt
+++ b/native/android/core/src/test/kotlin/io/legato/core/session/LegatoAndroidAudioFocusSessionRuntimeTest.kt
@@ -1,0 +1,39 @@
+package io.legato.core.session
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class LegatoAndroidAudioFocusSessionRuntimeTest {
+    @Test
+    fun `v1 policy pauses on loss and never auto-resumes on gain`() {
+        val runtime = LegatoAndroidAudioFocusSessionRuntime()
+
+        val policy = runtime.audioFocusPolicy()
+
+        assertEquals(LegatoAndroidAudioFocusGainHint.AUDIOFOCUS_GAIN, policy.gainHint)
+        assertFalse(policy.resumeAfterGainIfNotUserPaused)
+    }
+
+    @Test
+    fun `audio focus changes are emitted as interruption signals`() {
+        val runtime = LegatoAndroidAudioFocusSessionRuntime()
+        val signals = mutableListOf<LegatoAndroidInterruptionSignal>()
+        runtime.setInterruptionListener { signal ->
+            signals += signal
+        }
+
+        runtime.dispatchAudioFocusChange(android.media.AudioManager.AUDIOFOCUS_LOSS_TRANSIENT)
+        runtime.dispatchAudioFocusChange(android.media.AudioManager.AUDIOFOCUS_GAIN)
+        runtime.dispatchBecomingNoisy()
+
+        assertEquals(
+            listOf(
+                LegatoAndroidInterruptionSignal.AudioFocusLostTransient,
+                LegatoAndroidInterruptionSignal.AudioFocusGained,
+                LegatoAndroidInterruptionSignal.BecomingNoisy,
+            ),
+            signals,
+        )
+    }
+}

--- a/packages/capacitor/android/build.gradle
+++ b/packages/capacitor/android/build.gradle
@@ -27,4 +27,6 @@ dependencies {
     implementation project(':capacitor-android')
     // Explicitly pinned for now to keep coroutine behavior stable in this monorepo.
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1'
+
+    testImplementation 'junit:junit:4.13.2'
 }

--- a/packages/capacitor/android/src/main/AndroidManifest.xml
+++ b/packages/capacitor/android/src/main/AndroidManifest.xml
@@ -6,7 +6,9 @@
     <application>
         <service
             android:name="io.legato.capacitor.LegatoPlaybackService"
+            android:enabled="true"
             android:exported="false"
-            android:foregroundServiceType="mediaPlayback" />
+            android:foregroundServiceType="mediaPlayback"
+            android:stopWithTask="false" />
     </application>
 </manifest>

--- a/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoAndroidPlaybackCoordinator.kt
+++ b/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoAndroidPlaybackCoordinator.kt
@@ -1,0 +1,172 @@
+package io.legato.capacitor
+
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import io.legato.core.core.LegatoAndroidCoreComponents
+import io.legato.core.core.LegatoAndroidCoreFactory
+import io.legato.core.core.LegatoAndroidPauseOrigin
+import io.legato.core.core.LegatoAndroidServiceMode
+import java.util.concurrent.atomic.AtomicLong
+
+internal fun interface LegatoAndroidCoordinatorServiceRuntime {
+    fun ensureServiceRunning(mode: LegatoAndroidServiceMode)
+}
+
+internal object NoopLegatoAndroidCoordinatorServiceRuntime : LegatoAndroidCoordinatorServiceRuntime {
+    override fun ensureServiceRunning(mode: LegatoAndroidServiceMode) = Unit
+}
+
+internal class LegatoAndroidAppServiceRuntime(
+    private val appContext: Context,
+) : LegatoAndroidCoordinatorServiceRuntime {
+    override fun ensureServiceRunning(mode: LegatoAndroidServiceMode) {
+        if (mode == LegatoAndroidServiceMode.OFF) {
+            return
+        }
+
+        val intent = Intent(appContext, LegatoPlaybackService::class.java).apply {
+            putExtra(LegatoPlaybackService.EXTRA_SERVICE_MODE, mode.name)
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            appContext.startForegroundService(intent)
+        } else {
+            appContext.startService(intent)
+        }
+    }
+}
+
+internal class LegatoAndroidPlaybackCoordinator(
+    val core: LegatoAndroidCoreComponents,
+    private var serviceRuntime: LegatoAndroidCoordinatorServiceRuntime = NoopLegatoAndroidCoordinatorServiceRuntime,
+) {
+    private val modeListeners = linkedMapOf<Long, (LegatoAndroidServiceMode) -> Unit>()
+    private val modeListenerIds = AtomicLong(0L)
+    private val lock = Any()
+
+    private var projectedMode: LegatoAndroidServiceMode = core.playerEngine.getServiceMode()
+
+    private val coreProjectionListenerId: Long = core.eventEmitter.addListener {
+        projectServiceMode()
+    }
+
+    fun bindServiceRuntime(runtime: LegatoAndroidCoordinatorServiceRuntime) {
+        synchronized(lock) {
+            serviceRuntime = runtime
+        }
+        projectServiceMode()
+    }
+
+    fun setup() {
+        kotlinx.coroutines.runBlocking { core.playerEngine.setup() }
+        projectServiceMode()
+    }
+
+    fun load(tracks: List<io.legato.core.core.LegatoAndroidTrack>, startIndex: Int? = null) {
+        kotlinx.coroutines.runBlocking {
+            core.playerEngine.load(tracks = tracks, startIndex = startIndex)
+        }
+        projectServiceMode()
+    }
+
+    fun play() {
+        kotlinx.coroutines.runBlocking { core.playerEngine.play() }
+        projectServiceMode()
+    }
+
+    fun pause() {
+        kotlinx.coroutines.runBlocking { core.playerEngine.pause() }
+        projectServiceMode()
+    }
+
+    fun stop() {
+        kotlinx.coroutines.runBlocking { core.playerEngine.stop() }
+        projectServiceMode()
+    }
+
+    fun seekTo(positionMs: Long) {
+        kotlinx.coroutines.runBlocking { core.playerEngine.seekTo(positionMs) }
+        projectServiceMode()
+    }
+
+    fun skipToNext() {
+        kotlinx.coroutines.runBlocking { core.playerEngine.skipToNext() }
+        projectServiceMode()
+    }
+
+    fun skipToPrevious() {
+        kotlinx.coroutines.runBlocking { core.playerEngine.skipToPrevious() }
+        projectServiceMode()
+    }
+
+    fun addCoreEventListener(listener: (io.legato.core.core.LegatoAndroidEvent) -> Unit): Long =
+        core.eventEmitter.addListener(listener)
+
+    fun removeCoreEventListener(listenerId: Long) {
+        core.eventEmitter.removeListener(listenerId)
+    }
+
+    fun addServiceModeListener(listener: (LegatoAndroidServiceMode) -> Unit): Long {
+        val id = modeListenerIds.incrementAndGet()
+        synchronized(lock) {
+            modeListeners[id] = listener
+        }
+        listener(currentServiceMode())
+        return id
+    }
+
+    fun removeServiceModeListener(listenerId: Long) {
+        synchronized(lock) {
+            modeListeners.remove(listenerId)
+        }
+    }
+
+    fun currentServiceMode(): LegatoAndroidServiceMode = synchronized(lock) { projectedMode }
+
+    fun currentPauseOrigin(): LegatoAndroidPauseOrigin = core.playerEngine.getPauseOrigin()
+
+    fun projectServiceMode() {
+        val nextMode = core.playerEngine.getServiceMode()
+        val listenersToNotify: List<(LegatoAndroidServiceMode) -> Unit>
+        val shouldNotify: Boolean
+        val runtime: LegatoAndroidCoordinatorServiceRuntime
+
+        synchronized(lock) {
+            shouldNotify = nextMode != projectedMode
+            projectedMode = nextMode
+            listenersToNotify = modeListeners.values.toList()
+            runtime = serviceRuntime
+        }
+
+        if (nextMode != LegatoAndroidServiceMode.OFF) {
+            runtime.ensureServiceRunning(nextMode)
+        }
+
+        if (shouldNotify) {
+            listenersToNotify.forEach { it(nextMode) }
+        }
+    }
+
+    fun release() {
+        core.eventEmitter.removeListener(coreProjectionListenerId)
+        core.playerEngine.release()
+    }
+}
+
+internal object LegatoAndroidPlaybackCoordinatorStore {
+    private val lock = Any()
+    private var coordinator: LegatoAndroidPlaybackCoordinator? = null
+
+    fun getOrCreate(): LegatoAndroidPlaybackCoordinator = synchronized(lock) {
+        coordinator ?: LegatoAndroidPlaybackCoordinator(core = LegatoAndroidCoreFactory.create()).also {
+            coordinator = it
+        }
+    }
+
+    fun resetForTests() {
+        synchronized(lock) {
+            coordinator?.release()
+            coordinator = null
+        }
+    }
+}

--- a/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackService.kt
+++ b/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackService.kt
@@ -1,21 +1,116 @@
 package io.legato.capacitor
 
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
 import android.app.Service
+import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.IBinder
+import io.legato.core.core.LegatoAndroidServiceMode
 
-/**
- * Milestone 1 groundwork service stub.
- *
- * This class intentionally avoids Media3/session/runtime wiring for now and only
- * exists to anchor manifest + contract identity with a concrete Android Service.
- */
 class LegatoPlaybackService : Service() {
+    private val coordinator = LegatoAndroidPlaybackCoordinatorStore.getOrCreate()
+    private var modeListenerId: Long? = null
+    private var foregroundActive: Boolean = false
+
     override fun onBind(intent: Intent?): IBinder? = null
 
+    override fun onCreate() {
+        super.onCreate()
+        modeListenerId = coordinator.addServiceModeListener(::onServiceModeChanged)
+    }
+
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        // Non-production placeholder: foreground notification + transport runtime are pending.
-        stopSelfResult(startId)
-        return START_NOT_STICKY
+        val mode = intent?.getStringExtra(EXTRA_SERVICE_MODE)
+            ?.runCatching { LegatoAndroidServiceMode.valueOf(this) }
+            ?.getOrNull()
+            ?: coordinator.currentServiceMode()
+
+        onServiceModeChanged(mode)
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        modeListenerId?.let(coordinator::removeServiceModeListener)
+        modeListenerId = null
+        if (foregroundActive) {
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            foregroundActive = false
+        }
+        super.onDestroy()
+    }
+
+    private fun onServiceModeChanged(mode: LegatoAndroidServiceMode) {
+        if (mode == LegatoAndroidServiceMode.OFF) {
+            if (foregroundActive) {
+                stopForeground(STOP_FOREGROUND_REMOVE)
+                foregroundActive = false
+            }
+            stopSelf()
+            return
+        }
+
+        startForegroundInternal(mode)
+    }
+
+    private fun startForegroundInternal(mode: LegatoAndroidServiceMode) {
+        val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            notificationManager.createNotificationChannel(
+                NotificationChannel(
+                    CHANNEL_ID,
+                    CHANNEL_NAME,
+                    NotificationManager.IMPORTANCE_LOW,
+                ),
+            )
+        }
+
+        startForeground(NOTIFICATION_ID, buildNotification(mode))
+        foregroundActive = true
+    }
+
+    private fun buildNotification(mode: LegatoAndroidServiceMode): Notification {
+        val launchIntent = packageManager.getLaunchIntentForPackage(packageName)
+        val pendingIntent = launchIntent?.let {
+            PendingIntent.getActivity(
+                this,
+                1001,
+                it,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
+        }
+
+        val contentText = when (mode) {
+            LegatoAndroidServiceMode.PLAYBACK_ACTIVE -> "Playback active"
+            LegatoAndroidServiceMode.RESUME_PENDING_INTERRUPTION -> "Paused by interruption"
+            LegatoAndroidServiceMode.OFF -> "Idle"
+        }
+
+        val builder = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Notification.Builder(this, CHANNEL_ID)
+        } else {
+            Notification.Builder(this)
+        }
+
+        builder
+            .setSmallIcon(android.R.drawable.ic_media_play)
+            .setContentTitle("Legato Playback")
+            .setContentText(contentText)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setCategory(Notification.CATEGORY_TRANSPORT)
+            .setContentIntent(pendingIntent)
+
+        return builder.build()
+    }
+
+    companion object {
+        internal const val EXTRA_SERVICE_MODE: String = "legato.service_mode"
+        private const val CHANNEL_ID: String = "legato.playback"
+        private const val CHANNEL_NAME: String = "Legato playback"
+        private const val NOTIFICATION_ID: Int = 4242
     }
 }

--- a/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlugin.kt
+++ b/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlugin.kt
@@ -5,39 +5,38 @@ import com.getcapacitor.Plugin
 import com.getcapacitor.PluginCall
 import com.getcapacitor.PluginMethod
 import com.getcapacitor.annotation.CapacitorPlugin
-import io.legato.core.core.LegatoAndroidCoreFactory
 import io.legato.core.core.LegatoAndroidEventName
 import io.legato.core.core.LegatoAndroidEventPayload
 import io.legato.core.core.LegatoAndroidPlaybackSnapshot
 import io.legato.core.core.LegatoAndroidPlaybackState
 import io.legato.core.core.LegatoAndroidQueueSnapshot
 import io.legato.core.core.LegatoAndroidErrorCode
-import kotlinx.coroutines.runBlocking
 
 @CapacitorPlugin(name = "Legato")
 class LegatoPlugin : Plugin() {
     private val mapper = LegatoCapacitorMapper()
-    private val core = LegatoAndroidCoreFactory.create()
+    private val coordinator = LegatoAndroidPlaybackCoordinatorStore.getOrCreate()
+    private val core get() = coordinator.core
     private var coreListenerId: Long? = null
 
     override fun load() {
         super.load()
-        coreListenerId = core.eventEmitter.addListener { event ->
+        coordinator.bindServiceRuntime(LegatoAndroidAppServiceRuntime(context.applicationContext))
+        coreListenerId = coordinator.addCoreEventListener { event ->
             notifyListeners(event.name.wireValue, mapper.eventPayloadToJs(event.payload))
         }
     }
 
     override fun handleOnDestroy() {
-        coreListenerId?.let(core.eventEmitter::removeListener)
+        coreListenerId?.let(coordinator::removeCoreEventListener)
         coreListenerId = null
-        core.playerEngine.release()
         super.handleOnDestroy()
     }
 
     @PluginMethod
     fun setup(call: PluginCall) {
         runCatching {
-            runBlocking { core.playerEngine.setup() }
+            coordinator.setup()
             call.resolve(ok())
         }.onFailure { reject(call, it) }
     }
@@ -67,6 +66,8 @@ class LegatoPlugin : Plugin() {
                     payload = LegatoAndroidEventPayload.PlaybackStateChanged(next.state),
                 )
             }
+
+            coordinator.projectServiceMode()
 
             call.resolve(snapshotResult(next))
         }.onFailure { reject(call, it) }
@@ -118,6 +119,8 @@ class LegatoPlugin : Plugin() {
                 )
             }
 
+            coordinator.projectServiceMode()
+
             call.resolve(snapshotResult(next))
         }.onFailure { reject(call, it) }
     }
@@ -142,6 +145,8 @@ class LegatoPlugin : Plugin() {
                 payload = LegatoAndroidEventPayload.PlaybackStateChanged(snapshot.state),
             )
 
+            coordinator.projectServiceMode()
+
             call.resolve(snapshotResult(snapshot))
         }.onFailure { reject(call, it) }
     }
@@ -149,7 +154,7 @@ class LegatoPlugin : Plugin() {
     @PluginMethod
     fun play(call: PluginCall) {
         runCatching {
-            runBlocking { core.playerEngine.play() }
+            coordinator.play()
             call.resolve(ok())
         }.onFailure { reject(call, it) }
     }
@@ -157,7 +162,7 @@ class LegatoPlugin : Plugin() {
     @PluginMethod
     fun pause(call: PluginCall) {
         runCatching {
-            runBlocking { core.playerEngine.pause() }
+            coordinator.pause()
             call.resolve(ok())
         }.onFailure { reject(call, it) }
     }
@@ -165,7 +170,7 @@ class LegatoPlugin : Plugin() {
     @PluginMethod
     fun stop(call: PluginCall) {
         runCatching {
-            runBlocking { core.playerEngine.stop() }
+            coordinator.stop()
             call.resolve(ok())
         }.onFailure { reject(call, it) }
     }
@@ -175,7 +180,7 @@ class LegatoPlugin : Plugin() {
         runCatching {
             val position = call.getDouble("position")?.toLong()
                 ?: error("seekTo.position is required")
-            runBlocking { core.playerEngine.seekTo(position) }
+            coordinator.seekTo(position)
             call.resolve(ok())
         }.onFailure { reject(call, it) }
     }
@@ -192,6 +197,7 @@ class LegatoPlugin : Plugin() {
             val next = snapshotWithQueue(previous, nextQueue)
             core.snapshotStore.replacePlaybackSnapshot(next)
             publishQueueTrackProgress(next)
+            coordinator.projectServiceMode()
             call.resolve(snapshotResult(next))
         }.onFailure { reject(call, it) }
     }
@@ -199,7 +205,7 @@ class LegatoPlugin : Plugin() {
     @PluginMethod
     fun skipToNext(call: PluginCall) {
         runCatching {
-            runBlocking { core.playerEngine.skipToNext() }
+            coordinator.skipToNext()
             call.resolve(ok())
         }.onFailure { reject(call, it) }
     }
@@ -207,7 +213,7 @@ class LegatoPlugin : Plugin() {
     @PluginMethod
     fun skipToPrevious(call: PluginCall) {
         runCatching {
-            runBlocking { core.playerEngine.skipToPrevious() }
+            coordinator.skipToPrevious()
             call.resolve(ok())
         }.onFailure { reject(call, it) }
     }

--- a/packages/capacitor/android/src/test/kotlin/io/legato/capacitor/LegatoAndroidPlaybackCoordinatorTest.kt
+++ b/packages/capacitor/android/src/test/kotlin/io/legato/capacitor/LegatoAndroidPlaybackCoordinatorTest.kt
@@ -1,0 +1,195 @@
+package io.legato.capacitor
+
+import io.legato.core.core.LegatoAndroidCoreComponents
+import io.legato.core.core.LegatoAndroidCoreDependencies
+import io.legato.core.core.LegatoAndroidCoreFactory
+import io.legato.core.core.LegatoAndroidPauseOrigin
+import io.legato.core.core.LegatoAndroidPlaybackState
+import io.legato.core.core.LegatoAndroidProgressUpdate
+import io.legato.core.core.LegatoAndroidRemoteCommand
+import io.legato.core.core.LegatoAndroidServiceMode
+import io.legato.core.core.LegatoAndroidTrack
+import io.legato.core.core.LegatoAndroidNowPlayingMetadata
+import io.legato.core.queue.LegatoAndroidQueueManager
+import io.legato.core.remote.LegatoAndroidRemoteCommandRuntime
+import io.legato.core.runtime.LegatoAndroidPlaybackRuntime
+import io.legato.core.runtime.LegatoAndroidPlaybackRuntimeListener
+import io.legato.core.runtime.LegatoAndroidRuntimeSnapshot
+import io.legato.core.runtime.LegatoAndroidRuntimeTrackSource
+import io.legato.core.session.LegatoAndroidAudioFocusGainHint
+import io.legato.core.session.LegatoAndroidAudioFocusPolicy
+import io.legato.core.session.LegatoAndroidInterruptionSignal
+import io.legato.core.session.LegatoAndroidSessionManager
+import io.legato.core.session.LegatoAndroidSessionRuntime
+import io.legato.core.snapshot.LegatoAndroidSnapshotStore
+import io.legato.core.state.LegatoAndroidStateMachine
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LegatoAndroidPlaybackCoordinatorTest {
+    @Test
+    fun `coordinator projects active and off service modes from engine transitions`() = runBlocking {
+        val runtime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val serviceRuntime = RecordingCoordinatorServiceRuntime()
+        val coordinator = LegatoAndroidPlaybackCoordinator(
+            core = buildCore(runtime, sessionRuntime),
+            serviceRuntime = serviceRuntime,
+        )
+        val modes = mutableListOf<LegatoAndroidServiceMode>()
+        coordinator.addServiceModeListener { modes += it }
+
+        coordinator.setup()
+        coordinator.load(
+            listOf(
+                LegatoAndroidTrack(
+                    id = "track-1",
+                    url = "https://example.com/track.mp3",
+                ),
+            ),
+        )
+
+        coordinator.play()
+        coordinator.stop()
+
+        assertTrue(modes.contains(LegatoAndroidServiceMode.PLAYBACK_ACTIVE))
+        assertEquals(LegatoAndroidServiceMode.OFF, coordinator.currentServiceMode())
+        assertTrue(serviceRuntime.ensureServiceRunningCalls > 0)
+    }
+
+    @Test
+    fun `coordinator projects interruption pending mode on focus loss without auto resume`() = runBlocking {
+        val runtime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val coordinator = LegatoAndroidPlaybackCoordinator(
+            core = buildCore(runtime, sessionRuntime),
+            serviceRuntime = RecordingCoordinatorServiceRuntime(),
+        )
+
+        coordinator.setup()
+        coordinator.load(
+            listOf(
+                LegatoAndroidTrack(
+                    id = "track-1",
+                    url = "https://example.com/track.mp3",
+                ),
+            ),
+        )
+        coordinator.play()
+
+        val playCallsBeforeLoss = runtime.playCallCount
+        sessionRuntime.emit(LegatoAndroidInterruptionSignal.AudioFocusLostTransient)
+        sessionRuntime.emit(LegatoAndroidInterruptionSignal.AudioFocusGained)
+
+        assertEquals(LegatoAndroidServiceMode.RESUME_PENDING_INTERRUPTION, coordinator.currentServiceMode())
+        assertEquals(playCallsBeforeLoss, runtime.playCallCount)
+        assertEquals(LegatoAndroidPauseOrigin.INTERRUPTION, coordinator.currentPauseOrigin())
+    }
+
+    private fun buildCore(
+        runtime: RecordingPlaybackRuntime,
+        sessionRuntime: RecordingSessionRuntime,
+    ): LegatoAndroidCoreComponents = LegatoAndroidCoreFactory.create(
+        dependencies = LegatoAndroidCoreDependencies(
+            queueManager = LegatoAndroidQueueManager(),
+            snapshotStore = LegatoAndroidSnapshotStore(),
+            stateMachine = LegatoAndroidStateMachine(),
+            sessionManager = LegatoAndroidSessionManager(sessionRuntime),
+            remoteCommandManager = io.legato.core.remote.LegatoAndroidRemoteCommandManager(
+                object : LegatoAndroidRemoteCommandRuntime {
+                    override fun bind(listener: (LegatoAndroidRemoteCommand) -> Unit) = Unit
+
+                    override fun updatePlaybackState(state: LegatoAndroidPlaybackState) = Unit
+
+                    override fun unbind() = Unit
+                },
+            ),
+            playbackRuntime = runtime,
+        ),
+    )
+}
+
+private class RecordingCoordinatorServiceRuntime : LegatoAndroidCoordinatorServiceRuntime {
+    var ensureServiceRunningCalls: Int = 0
+        private set
+
+    override fun ensureServiceRunning(mode: LegatoAndroidServiceMode) {
+        ensureServiceRunningCalls += 1
+    }
+}
+
+private class RecordingPlaybackRuntime : LegatoAndroidPlaybackRuntime {
+    private var listener: LegatoAndroidPlaybackRuntimeListener? = null
+    private var snapshot = LegatoAndroidRuntimeSnapshot()
+
+    var playCallCount: Int = 0
+        private set
+
+    override fun configure() = Unit
+
+    override fun setListener(listener: LegatoAndroidPlaybackRuntimeListener?) {
+        this.listener = listener
+    }
+
+    override fun replaceQueue(items: List<LegatoAndroidRuntimeTrackSource>, startIndex: Int?) {
+        snapshot = snapshot.copy(currentIndex = if (items.isEmpty()) null else (startIndex ?: 0))
+    }
+
+    override fun selectIndex(index: Int) {
+        snapshot = snapshot.copy(currentIndex = index)
+    }
+
+    override fun play() {
+        playCallCount += 1
+    }
+
+    override fun pause() = Unit
+
+    override fun stop(resetPosition: Boolean) = Unit
+
+    override fun seekTo(positionMs: Long) {
+        snapshot = snapshot.copy(progress = snapshot.progress.copy(positionMs = positionMs))
+    }
+
+    override fun snapshot(): LegatoAndroidRuntimeSnapshot = snapshot
+
+    override fun release() {
+        listener = null
+    }
+}
+
+private class RecordingSessionRuntime : LegatoAndroidSessionRuntime {
+    private var listener: ((LegatoAndroidInterruptionSignal) -> Unit)? = null
+
+    override fun configureSession() = Unit
+
+    override fun audioFocusPolicy(): LegatoAndroidAudioFocusPolicy =
+        LegatoAndroidAudioFocusPolicy(
+            gainHint = LegatoAndroidAudioFocusGainHint.AUDIOFOCUS_GAIN,
+            pauseOnTransientLoss = true,
+            duckOnTransientCanDuck = true,
+            resumeAfterGainIfNotUserPaused = false,
+        )
+
+    override fun setInterruptionListener(listener: ((LegatoAndroidInterruptionSignal) -> Unit)?) {
+        this.listener = listener
+    }
+
+    override fun onInterruption(signal: LegatoAndroidInterruptionSignal) = Unit
+
+    override fun updatePlaybackState(state: LegatoAndroidPlaybackState) = Unit
+
+    override fun updateNowPlayingMetadata(metadata: LegatoAndroidNowPlayingMetadata?) = Unit
+
+    override fun updateProgress(progress: LegatoAndroidProgressUpdate) = Unit
+
+    override fun releaseSession() {
+        listener = null
+    }
+
+    fun emit(signal: LegatoAndroidInterruptionSignal) {
+        listener?.invoke(signal)
+    }
+}


### PR DESCRIPTION
Closes #13

## Summary
- add a real Android runtime/session callback foundation with conservative audio-focus semantics (`pause` on loss, no auto-resume on gain)
- introduce a shared playback coordinator so plugin + service can coordinate lifecycle without making the service the playback owner
- upgrade the Capacitor demo harness and Android validation scaffolding so the parity slice can be exercised and regression-tested

## Changes
| File | Change |
|------|--------|
| `native/android/core/src/main/kotlin/io/legato/core/runtime/LegatoAndroidPlaybackRuntime.kt` | extends Android playback runtime seam with callbacks and buffering/error hooks |
| `native/android/core/src/main/kotlin/io/legato/core/runtime/LegatoAndroidMedia3PlaybackRuntime.kt` | adds real runtime foundation for Android playback callbacks |
| `native/android/core/src/main/kotlin/io/legato/core/session/LegatoAndroidSessionRuntime.kt` | adds typed focus/interruption policy surface and noop-compatible runtime behavior |
| `native/android/core/src/main/kotlin/io/legato/core/session/LegatoAndroidSessionManager.kt` | exposes Android session/focus signal seam through the manager |
| `native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidPlayerEngine.kt` | maps runtime/session callbacks into canonical playback semantics and service projection |
| `native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidCoreComposition.kt` | wires real Android runtime/session foundations into composition |
| `packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoAndroidPlaybackCoordinator.kt` | shared playback coordinator between plugin and service |
| `packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlugin.kt` | integrates plugin lifecycle with coordinator-owned playback core |
| `packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackService.kt` | foreground service lifecycle coordination without taking playback ownership |
| `packages/capacitor/android/src/main/AndroidManifest.xml` | aligns service/permission declarations for parity v1 |
| `apps/capacitor-demo/index.html`, `apps/capacitor-demo/src/main.ts`, `apps/capacitor-demo/README.md` | richer native harness surfaces and Android lifecycle validation guidance |
| Android test files under `native/android/core/src/test/` and `packages/capacitor/android/src/test/` | focused unit/contract coverage for runtime, focus policy, coordinator behavior, and harness validation |

## Test Plan
- [x] Strict-TDD-driven Android core/unit test additions for runtime, session policy, and coordinator behavior
- [x] `sh ./gradlew test` from `apps/capacitor-demo/android` completed successfully during implementation batches
- [x] Harness validation contract test added for demo/manual validation affordances
- [ ] Manual Android device/emulator validation still required for real background/focus/noisy-route behavior

## Notes
- This is parity **v1**, not final Android completeness: lockscreen/BT/car richness and broader OEM hardening remain future work.
- Focus regain stays conservative in v1: no automatic resume.
