### PR TITLE
feat(native): add remote now-playing parity

### DIFF
--- a/apps/capacitor-demo/README.md
+++ b/apps/capacitor-demo/README.md
@@ -43,8 +43,9 @@ Harness now supports both one-click smoke and manual controls for:
 - `setup`, `sync.start`, `sync.stop`
 - `add`, `play`, `pause`, `stop`, `seekTo`, `getSnapshot`
 - copy-friendly recent events + raw log + snapshot summary/json
+- a compact **Remote parity inspector** summary (state/progress trend/metadata presence/event signals)
 
-Use direct samplelib MP3 URLs from the default fixtures (no redirect links) to keep playback behavior deterministic during native checks.
+Default fixtures now include title/artist/album/artwork/duration metadata and direct samplelib MP3 URLs (no redirect links) to keep playback behavior deterministic during native checks.
 
 Before opening Android Studio/Xcode after harness changes, ALWAYS refresh native hosts:
 
@@ -55,10 +56,12 @@ npm run cap:sync
 
 Manual parity checklist to close milestone validation:
 
-1. Background continuity: playback keeps running with app backgrounded and foreground notification remains active.
-2. Focus loss pauses playback.
-3. Focus regain does not auto-resume (explicit play required).
-4. `stop()` + idle tears down foreground service/notification.
+1. Start `Run smoke flow` (or manual setup/sync/add/play), then background the app.
+2. Trigger lock-screen/media-notification **pause**, return to app, tap `getSnapshot()`, and verify paused state + frozen progress.
+3. Trigger lock-screen/media-notification **play**, return to app, tap `getSnapshot()`, and verify playing state + advancing progress.
+4. Verify now-playing surfaces show title/artist/album/artwork/duration from fixture metadata.
+5. Trigger next/previous/seek from remote surfaces and confirm v1 inert behavior (no crash, no playback jump).
+6. (Android lifecycle carry-over) `stop()` + idle tears down foreground service/notification.
 
 ## Quick smoke checklist (manual, lightweight)
 

--- a/apps/capacitor-demo/index.html
+++ b/apps/capacitor-demo/index.html
@@ -117,6 +117,17 @@
         font-size: 0.83rem;
       }
 
+      #parity-summary {
+        margin: 0;
+        padding: 0.75rem;
+        border: 1px solid #d1d5db;
+        border-radius: 8px;
+        min-height: 96px;
+        white-space: pre-wrap;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+        font-size: 0.82rem;
+      }
+
       #events {
         min-height: 140px;
       }
@@ -172,6 +183,8 @@
         <section class="card stack">
           <h2>Snapshot summary</h2>
           <pre id="snapshot-summary">No snapshot captured yet.</pre>
+          <h2 style="margin-top: 0.35rem">Remote parity inspector (iOS + Android)</h2>
+          <pre id="parity-summary">No parity signals yet.</pre>
           <textarea id="snapshot-json" readonly spellcheck="false" placeholder="Latest snapshot JSON payload..."></textarea>
         </section>
 
@@ -186,12 +199,12 @@
         </section>
 
         <section class="card stack">
-          <h2>Android lifecycle validation checklist</h2>
+          <h2>Remote parity validation checklist</h2>
           <ul>
-            <li>Background continuity: start playback, background app, verify audio keeps running and service notification stays visible.</li>
-            <li>Focus loss pauses playback: trigger interruption/noisy route change and verify state becomes paused.</li>
-            <li>Focus regain does not auto-resume: after focus returns, playback must remain paused until explicit play().</li>
-            <li>stop+idle tears down foreground service: run stop() and verify foreground notification/service are removed.</li>
+            <li>Background play/pause parity: with playback running, background app and toggle lock-screen/notification play↔pause; verify state changes match manual play()/pause().</li>
+            <li>Now-playing metadata parity: verify title/artist/album/artwork/duration are visible in lock screen / media notification.</li>
+            <li>Progress parity: while playing, lock-screen/notification progress advances; after pause it stays frozen at pause point.</li>
+            <li>v1 command scope: next/previous/seek from remote surface must be inert (no crashes, no track/position jump).</li>
           </ul>
           <p>After harness updates: run <code>npm run build</code> and <code>npm run cap:sync</code> before Android Studio/Xcode validation.</p>
         </section>

--- a/apps/capacitor-demo/src/main.ts
+++ b/apps/capacitor-demo/src/main.ts
@@ -21,6 +21,7 @@ const envStatusNode = document.querySelector<HTMLDivElement>('#env-status');
 const logNode = document.querySelector<HTMLTextAreaElement>('#log');
 const eventsNode = document.querySelector<HTMLTextAreaElement>('#events');
 const snapshotSummaryNode = document.querySelector<HTMLPreElement>('#snapshot-summary');
+const paritySummaryNode = document.querySelector<HTMLPreElement>('#parity-summary');
 const snapshotJsonNode = document.querySelector<HTMLTextAreaElement>('#snapshot-json');
 
 if (
@@ -42,6 +43,7 @@ if (
   || !logNode
   || !eventsNode
   || !snapshotSummaryNode
+  || !paritySummaryNode
   || !snapshotJsonNode
 ) {
   throw new Error('Demo UI nodes are missing');
@@ -51,6 +53,7 @@ const nativeActionButtons = Array.from(document.querySelectorAll<HTMLButtonEleme
 const playbackSmokeDelayMs = 1500;
 const endSmokeDelayMs = 6500;
 const recentEventsLimit = 24;
+const progressSamplesLimit = 8;
 
 const platform = Capacitor.getPlatform();
 const isNative = Capacitor.isNativePlatform();
@@ -58,6 +61,8 @@ const isNative = Capacitor.isNativePlatform();
 let syncController: LegatoSyncController | null = null;
 let latestSnapshot: PlaybackSnapshot | null = null;
 let recentEvents: string[] = [];
+let recentProgressSamples: Array<{ state: string; positionMs: number }> = [];
+const observedSyncEvents = new Set<string>();
 
 const demoTracks: Track[] = [
   {
@@ -65,6 +70,8 @@ const demoTracks: Track[] = [
     url: 'https://samplelib.com/mp3/sample-3s.mp3',
     title: 'Demo Track 1 (3s sample)',
     artist: 'Samplelib',
+    album: 'Legato Remote Parity Fixtures',
+    artwork: 'https://samplelib.com/lib/preview/png/sample-bumblebee-400x300.png',
     duration: 3000,
     type: 'progressive',
   },
@@ -73,6 +80,8 @@ const demoTracks: Track[] = [
     url: 'https://samplelib.com/mp3/sample-6s.mp3',
     title: 'Demo Track 2 (6s sample)',
     artist: 'Samplelib',
+    album: 'Legato Remote Parity Fixtures',
+    artwork: 'https://samplelib.com/lib/preview/png/sample-bumblebee-400x300.png',
     duration: 6000,
     type: 'progressive',
   },
@@ -173,6 +182,95 @@ const summarizePayload = (payload: unknown): string => {
   return compact.length > 220 ? `${compact.slice(0, 220)}…` : compact;
 };
 
+const formatRequiredMetadataSignal = (snapshot: PlaybackSnapshot): string => {
+  const track = snapshot.currentTrack as Record<string, unknown> | null | undefined;
+
+  if (!track) {
+    return 'missing title/artist/album/artwork/duration (no current track)';
+  }
+
+  const missing: string[] = [];
+  const checkTextField = (field: 'title' | 'artist' | 'album' | 'artwork'): void => {
+    const value = track[field];
+    if (typeof value !== 'string' || value.trim() === '') {
+      missing.push(field);
+    }
+  };
+
+  checkTextField('title');
+  checkTextField('artist');
+  checkTextField('album');
+  checkTextField('artwork');
+
+  const durationValue = track.duration;
+  if (typeof durationValue !== 'number' || !Number.isFinite(durationValue) || durationValue <= 0) {
+    missing.push('duration');
+  }
+
+  if (missing.length === 0) {
+    return 'all required fields present (title/artist/album/artwork/duration)';
+  }
+
+  return `missing ${missing.join('/')}`;
+};
+
+const addProgressSample = (snapshot: PlaybackSnapshot): void => {
+  if (typeof snapshot.position !== 'number' || Number.isNaN(snapshot.position)) {
+    return;
+  }
+
+  recentProgressSamples = [
+    ...recentProgressSamples.slice(-progressSamplesLimit + 1),
+    { state: snapshot.state, positionMs: snapshot.position },
+  ];
+};
+
+const summarizeProgressSignal = (): string => {
+  if (recentProgressSamples.length < 2) {
+    return 'insufficient samples (capture at least two snapshots/events)';
+  }
+
+  const [previous, current] = recentProgressSamples.slice(-2);
+  const deltaMs = current.positionMs - previous.positionMs;
+
+  if (current.state === 'playing') {
+    if (deltaMs > 250) {
+      return `advancing while playing (+${deltaMs}ms latest delta)`;
+    }
+    return `not clearly advancing while playing (+${deltaMs}ms latest delta)`;
+  }
+
+  if (current.state === 'paused') {
+    if (Math.abs(deltaMs) <= 150) {
+      return `frozen while paused (${deltaMs >= 0 ? '+' : ''}${deltaMs}ms latest delta)`;
+    }
+    return `unexpected movement while paused (${deltaMs >= 0 ? '+' : ''}${deltaMs}ms latest delta)`;
+  }
+
+  return `state=${current.state} latest delta=${deltaMs >= 0 ? '+' : ''}${deltaMs}ms`;
+};
+
+const summarizeObservedEventSignals = (): string => {
+  const parityEventNames = [...observedSyncEvents].filter((name) => /remote|state|progress|play|pause|metadata|snapshot/i.test(name));
+  if (parityEventNames.length === 0) {
+    return 'none yet';
+  }
+
+  return parityEventNames.slice(-8).join(', ');
+};
+
+const updateParityInspector = (snapshot: PlaybackSnapshot): void => {
+  const lines = [
+    `state signal: ${snapshot.state}`,
+    `progress signal: ${summarizeProgressSignal()}`,
+    `metadata signal: ${formatRequiredMetadataSignal(snapshot)}`,
+    `observed sync events: ${summarizeObservedEventSignals()}`,
+    'manual remote check: background app, toggle lock-screen/notification play↔pause, then tap getSnapshot().',
+  ];
+
+  paritySummaryNode.textContent = lines.join('\n');
+};
+
 const log = (message: string, payload?: unknown): void => {
   const prefix = `[${new Date().toLocaleTimeString()}]`;
   const line = payload === undefined ? message : `${message} ${summarizePayload(payload)}`;
@@ -193,8 +291,10 @@ const addRecentEvent = (message: string): void => {
 
 const updateSnapshotViews = (snapshot: PlaybackSnapshot): void => {
   latestSnapshot = snapshot;
+  addProgressSample(snapshot);
   snapshotSummaryNode.textContent = summarizeSnapshot(snapshot);
   snapshotJsonNode.value = JSON.stringify(snapshot, null, 2);
+  updateParityInspector(snapshot);
   addRecentEvent(`snapshot summary ${summarizeSnapshot(snapshot)}`);
 };
 
@@ -232,9 +332,14 @@ const startSync = async (): Promise<void> => {
       log('sync snapshot', snapshot);
     },
     onEvent: (eventName, payload) => {
+      observedSyncEvents.add(eventName);
       const details = summarizePayload(payload);
       log(`event:${eventName}`, payload);
       addRecentEvent(`event:${eventName}${details ? ` | ${details}` : ''}`);
+
+      if (latestSnapshot) {
+        updateParityInspector(latestSnapshot);
+      }
     },
   });
 
@@ -419,4 +524,5 @@ if (!isNative) {
 
 if (latestSnapshot == null) {
   snapshotSummaryNode.textContent = 'No snapshot captured yet.';
+  paritySummaryNode.textContent = 'No parity signals yet.';
 }

--- a/native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidCoreComposition.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidCoreComposition.kt
@@ -3,11 +3,11 @@ package io.legato.core.core
 import io.legato.core.errors.LegatoAndroidErrorMapper
 import io.legato.core.events.LegatoAndroidEventEmitter
 import io.legato.core.mapping.LegatoAndroidTrackMapper
+import io.legato.core.remote.LegatoAndroidMediaSessionBridge
 import io.legato.core.queue.LegatoAndroidQueueManager
 import io.legato.core.remote.LegatoAndroidRemoteCommandManager
 import io.legato.core.runtime.LegatoAndroidMedia3PlaybackRuntime
 import io.legato.core.runtime.LegatoAndroidPlaybackRuntime
-import io.legato.core.session.LegatoAndroidAudioFocusSessionRuntime
 import io.legato.core.session.LegatoAndroidSessionManager
 import io.legato.core.snapshot.LegatoAndroidSnapshotStore
 import io.legato.core.state.LegatoAndroidStateMachine
@@ -19,9 +19,11 @@ data class LegatoAndroidCoreDependencies(
     val trackMapper: LegatoAndroidTrackMapper = LegatoAndroidTrackMapper(),
     val errorMapper: LegatoAndroidErrorMapper = LegatoAndroidErrorMapper(),
     val stateMachine: LegatoAndroidStateMachine = LegatoAndroidStateMachine(),
+    val mediaSessionBridge: LegatoAndroidMediaSessionBridge = LegatoAndroidMediaSessionBridge(),
     val sessionManager: LegatoAndroidSessionManager =
-        LegatoAndroidSessionManager(runtime = LegatoAndroidAudioFocusSessionRuntime()),
-    val remoteCommandManager: LegatoAndroidRemoteCommandManager = LegatoAndroidRemoteCommandManager(),
+        LegatoAndroidSessionManager(runtime = mediaSessionBridge),
+    val remoteCommandManager: LegatoAndroidRemoteCommandManager =
+        LegatoAndroidRemoteCommandManager(runtime = mediaSessionBridge),
     val playbackRuntime: LegatoAndroidPlaybackRuntime = LegatoAndroidMedia3PlaybackRuntime(),
 )
 
@@ -32,6 +34,7 @@ data class LegatoAndroidCoreComponents(
     val trackMapper: LegatoAndroidTrackMapper,
     val errorMapper: LegatoAndroidErrorMapper,
     val stateMachine: LegatoAndroidStateMachine,
+    val mediaSessionBridge: LegatoAndroidMediaSessionBridge,
     val sessionManager: LegatoAndroidSessionManager,
     val remoteCommandManager: LegatoAndroidRemoteCommandManager,
     val playbackRuntime: LegatoAndroidPlaybackRuntime,
@@ -62,6 +65,7 @@ object LegatoAndroidCoreFactory {
             trackMapper = dependencies.trackMapper,
             errorMapper = dependencies.errorMapper,
             stateMachine = dependencies.stateMachine,
+            mediaSessionBridge = dependencies.mediaSessionBridge,
             sessionManager = dependencies.sessionManager,
             remoteCommandManager = dependencies.remoteCommandManager,
             playbackRuntime = dependencies.playbackRuntime,

--- a/native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidPlayerEngine.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidPlayerEngine.kt
@@ -74,20 +74,12 @@ class LegatoAndroidPlayerEngine(
 
     suspend fun play() {
         guardSetup()
-        if (!runRuntimeOperation {
-            playbackRuntime.play()
-        }) return
-        pauseOrigin = LegatoAndroidPauseOrigin.USER
-        transitionTo(LegatoAndroidStateMachine.LegatoAndroidStateInput.PLAY)
+        executePlay()
     }
 
     suspend fun pause() {
         guardSetup()
-        if (!runRuntimeOperation {
-            playbackRuntime.pause()
-        }) return
-        pauseOrigin = LegatoAndroidPauseOrigin.USER
-        transitionTo(LegatoAndroidStateMachine.LegatoAndroidStateInput.PAUSE)
+        executePause()
     }
 
     suspend fun stop() {
@@ -374,15 +366,21 @@ class LegatoAndroidPlayerEngine(
 
     private fun onRemoteCommand(command: LegatoAndroidRemoteCommand) {
         when (command) {
-            LegatoAndroidRemoteCommand.Play -> eventEmitter.emit(
-                name = LegatoAndroidEventName.REMOTE_PLAY,
-                payload = LegatoAndroidEventPayload.RemotePlay,
-            )
+            LegatoAndroidRemoteCommand.Play -> {
+                executePlay()
+                eventEmitter.emit(
+                    name = LegatoAndroidEventName.REMOTE_PLAY,
+                    payload = LegatoAndroidEventPayload.RemotePlay,
+                )
+            }
 
-            LegatoAndroidRemoteCommand.Pause -> eventEmitter.emit(
-                name = LegatoAndroidEventName.REMOTE_PAUSE,
-                payload = LegatoAndroidEventPayload.RemotePause,
-            )
+            LegatoAndroidRemoteCommand.Pause -> {
+                executePause()
+                eventEmitter.emit(
+                    name = LegatoAndroidEventName.REMOTE_PAUSE,
+                    payload = LegatoAndroidEventPayload.RemotePause,
+                )
+            }
 
             LegatoAndroidRemoteCommand.Next -> eventEmitter.emit(
                 name = LegatoAndroidEventName.REMOTE_NEXT,
@@ -399,7 +397,23 @@ class LegatoAndroidPlayerEngine(
                 payload = LegatoAndroidEventPayload.RemoteSeek(command.positionMs),
             )
         }
+    }
 
-        // TODO(phase-4): Route remote commands through the same transport pipeline as binding commands.
+    private fun executePlay() {
+        if (!runRuntimeOperation {
+            playbackRuntime.play()
+        }) return
+
+        pauseOrigin = LegatoAndroidPauseOrigin.USER
+        transitionTo(LegatoAndroidStateMachine.LegatoAndroidStateInput.PLAY)
+    }
+
+    private fun executePause() {
+        if (!runRuntimeOperation {
+            playbackRuntime.pause()
+        }) return
+
+        pauseOrigin = LegatoAndroidPauseOrigin.USER
+        transitionTo(LegatoAndroidStateMachine.LegatoAndroidStateInput.PAUSE)
     }
 }

--- a/native/android/core/src/main/kotlin/io/legato/core/remote/LegatoAndroidMediaSessionBridge.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/remote/LegatoAndroidMediaSessionBridge.kt
@@ -1,0 +1,113 @@
+package io.legato.core.remote
+
+import io.legato.core.core.LegatoAndroidNowPlayingMetadata
+import io.legato.core.core.LegatoAndroidPlaybackState
+import io.legato.core.core.LegatoAndroidProgressUpdate
+import io.legato.core.core.LegatoAndroidRemoteCommand
+import io.legato.core.session.LegatoAndroidAudioFocusPolicy
+import io.legato.core.session.LegatoAndroidInterruptionSignal
+import io.legato.core.session.LegatoAndroidSessionDefaults
+import io.legato.core.session.LegatoAndroidSessionRuntime
+
+/**
+ * Shared Android foundation runtime for MediaSession parity work.
+ *
+ * This bridge is intentionally minimal for v1 foundation:
+ * - Session side: receives projected state/metadata/progress from the engine.
+ * - Remote side: forwards platform transport callbacks into the engine listener.
+ *
+ * Concrete MediaSession wiring (platform callbacks + notification actions) is added
+ * by follow-up Android runtime tasks while preserving this shared seam.
+ */
+class LegatoAndroidMediaSessionBridge : LegatoAndroidSessionRuntime, LegatoAndroidRemoteCommandRuntime {
+    enum class TransportControl {
+        PLAY,
+        PAUSE,
+    }
+
+    private var interruptionListener: ((LegatoAndroidInterruptionSignal) -> Unit)? = null
+    private var remoteDispatch: ((LegatoAndroidRemoteCommand) -> Unit)? = null
+
+    internal var lastPlaybackState: LegatoAndroidPlaybackState? = null
+        private set
+
+    internal var lastNowPlayingMetadata: LegatoAndroidNowPlayingMetadata? = null
+        private set
+
+    internal var lastProgress: LegatoAndroidProgressUpdate? = null
+        private set
+
+    override fun configureSession() {
+        // Foundation-only: concrete MediaSession object wiring is deferred.
+    }
+
+    override fun audioFocusPolicy(): LegatoAndroidAudioFocusPolicy =
+        LegatoAndroidSessionDefaults.MILESTONE1_AUDIO_FOCUS_POLICY
+
+    override fun setInterruptionListener(listener: ((LegatoAndroidInterruptionSignal) -> Unit)?) {
+        interruptionListener = listener
+    }
+
+    override fun onInterruption(signal: LegatoAndroidInterruptionSignal) {
+        interruptionListener?.invoke(signal)
+    }
+
+    override fun updatePlaybackState(state: LegatoAndroidPlaybackState) {
+        lastPlaybackState = state
+    }
+
+    override fun updateNowPlayingMetadata(metadata: LegatoAndroidNowPlayingMetadata?) {
+        lastNowPlayingMetadata = metadata
+    }
+
+    override fun updateProgress(progress: LegatoAndroidProgressUpdate) {
+        lastProgress = progress
+    }
+
+    override fun releaseSession() {
+        interruptionListener = null
+    }
+
+    override fun bind(dispatch: (LegatoAndroidRemoteCommand) -> Unit) {
+        remoteDispatch = dispatch
+    }
+
+    override fun unbind() {
+        remoteDispatch = null
+    }
+
+    fun projectedTransportControl(): TransportControl {
+        val state = lastPlaybackState
+        return if (state == LegatoAndroidPlaybackState.PLAYING || state == LegatoAndroidPlaybackState.BUFFERING) {
+            TransportControl.PAUSE
+        } else {
+            TransportControl.PLAY
+        }
+    }
+
+    fun dispatchProjectedTransportControl() {
+        when (projectedTransportControl()) {
+            TransportControl.PLAY -> remoteDispatch?.invoke(LegatoAndroidRemoteCommand.Play)
+            TransportControl.PAUSE -> remoteDispatch?.invoke(LegatoAndroidRemoteCommand.Pause)
+        }
+    }
+
+    fun dispatchMediaSessionPlay() {
+        remoteDispatch?.invoke(LegatoAndroidRemoteCommand.Play)
+    }
+
+    fun dispatchMediaSessionPause() {
+        remoteDispatch?.invoke(LegatoAndroidRemoteCommand.Pause)
+    }
+
+    fun dispatchTransportControl(control: TransportControl) {
+        when (control) {
+            TransportControl.PLAY -> dispatchMediaSessionPlay()
+            TransportControl.PAUSE -> dispatchMediaSessionPause()
+        }
+    }
+
+    internal fun dispatchRemoteCommandForTesting(command: LegatoAndroidRemoteCommand) {
+        remoteDispatch?.invoke(command)
+    }
+}

--- a/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidCoreCompositionMediaSessionBridgeTest.kt
+++ b/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidCoreCompositionMediaSessionBridgeTest.kt
@@ -1,0 +1,148 @@
+package io.legato.core.core
+
+import io.legato.core.events.LegatoAndroidEventEmitter
+import io.legato.core.remote.LegatoAndroidMediaSessionBridge
+import io.legato.core.runtime.LegatoAndroidPlaybackRuntime
+import io.legato.core.runtime.LegatoAndroidPlaybackRuntimeListener
+import io.legato.core.runtime.LegatoAndroidRuntimeSnapshot
+import io.legato.core.runtime.LegatoAndroidRuntimeTrackSource
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LegatoAndroidCoreCompositionMediaSessionBridgeTest {
+    @Test
+    fun `factory defaults project session state into shared media-session bridge`() = runBlocking {
+        val playbackRuntime = BridgeRecordingPlaybackRuntime()
+        val dependencies = LegatoAndroidCoreDependencies(
+            playbackRuntime = playbackRuntime,
+        )
+        val components = LegatoAndroidCoreFactory.create(dependencies)
+
+        components.playerEngine.setup()
+        components.playerEngine.load(
+            tracks = listOf(
+                LegatoAndroidTrack(
+                    id = "track-1",
+                    url = "https://example.com/audio.mp3",
+                    title = "Track 1",
+                    artist = "Legato",
+                    durationMs = 120_000L,
+                ),
+            ),
+        )
+        components.playerEngine.play()
+
+        assertEquals(LegatoAndroidPlaybackState.PLAYING, dependencies.mediaSessionBridge.lastPlaybackState)
+        assertEquals("track-1", dependencies.mediaSessionBridge.lastNowPlayingMetadata?.trackId)
+        assertNotNull(dependencies.mediaSessionBridge.lastProgress)
+    }
+
+    @Test
+    fun `shared media-session bridge dispatches remote commands to engine listener`() = runBlocking {
+        val playbackRuntime = BridgeRecordingPlaybackRuntime()
+        val eventEmitter = LegatoAndroidEventEmitter()
+        val dependencies = LegatoAndroidCoreDependencies(
+            eventEmitter = eventEmitter,
+            playbackRuntime = playbackRuntime,
+        )
+        val components = LegatoAndroidCoreFactory.create(dependencies)
+        val events = mutableListOf<LegatoAndroidEvent>()
+        eventEmitter.addListener { event: LegatoAndroidEvent -> events += event }
+
+        components.playerEngine.setup()
+        dependencies.mediaSessionBridge.dispatchRemoteCommandForTesting(LegatoAndroidRemoteCommand.Pause)
+
+        assertTrue(events.any { it.name == LegatoAndroidEventName.REMOTE_PAUSE })
+    }
+
+    @Test
+    fun `shared media-session bridge projects pause transport action while playing`() = runBlocking {
+        val playbackRuntime = BridgeRecordingPlaybackRuntime()
+        val dependencies = LegatoAndroidCoreDependencies(
+            playbackRuntime = playbackRuntime,
+        )
+        val components = LegatoAndroidCoreFactory.create(dependencies)
+
+        components.playerEngine.setup()
+        components.playerEngine.load(
+            tracks = listOf(
+                LegatoAndroidTrack(
+                    id = "track-1",
+                    url = "https://example.com/audio.mp3",
+                ),
+            ),
+        )
+        components.playerEngine.play()
+
+        assertEquals(
+            LegatoAndroidMediaSessionBridge.TransportControl.PAUSE,
+            dependencies.mediaSessionBridge.projectedTransportControl(),
+        )
+    }
+
+    @Test
+    fun `shared media-session bridge dispatches projected transport control to canonical remote path`() = runBlocking {
+        val playbackRuntime = BridgeRecordingPlaybackRuntime()
+        val eventEmitter = LegatoAndroidEventEmitter()
+        val dependencies = LegatoAndroidCoreDependencies(
+            eventEmitter = eventEmitter,
+            playbackRuntime = playbackRuntime,
+        )
+        val components = LegatoAndroidCoreFactory.create(dependencies)
+        val events = mutableListOf<LegatoAndroidEvent>()
+        eventEmitter.addListener { event: LegatoAndroidEvent -> events += event }
+
+        components.playerEngine.setup()
+        components.playerEngine.load(
+            tracks = listOf(
+                LegatoAndroidTrack(
+                    id = "track-1",
+                    url = "https://example.com/audio.mp3",
+                ),
+            ),
+        )
+        components.playerEngine.play()
+
+        dependencies.mediaSessionBridge.dispatchProjectedTransportControl()
+
+        assertTrue(events.any { it.name == LegatoAndroidEventName.REMOTE_PAUSE })
+    }
+}
+
+private class BridgeRecordingPlaybackRuntime : LegatoAndroidPlaybackRuntime {
+    private var listener: LegatoAndroidPlaybackRuntimeListener? = null
+    private var snapshot = LegatoAndroidRuntimeSnapshot()
+
+    override fun configure() = Unit
+
+    override fun setListener(listener: LegatoAndroidPlaybackRuntimeListener?) {
+        this.listener = listener
+    }
+
+    override fun replaceQueue(items: List<LegatoAndroidRuntimeTrackSource>, startIndex: Int?) {
+        snapshot = snapshot.copy(currentIndex = if (items.isEmpty()) null else (startIndex ?: 0))
+    }
+
+    override fun selectIndex(index: Int) {
+        snapshot = snapshot.copy(currentIndex = index)
+    }
+
+    override fun play() = Unit
+
+    override fun pause() = Unit
+
+    override fun stop(resetPosition: Boolean) = Unit
+
+    override fun seekTo(positionMs: Long) {
+        snapshot = snapshot.copy(progress = snapshot.progress.copy(positionMs = positionMs))
+    }
+
+    override fun snapshot(): LegatoAndroidRuntimeSnapshot = snapshot
+
+    override fun release() {
+        listener = null
+    }
+}

--- a/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineRemoteCommandRoutingTest.kt
+++ b/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineRemoteCommandRoutingTest.kt
@@ -1,0 +1,170 @@
+package io.legato.core.core
+
+import io.legato.core.events.LegatoAndroidEventEmitter
+import io.legato.core.runtime.LegatoAndroidPlaybackRuntime
+import io.legato.core.runtime.LegatoAndroidPlaybackRuntimeListener
+import io.legato.core.runtime.LegatoAndroidRuntimeSnapshot
+import io.legato.core.runtime.LegatoAndroidRuntimeTrackSource
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LegatoAndroidPlayerEngineRemoteCommandRoutingTest {
+    @Test
+    fun `remote pause routes through canonical playback path`() = runBlocking {
+        val playbackRuntime = RemoteRoutingPlaybackRuntime()
+        val eventEmitter = LegatoAndroidEventEmitter()
+        val dependencies = LegatoAndroidCoreDependencies(
+            eventEmitter = eventEmitter,
+            playbackRuntime = playbackRuntime,
+        )
+        val components = LegatoAndroidCoreFactory.create(dependencies)
+        val events = mutableListOf<LegatoAndroidEvent>()
+        eventEmitter.addListener { event -> events += event }
+
+        components.playerEngine.setup()
+        components.playerEngine.load(tracks = listOf(track()))
+        components.playerEngine.play()
+        playbackRuntime.resetCommandCounters()
+
+        val eventsBeforeRemote = events.size
+        dependencies.mediaSessionBridge.dispatchRemoteCommandForTesting(LegatoAndroidRemoteCommand.Pause)
+
+        assertEquals(1, playbackRuntime.pauseCalls)
+        assertEquals(LegatoAndroidPlaybackState.PAUSED, components.playerEngine.getSnapshot().state)
+
+        val remoteEvents = events.drop(eventsBeforeRemote)
+        assertTrue(remoteEvents.any { it.name == LegatoAndroidEventName.REMOTE_PAUSE })
+        assertTrue(
+            remoteEvents.any {
+                it.name == LegatoAndroidEventName.PLAYBACK_STATE_CHANGED &&
+                    (it.payload as? LegatoAndroidEventPayload.PlaybackStateChanged)?.state == LegatoAndroidPlaybackState.PAUSED
+            },
+        )
+    }
+
+    @Test
+    fun `remote play routes through canonical playback path`() = runBlocking {
+        val playbackRuntime = RemoteRoutingPlaybackRuntime()
+        val eventEmitter = LegatoAndroidEventEmitter()
+        val dependencies = LegatoAndroidCoreDependencies(
+            eventEmitter = eventEmitter,
+            playbackRuntime = playbackRuntime,
+        )
+        val components = LegatoAndroidCoreFactory.create(dependencies)
+        val events = mutableListOf<LegatoAndroidEvent>()
+        eventEmitter.addListener { event -> events += event }
+
+        components.playerEngine.setup()
+        components.playerEngine.load(tracks = listOf(track()))
+        playbackRuntime.resetCommandCounters()
+
+        val eventsBeforeRemote = events.size
+        dependencies.mediaSessionBridge.dispatchRemoteCommandForTesting(LegatoAndroidRemoteCommand.Play)
+
+        assertEquals(1, playbackRuntime.playCalls)
+        assertEquals(LegatoAndroidPlaybackState.PLAYING, components.playerEngine.getSnapshot().state)
+
+        val remoteEvents = events.drop(eventsBeforeRemote)
+        assertTrue(remoteEvents.any { it.name == LegatoAndroidEventName.REMOTE_PLAY })
+        assertTrue(
+            remoteEvents.any {
+                it.name == LegatoAndroidEventName.PLAYBACK_STATE_CHANGED &&
+                    (it.payload as? LegatoAndroidEventPayload.PlaybackStateChanged)?.state == LegatoAndroidPlaybackState.PLAYING
+            },
+        )
+    }
+
+    @Test
+    fun `remote next previous and seek stay no-op in v1`() = runBlocking {
+        val playbackRuntime = RemoteRoutingPlaybackRuntime()
+        val dependencies = LegatoAndroidCoreDependencies(
+            playbackRuntime = playbackRuntime,
+        )
+        val components = LegatoAndroidCoreFactory.create(dependencies)
+
+        components.playerEngine.setup()
+        components.playerEngine.load(tracks = listOf(track()))
+        components.playerEngine.play()
+        playbackRuntime.resetCommandCounters()
+
+        dependencies.mediaSessionBridge.dispatchRemoteCommandForTesting(LegatoAndroidRemoteCommand.Next)
+        dependencies.mediaSessionBridge.dispatchRemoteCommandForTesting(LegatoAndroidRemoteCommand.Previous)
+        dependencies.mediaSessionBridge.dispatchRemoteCommandForTesting(LegatoAndroidRemoteCommand.Seek(45_000L))
+
+        assertEquals(0, playbackRuntime.pauseCalls)
+        assertEquals(0, playbackRuntime.playCalls)
+        assertEquals(0, playbackRuntime.seekCalls)
+        assertEquals(0, playbackRuntime.selectIndexCalls)
+        assertEquals(LegatoAndroidPlaybackState.PLAYING, components.playerEngine.getSnapshot().state)
+    }
+
+    private fun track(): LegatoAndroidTrack = LegatoAndroidTrack(
+        id = "remote-routing-track",
+        url = "https://example.com/audio.mp3",
+        title = "Remote Routing",
+        artist = "Legato",
+        durationMs = 180_000L,
+    )
+}
+
+private class RemoteRoutingPlaybackRuntime : LegatoAndroidPlaybackRuntime {
+    private var snapshot = LegatoAndroidRuntimeSnapshot()
+    private var listener: LegatoAndroidPlaybackRuntimeListener? = null
+
+    var playCalls: Int = 0
+        private set
+
+    var pauseCalls: Int = 0
+        private set
+
+    var seekCalls: Int = 0
+        private set
+
+    var selectIndexCalls: Int = 0
+        private set
+
+    override fun configure() = Unit
+
+    override fun setListener(listener: LegatoAndroidPlaybackRuntimeListener?) {
+        this.listener = listener
+    }
+
+    override fun replaceQueue(items: List<LegatoAndroidRuntimeTrackSource>, startIndex: Int?) {
+        snapshot = snapshot.copy(currentIndex = if (items.isEmpty()) null else (startIndex ?: 0))
+    }
+
+    override fun selectIndex(index: Int) {
+        selectIndexCalls += 1
+        snapshot = snapshot.copy(currentIndex = index)
+    }
+
+    override fun play() {
+        playCalls += 1
+    }
+
+    override fun pause() {
+        pauseCalls += 1
+    }
+
+    override fun stop(resetPosition: Boolean) = Unit
+
+    override fun seekTo(positionMs: Long) {
+        seekCalls += 1
+        snapshot = snapshot.copy(progress = snapshot.progress.copy(positionMs = positionMs))
+    }
+
+    override fun snapshot(): LegatoAndroidRuntimeSnapshot = snapshot
+
+    override fun release() {
+        listener = null
+    }
+
+    fun resetCommandCounters() {
+        playCalls = 0
+        pauseCalls = 0
+        seekCalls = 0
+        selectIndexCalls = 0
+    }
+}

--- a/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoAndroidPlaybackCoordinator.kt
+++ b/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoAndroidPlaybackCoordinator.kt
@@ -6,6 +6,7 @@ import android.os.Build
 import io.legato.core.core.LegatoAndroidCoreComponents
 import io.legato.core.core.LegatoAndroidCoreFactory
 import io.legato.core.core.LegatoAndroidPauseOrigin
+import io.legato.core.core.LegatoAndroidPlaybackState
 import io.legato.core.core.LegatoAndroidServiceMode
 import java.util.concurrent.atomic.AtomicLong
 
@@ -41,13 +42,16 @@ internal class LegatoAndroidPlaybackCoordinator(
     private var serviceRuntime: LegatoAndroidCoordinatorServiceRuntime = NoopLegatoAndroidCoordinatorServiceRuntime,
 ) {
     private val modeListeners = linkedMapOf<Long, (LegatoAndroidServiceMode) -> Unit>()
+    private val playbackStateListeners = linkedMapOf<Long, (LegatoAndroidPlaybackState) -> Unit>()
     private val modeListenerIds = AtomicLong(0L)
     private val lock = Any()
 
     private var projectedMode: LegatoAndroidServiceMode = core.playerEngine.getServiceMode()
+    private var projectedPlaybackState: LegatoAndroidPlaybackState = core.playerEngine.getSnapshot().state
 
     private val coreProjectionListenerId: Long = core.eventEmitter.addListener {
         projectServiceMode()
+        projectPlaybackState()
     }
 
     fun bindServiceRuntime(runtime: LegatoAndroidCoordinatorServiceRuntime) {
@@ -60,6 +64,7 @@ internal class LegatoAndroidPlaybackCoordinator(
     fun setup() {
         kotlinx.coroutines.runBlocking { core.playerEngine.setup() }
         projectServiceMode()
+        projectPlaybackState()
     }
 
     fun load(tracks: List<io.legato.core.core.LegatoAndroidTrack>, startIndex: Int? = null) {
@@ -67,36 +72,43 @@ internal class LegatoAndroidPlaybackCoordinator(
             core.playerEngine.load(tracks = tracks, startIndex = startIndex)
         }
         projectServiceMode()
+        projectPlaybackState()
     }
 
     fun play() {
         kotlinx.coroutines.runBlocking { core.playerEngine.play() }
         projectServiceMode()
+        projectPlaybackState()
     }
 
     fun pause() {
         kotlinx.coroutines.runBlocking { core.playerEngine.pause() }
         projectServiceMode()
+        projectPlaybackState()
     }
 
     fun stop() {
         kotlinx.coroutines.runBlocking { core.playerEngine.stop() }
         projectServiceMode()
+        projectPlaybackState()
     }
 
     fun seekTo(positionMs: Long) {
         kotlinx.coroutines.runBlocking { core.playerEngine.seekTo(positionMs) }
         projectServiceMode()
+        projectPlaybackState()
     }
 
     fun skipToNext() {
         kotlinx.coroutines.runBlocking { core.playerEngine.skipToNext() }
         projectServiceMode()
+        projectPlaybackState()
     }
 
     fun skipToPrevious() {
         kotlinx.coroutines.runBlocking { core.playerEngine.skipToPrevious() }
         projectServiceMode()
+        projectPlaybackState()
     }
 
     fun addCoreEventListener(listener: (io.legato.core.core.LegatoAndroidEvent) -> Unit): Long =
@@ -115,13 +127,30 @@ internal class LegatoAndroidPlaybackCoordinator(
         return id
     }
 
+    fun addPlaybackStateListener(listener: (LegatoAndroidPlaybackState) -> Unit): Long {
+        val id = modeListenerIds.incrementAndGet()
+        synchronized(lock) {
+            playbackStateListeners[id] = listener
+        }
+        listener(currentPlaybackState())
+        return id
+    }
+
     fun removeServiceModeListener(listenerId: Long) {
         synchronized(lock) {
             modeListeners.remove(listenerId)
         }
     }
 
+    fun removePlaybackStateListener(listenerId: Long) {
+        synchronized(lock) {
+            playbackStateListeners.remove(listenerId)
+        }
+    }
+
     fun currentServiceMode(): LegatoAndroidServiceMode = synchronized(lock) { projectedMode }
+
+    fun currentPlaybackState(): LegatoAndroidPlaybackState = synchronized(lock) { projectedPlaybackState }
 
     fun currentPauseOrigin(): LegatoAndroidPauseOrigin = core.playerEngine.getPauseOrigin()
 
@@ -144,6 +173,22 @@ internal class LegatoAndroidPlaybackCoordinator(
 
         if (shouldNotify) {
             listenersToNotify.forEach { it(nextMode) }
+        }
+    }
+
+    fun projectPlaybackState() {
+        val nextState = core.playerEngine.getSnapshot().state
+        val listenersToNotify: List<(LegatoAndroidPlaybackState) -> Unit>
+        val shouldNotify: Boolean
+
+        synchronized(lock) {
+            shouldNotify = nextState != projectedPlaybackState
+            projectedPlaybackState = nextState
+            listenersToNotify = playbackStateListeners.values.toList()
+        }
+
+        if (shouldNotify) {
+            listenersToNotify.forEach { it(nextState) }
         }
     }
 

--- a/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackNotificationTransport.kt
+++ b/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackNotificationTransport.kt
@@ -1,0 +1,25 @@
+package io.legato.capacitor
+
+import io.legato.core.core.LegatoAndroidPlaybackState
+import io.legato.core.remote.LegatoAndroidMediaSessionBridge
+
+internal object LegatoPlaybackNotificationTransport {
+    const val ACTION_PLAY: String = "io.legato.capacitor.action.PLAY"
+    const val ACTION_PAUSE: String = "io.legato.capacitor.action.PAUSE"
+
+    fun projectedControlFor(state: LegatoAndroidPlaybackState): LegatoAndroidMediaSessionBridge.TransportControl {
+        return if (state == LegatoAndroidPlaybackState.PLAYING || state == LegatoAndroidPlaybackState.BUFFERING) {
+            LegatoAndroidMediaSessionBridge.TransportControl.PAUSE
+        } else {
+            LegatoAndroidMediaSessionBridge.TransportControl.PLAY
+        }
+    }
+
+    fun transportControlFromIntentAction(action: String?): LegatoAndroidMediaSessionBridge.TransportControl? {
+        return when (action) {
+            ACTION_PLAY -> LegatoAndroidMediaSessionBridge.TransportControl.PLAY
+            ACTION_PAUSE -> LegatoAndroidMediaSessionBridge.TransportControl.PAUSE
+            else -> null
+        }
+    }
+}

--- a/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackService.kt
+++ b/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackService.kt
@@ -7,23 +7,55 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.media.session.MediaSession
+import android.media.session.PlaybackState
 import android.os.Build
 import android.os.IBinder
+import io.legato.core.core.LegatoAndroidPlaybackState
 import io.legato.core.core.LegatoAndroidServiceMode
+import io.legato.core.remote.LegatoAndroidMediaSessionBridge
 
 class LegatoPlaybackService : Service() {
     private val coordinator = LegatoAndroidPlaybackCoordinatorStore.getOrCreate()
     private var modeListenerId: Long? = null
+    private var playbackStateListenerId: Long? = null
     private var foregroundActive: Boolean = false
+    private var currentMode: LegatoAndroidServiceMode = coordinator.currentServiceMode()
+    private var currentPlaybackState: LegatoAndroidPlaybackState = coordinator.currentPlaybackState()
+    private var mediaSession: MediaSession? = null
 
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onCreate() {
         super.onCreate()
         modeListenerId = coordinator.addServiceModeListener(::onServiceModeChanged)
+        playbackStateListenerId = coordinator.addPlaybackStateListener(::onPlaybackStateChanged)
+
+        mediaSession = MediaSession(this, MEDIA_SESSION_TAG).apply {
+            setCallback(
+                object : MediaSession.Callback() {
+                    override fun onPlay() {
+                        coordinator.core.mediaSessionBridge.dispatchMediaSessionPlay()
+                    }
+
+                    override fun onPause() {
+                        coordinator.core.mediaSessionBridge.dispatchMediaSessionPause()
+                    }
+                },
+            )
+            setFlags(MediaSession.FLAG_HANDLES_MEDIA_BUTTONS or MediaSession.FLAG_HANDLES_TRANSPORT_CONTROLS)
+            isActive = true
+        }
+        syncMediaSessionPlaybackState(currentPlaybackState)
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        LegatoPlaybackNotificationTransport.transportControlFromIntentAction(intent?.action)
+            ?.let { control ->
+                coordinator.core.mediaSessionBridge.dispatchTransportControl(control)
+                return START_STICKY
+            }
+
         val mode = intent?.getStringExtra(EXTRA_SERVICE_MODE)
             ?.runCatching { LegatoAndroidServiceMode.valueOf(this) }
             ?.getOrNull()
@@ -36,6 +68,12 @@ class LegatoPlaybackService : Service() {
     override fun onDestroy() {
         modeListenerId?.let(coordinator::removeServiceModeListener)
         modeListenerId = null
+        playbackStateListenerId?.let(coordinator::removePlaybackStateListener)
+        playbackStateListenerId = null
+
+        mediaSession?.release()
+        mediaSession = null
+
         if (foregroundActive) {
             stopForeground(STOP_FOREGROUND_REMOVE)
             foregroundActive = false
@@ -44,6 +82,7 @@ class LegatoPlaybackService : Service() {
     }
 
     private fun onServiceModeChanged(mode: LegatoAndroidServiceMode) {
+        currentMode = mode
         if (mode == LegatoAndroidServiceMode.OFF) {
             if (foregroundActive) {
                 stopForeground(STOP_FOREGROUND_REMOVE)
@@ -54,6 +93,15 @@ class LegatoPlaybackService : Service() {
         }
 
         startForegroundInternal(mode)
+    }
+
+    private fun onPlaybackStateChanged(state: LegatoAndroidPlaybackState) {
+        currentPlaybackState = state
+        syncMediaSessionPlaybackState(state)
+        if (foregroundActive && currentMode != LegatoAndroidServiceMode.OFF) {
+            val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.notify(NOTIFICATION_ID, buildNotification(currentMode))
+        }
     }
 
     private fun startForegroundInternal(mode: LegatoAndroidServiceMode) {
@@ -74,14 +122,27 @@ class LegatoPlaybackService : Service() {
 
     private fun buildNotification(mode: LegatoAndroidServiceMode): Notification {
         val launchIntent = packageManager.getLaunchIntentForPackage(packageName)
-        val pendingIntent = launchIntent?.let {
+        val launchPendingIntent = launchIntent?.let {
             PendingIntent.getActivity(
                 this,
-                1001,
+                REQUEST_CODE_OPEN_APP,
                 it,
                 PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
             )
         }
+
+        val projectedControl = LegatoPlaybackNotificationTransport.projectedControlFor(currentPlaybackState)
+        val transportPendingIntent = PendingIntent.getService(
+            this,
+            REQUEST_CODE_TRANSPORT,
+            Intent(this, LegatoPlaybackService::class.java).apply {
+                action = when (projectedControl) {
+                    LegatoAndroidMediaSessionBridge.TransportControl.PLAY -> LegatoPlaybackNotificationTransport.ACTION_PLAY
+                    LegatoAndroidMediaSessionBridge.TransportControl.PAUSE -> LegatoPlaybackNotificationTransport.ACTION_PAUSE
+                }
+            },
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
 
         val contentText = when (mode) {
             LegatoAndroidServiceMode.PLAYBACK_ACTIVE -> "Playback active"
@@ -102,9 +163,58 @@ class LegatoPlaybackService : Service() {
             .setOngoing(true)
             .setOnlyAlertOnce(true)
             .setCategory(Notification.CATEGORY_TRANSPORT)
-            .setContentIntent(pendingIntent)
+            .setContentIntent(launchPendingIntent)
+            .addAction(
+                Notification.Action.Builder(
+                    if (projectedControl == LegatoAndroidMediaSessionBridge.TransportControl.PAUSE) {
+                        android.R.drawable.ic_media_pause
+                    } else {
+                        android.R.drawable.ic_media_play
+                    },
+                    if (projectedControl == LegatoAndroidMediaSessionBridge.TransportControl.PAUSE) "Pause" else "Play",
+                    transportPendingIntent,
+                ).build(),
+            )
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            builder.setStyle(
+                Notification.MediaStyle()
+                    .setMediaSession(mediaSession?.sessionToken)
+                    .setShowActionsInCompactView(0),
+            )
+        }
 
         return builder.build()
+    }
+
+    private fun syncMediaSessionPlaybackState(state: LegatoAndroidPlaybackState) {
+        val playbackState = PlaybackState.Builder()
+            .setActions(PlaybackState.ACTION_PLAY or PlaybackState.ACTION_PAUSE)
+            .setState(
+                when (state) {
+                    LegatoAndroidPlaybackState.PLAYING,
+                    LegatoAndroidPlaybackState.BUFFERING,
+                    -> PlaybackState.STATE_PLAYING
+
+                    LegatoAndroidPlaybackState.PAUSED,
+                    LegatoAndroidPlaybackState.READY,
+                    -> PlaybackState.STATE_PAUSED
+
+                    LegatoAndroidPlaybackState.LOADING -> PlaybackState.STATE_BUFFERING
+                    LegatoAndroidPlaybackState.ENDED,
+                    LegatoAndroidPlaybackState.IDLE,
+                    LegatoAndroidPlaybackState.ERROR,
+                    -> PlaybackState.STATE_STOPPED
+                },
+                0L,
+                if (state == LegatoAndroidPlaybackState.PLAYING || state == LegatoAndroidPlaybackState.BUFFERING) {
+                    1f
+                } else {
+                    0f
+                },
+            )
+            .build()
+        mediaSession?.setPlaybackState(playbackState)
     }
 
     companion object {
@@ -112,5 +222,8 @@ class LegatoPlaybackService : Service() {
         private const val CHANNEL_ID: String = "legato.playback"
         private const val CHANNEL_NAME: String = "Legato playback"
         private const val NOTIFICATION_ID: Int = 4242
+        private const val REQUEST_CODE_OPEN_APP: Int = 1001
+        private const val REQUEST_CODE_TRANSPORT: Int = 1002
+        private const val MEDIA_SESSION_TAG: String = "legato.playback"
     }
 }

--- a/packages/capacitor/android/src/test/kotlin/io/legato/capacitor/LegatoAndroidPlaybackCoordinatorTest.kt
+++ b/packages/capacitor/android/src/test/kotlin/io/legato/capacitor/LegatoAndroidPlaybackCoordinatorTest.kt
@@ -88,6 +88,35 @@ class LegatoAndroidPlaybackCoordinatorTest {
         assertEquals(LegatoAndroidPauseOrigin.INTERRUPTION, coordinator.currentPauseOrigin())
     }
 
+    @Test
+    fun `coordinator projects playback state and notifies listeners on transitions`() = runBlocking {
+        val runtime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val coordinator = LegatoAndroidPlaybackCoordinator(
+            core = buildCore(runtime, sessionRuntime),
+            serviceRuntime = RecordingCoordinatorServiceRuntime(),
+        )
+        val projectedStates = mutableListOf<LegatoAndroidPlaybackState>()
+        coordinator.addPlaybackStateListener { projectedStates += it }
+
+        coordinator.setup()
+        coordinator.load(
+            listOf(
+                LegatoAndroidTrack(
+                    id = "track-1",
+                    url = "https://example.com/track.mp3",
+                ),
+            ),
+        )
+
+        coordinator.play()
+        coordinator.pause()
+
+        assertEquals(LegatoAndroidPlaybackState.PAUSED, coordinator.currentPlaybackState())
+        assertTrue(projectedStates.contains(LegatoAndroidPlaybackState.PLAYING))
+        assertTrue(projectedStates.contains(LegatoAndroidPlaybackState.PAUSED))
+    }
+
     private fun buildCore(
         runtime: RecordingPlaybackRuntime,
         sessionRuntime: RecordingSessionRuntime,

--- a/packages/capacitor/android/src/test/kotlin/io/legato/capacitor/LegatoPlaybackNotificationTransportTest.kt
+++ b/packages/capacitor/android/src/test/kotlin/io/legato/capacitor/LegatoPlaybackNotificationTransportTest.kt
@@ -1,0 +1,44 @@
+package io.legato.capacitor
+
+import io.legato.core.core.LegatoAndroidPlaybackState
+import io.legato.core.remote.LegatoAndroidMediaSessionBridge
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class LegatoPlaybackNotificationTransportTest {
+    @Test
+    fun `notification projects pause action while currently playing`() {
+        val projectedAction = LegatoPlaybackNotificationTransport.projectedControlFor(
+            LegatoAndroidPlaybackState.PLAYING,
+        )
+
+        assertEquals(LegatoAndroidMediaSessionBridge.TransportControl.PAUSE, projectedAction)
+    }
+
+    @Test
+    fun `notification projects play action while paused`() {
+        val projectedAction = LegatoPlaybackNotificationTransport.projectedControlFor(
+            LegatoAndroidPlaybackState.PAUSED,
+        )
+
+        assertEquals(LegatoAndroidMediaSessionBridge.TransportControl.PLAY, projectedAction)
+    }
+
+    @Test
+    fun `notification intent action maps into supported transport controls only`() {
+        assertEquals(
+            LegatoAndroidMediaSessionBridge.TransportControl.PLAY,
+            LegatoPlaybackNotificationTransport.transportControlFromIntentAction(
+                LegatoPlaybackNotificationTransport.ACTION_PLAY,
+            ),
+        )
+        assertEquals(
+            LegatoAndroidMediaSessionBridge.TransportControl.PAUSE,
+            LegatoPlaybackNotificationTransport.transportControlFromIntentAction(
+                LegatoPlaybackNotificationTransport.ACTION_PAUSE,
+            ),
+        )
+        assertNull(LegatoPlaybackNotificationTransport.transportControlFromIntentAction("unsupported"))
+    }
+}


### PR DESCRIPTION
Closes #15

## Summary
- add Android play/pause remote command routing through the canonical engine path using a shared MediaSession bridge foundation
- add minimal notification/media-transport play/pause binding plus projected metadata/progress parity support
- enrich the Capacitor demo harness with a compact remote parity inspector and validation guidance for iOS/Android

## Changes
| File | Change |
|------|--------|
| `native/android/core/src/main/kotlin/io/legato/core/remote/LegatoAndroidMediaSessionBridge.kt` | shared Android foundation bridge for session projection + remote dispatch |
| `native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidCoreComposition.kt` | shared bridge injected into Android session/remote managers |
| `native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidPlayerEngine.kt` | remote play/pause now route through canonical engine behavior |
| `packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoAndroidPlaybackCoordinator.kt` | playback-state projection support for notification/media controls |
| `packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackNotificationTransport.kt` | minimal play/pause transport mapping for notification/media actions |
| `packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackService.kt` | binds platform MediaSession + notification play/pause callbacks into shared bridge |
| `apps/capacitor-demo/index.html`, `apps/capacitor-demo/src/main.ts`, `apps/capacitor-demo/README.md` | compact remote parity inspector, richer metadata fixtures, and validation guidance |
| Android tests under `native/android/core/src/test/` and `packages/capacitor/android/src/test/` | coverage for shared bridge wiring, remote play/pause routing, coordinator projection, and transport mapping |

## Test Plan
- [x] Strict-TDD unit cycles for Android core routing and transport mapping
- [x] `sh ./gradlew test` executed in the Android demo host during milestone batches
- [x] Harness validation scaffolding updated for practical remote parity inspection
- [ ] Manual device/emulator validation still required for real notification/lock-screen play/pause behavior on iOS + Android

## Notes
- This is parity **v1**: next/previous/seek remain deferred and intentionally inert.
- Android platform callback binding is now real for play/pause, but richer transport UX and cross-device/media-surface polish remain future work.
