### PR TITLE
feat(native): add remote transport richness

### DIFF
--- a/apps/capacitor-demo/README.md
+++ b/apps/capacitor-demo/README.md
@@ -36,14 +36,15 @@ Validate native bridge + snapshot/event plumbing for the minimal flow in `src/ma
 
 This is a **native smoke** (Android/iOS host), not a browser-only check.
 
-## Android parity v1 validation
+## Remote transport richness v2 validation
 
 Harness now supports both one-click smoke and manual controls for:
 
 - `setup`, `sync.start`, `sync.stop`
-- `add`, `play`, `pause`, `stop`, `seekTo`, `getSnapshot`
+- `add`, `play`, `pause`, `stop`, `skipToPrevious`, `skipToNext`, `seekTo`, `getSnapshot`
 - copy-friendly recent events + raw log + snapshot summary/json
 - a compact **Remote parity inspector** summary (state/progress trend/metadata presence/event signals)
+- a compact **Capability projection** summary (`canSkipNext`, `canSkipPrevious`, `canSeek`, queue/index)
 
 Default fixtures now include title/artist/album/artwork/duration metadata and direct samplelib MP3 URLs (no redirect links) to keep playback behavior deterministic during native checks.
 
@@ -60,8 +61,11 @@ Manual parity checklist to close milestone validation:
 2. Trigger lock-screen/media-notification **pause**, return to app, tap `getSnapshot()`, and verify paused state + frozen progress.
 3. Trigger lock-screen/media-notification **play**, return to app, tap `getSnapshot()`, and verify playing state + advancing progress.
 4. Verify now-playing surfaces show title/artist/album/artwork/duration from fixture metadata.
-5. Trigger next/previous/seek from remote surfaces and confirm v1 inert behavior (no crash, no playback jump).
-6. (Android lifecycle carry-over) `stop()` + idle tears down foreground service/notification.
+5. Trigger remote/manual `skipToNext`/`skipToPrevious` and verify queue transitions match canonical engine behavior.
+6. Trigger remote/manual seek and verify snapshot position updates consistently.
+7. Validate capability projection summary: mid-queue enables next/previous, first track disables previous, ended disables all (`canSkipNext=false`, `canSkipPrevious=false`, `canSeek=false`).
+8. Verify now-playing surfaces show title/artist/album/artwork/duration from fixture metadata.
+9. (Android lifecycle carry-over) `stop()` + idle tears down foreground service/notification.
 
 ## Quick smoke checklist (manual, lightweight)
 

--- a/apps/capacitor-demo/android/app/src/test/java/com/getcapacitor/myapp/HarnessValidationContractTest.java
+++ b/apps/capacitor-demo/android/app/src/test/java/com/getcapacitor/myapp/HarnessValidationContractTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 public class HarnessValidationContractTest {
 
     private static final String[] HARNESS_CONTROL_IDS = new String[] {
+            "id=\"run-boundary-smoke\"",
             "id=\"action-setup\"",
             "id=\"action-sync-start\"",
             "id=\"action-sync-stop\"",
@@ -19,44 +20,52 @@ public class HarnessValidationContractTest {
             "id=\"action-play\"",
             "id=\"action-pause\"",
             "id=\"action-stop\"",
+            "id=\"action-previous\"",
+            "id=\"action-next\"",
             "id=\"action-seek\"",
             "id=\"action-snapshot\"",
             "id=\"copy-events\""
     };
 
     @Test
-    public void indexHtml_exposesManualControlsAndValidationChecklist() throws Exception {
+    public void indexHtml_exposesRemoteTransportV2ControlsAndChecklist() throws Exception {
         String html = readRepoFile("apps/capacitor-demo/index.html");
 
         for (String control : HARNESS_CONTROL_IDS) {
             assertTrue("Missing control marker in index.html: " + control, html.contains(control));
         }
 
-        assertTrue("Missing Android lifecycle checklist section", html.contains("Android lifecycle validation checklist"));
-        assertTrue("Missing focus-loss checklist item", html.contains("Focus loss pauses playback"));
-        assertTrue("Missing no-auto-resume checklist item", html.contains("Focus regain does not auto-resume"));
-        assertTrue("Missing service teardown checklist item", html.contains("stop+idle tears down foreground service"));
+        assertTrue("Missing capability summary node", html.contains("id=\"capability-summary\""));
+        assertTrue("Missing transport checklist section", html.contains("Remote transport v2 validation checklist"));
+        assertTrue("Missing remote next/previous checklist item", html.contains("Remote next/previous parity"));
+        assertTrue("Missing remote seek checklist item", html.contains("Remote seek parity"));
+        assertTrue("Missing boundary checklist item", html.contains("Boundary behavior parity"));
+        assertTrue("Missing now-playing checklist item", html.contains("Now-playing metadata parity"));
         assertTrue("Missing recent events node", html.contains("id=\"events\""));
         assertTrue("Missing snapshot summary node", html.contains("id=\"snapshot-summary\""));
         assertTrue("Missing snapshot JSON node", html.contains("id=\"snapshot-json\""));
     }
 
     @Test
-    public void mainTs_usesDirectAudioUrlsAndAndroidFocusedLogging() throws Exception {
+    public void mainTs_usesDirectAudioUrlsAndExposesBoundaryAndCapabilitySignals() throws Exception {
         String mainTs = readRepoFile("apps/capacitor-demo/src/main.ts");
 
         assertTrue("Smoke defaults should avoid redirect URLs", !mainTs.contains("soundhelix.com") && !mainTs.contains("redirect"));
         assertTrue("Expected direct samplelib URL for smoke fixture", mainTs.contains("https://samplelib.com/mp3/sample-3s.mp3"));
-        assertTrue("Expected explicit background instructions logger", mainTs.contains("Background check:"));
-        assertTrue("Expected Android parity snapshot logging", mainTs.contains("snapshot summary"));
+        assertTrue("Expected skip-to-next handler", mainTs.contains("Legato.skipToNext()"));
+        assertTrue("Expected skip-to-previous handler", mainTs.contains("Legato.skipToPrevious()"));
+        assertTrue("Expected capability projection renderer", mainTs.contains("renderCapabilitySummary"));
+        assertTrue("Expected boundary smoke flow helper", mainTs.contains("runBoundarySmokeFlow"));
         assertTrue("Expected recent events rendering helper", mainTs.contains("renderRecentEvents"));
     }
 
     @Test
-    public void readme_includesBuildAndSyncValidationReminder() throws Exception {
+    public void readme_includesRemoteTransportV2ValidationReminder() throws Exception {
         String readme = readRepoFile("apps/capacitor-demo/README.md");
 
-        assertTrue("README should include Android parity validation heading", readme.contains("Android parity v1 validation"));
+        assertTrue("README should include transport v2 heading", readme.contains("Remote transport richness v2 validation"));
+        assertTrue("README should include manual next/previous mention", readme.contains("skipToNext") && readme.contains("skipToPrevious"));
+        assertTrue("README should include capability projection mention", readme.contains("canSkipNext") && readme.contains("canSkipPrevious"));
         assertTrue("README should include build reminder", readme.contains("npm run build"));
         assertTrue("README should include cap sync reminder", readme.contains("npm run cap:sync"));
     }

--- a/apps/capacitor-demo/index.html
+++ b/apps/capacitor-demo/index.html
@@ -128,6 +128,16 @@
         font-size: 0.82rem;
       }
 
+      #capability-summary {
+        margin: 0;
+        padding: 0.65rem 0.75rem;
+        border: 1px solid #d1d5db;
+        border-radius: 8px;
+        min-height: 56px;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+        font-size: 0.82rem;
+      }
+
       #events {
         min-height: 140px;
       }
@@ -152,6 +162,7 @@
           <div class="actions">
             <button id="run-smoke" class="native-action" type="button">Run smoke flow (setup/add/play/pause/snapshot)</button>
             <button id="run-end-smoke" class="native-action" type="button">Run let-it-end smoke</button>
+            <button id="run-boundary-smoke" class="native-action" type="button">Run boundary smoke (previous/next/end)</button>
             <button id="copy-log" type="button">Copy raw log</button>
             <button id="copy-events" type="button">Copy recent events</button>
           </div>
@@ -169,6 +180,8 @@
             <button id="action-play" class="native-action" type="button">play()</button>
             <button id="action-pause" class="native-action" type="button">pause()</button>
             <button id="action-stop" class="native-action" type="button">stop()</button>
+            <button id="action-previous" class="native-action" type="button">skipToPrevious()</button>
+            <button id="action-next" class="native-action" type="button">skipToNext()</button>
             <button id="action-seek" class="native-action" type="button">seekTo()</button>
             <button id="action-snapshot" class="native-action" type="button">getSnapshot()</button>
           </div>
@@ -183,6 +196,8 @@
         <section class="card stack">
           <h2>Snapshot summary</h2>
           <pre id="snapshot-summary">No snapshot captured yet.</pre>
+          <h2 style="margin-top: 0.35rem">Capability projection</h2>
+          <pre id="capability-summary">No capability projection yet.</pre>
           <h2 style="margin-top: 0.35rem">Remote parity inspector (iOS + Android)</h2>
           <pre id="parity-summary">No parity signals yet.</pre>
           <textarea id="snapshot-json" readonly spellcheck="false" placeholder="Latest snapshot JSON payload..."></textarea>
@@ -199,12 +214,15 @@
         </section>
 
         <section class="card stack">
-          <h2>Remote parity validation checklist</h2>
+          <h2>Remote transport v2 validation checklist</h2>
           <ul>
             <li>Background play/pause parity: with playback running, background app and toggle lock-screen/notification play↔pause; verify state changes match manual play()/pause().</li>
-            <li>Now-playing metadata parity: verify title/artist/album/artwork/duration are visible in lock screen / media notification.</li>
+            <li>Remote next/previous parity: on lock-screen/notification and manual buttons, next/previous must match queue transitions from skipToNext()/skipToPrevious().</li>
+            <li>Remote seek parity: lock-screen/notification seek must match seekTo() and keep snapshot position aligned.</li>
+            <li>Boundary behavior parity: previous at first track restarts to 0, next at last track transitions to ended + playbackEnded event.</li>
+            <li>Capability projection parity: canSkipNext/canSkipPrevious/canSeek summary must align with queue index + ended/empty states.</li>
             <li>Progress parity: while playing, lock-screen/notification progress advances; after pause it stays frozen at pause point.</li>
-            <li>v1 command scope: next/previous/seek from remote surface must be inert (no crashes, no track/position jump).</li>
+            <li>Now-playing metadata parity: verify title/artist/album/artwork/duration are visible in lock screen / media notification.</li>
           </ul>
           <p>After harness updates: run <code>npm run build</code> and <code>npm run cap:sync</code> before Android Studio/Xcode validation.</p>
         </section>

--- a/apps/capacitor-demo/src/main.ts
+++ b/apps/capacitor-demo/src/main.ts
@@ -5,6 +5,7 @@ type LegatoSyncController = ReturnType<typeof createLegatoSync>;
 
 const smokeButton = document.querySelector<HTMLButtonElement>('#run-smoke');
 const endSmokeButton = document.querySelector<HTMLButtonElement>('#run-end-smoke');
+const boundarySmokeButton = document.querySelector<HTMLButtonElement>('#run-boundary-smoke');
 const copyLogButton = document.querySelector<HTMLButtonElement>('#copy-log');
 const copyEventsButton = document.querySelector<HTMLButtonElement>('#copy-events');
 const setupButton = document.querySelector<HTMLButtonElement>('#action-setup');
@@ -14,6 +15,8 @@ const addButton = document.querySelector<HTMLButtonElement>('#action-add');
 const playButton = document.querySelector<HTMLButtonElement>('#action-play');
 const pauseButton = document.querySelector<HTMLButtonElement>('#action-pause');
 const stopButton = document.querySelector<HTMLButtonElement>('#action-stop');
+const previousButton = document.querySelector<HTMLButtonElement>('#action-previous');
+const nextButton = document.querySelector<HTMLButtonElement>('#action-next');
 const seekButton = document.querySelector<HTMLButtonElement>('#action-seek');
 const snapshotButton = document.querySelector<HTMLButtonElement>('#action-snapshot');
 const seekInput = document.querySelector<HTMLInputElement>('#seek-ms');
@@ -21,12 +24,14 @@ const envStatusNode = document.querySelector<HTMLDivElement>('#env-status');
 const logNode = document.querySelector<HTMLTextAreaElement>('#log');
 const eventsNode = document.querySelector<HTMLTextAreaElement>('#events');
 const snapshotSummaryNode = document.querySelector<HTMLPreElement>('#snapshot-summary');
+const capabilitySummaryNode = document.querySelector<HTMLPreElement>('#capability-summary');
 const paritySummaryNode = document.querySelector<HTMLPreElement>('#parity-summary');
 const snapshotJsonNode = document.querySelector<HTMLTextAreaElement>('#snapshot-json');
 
 if (
   !smokeButton
   || !endSmokeButton
+  || !boundarySmokeButton
   || !copyLogButton
   || !copyEventsButton
   || !setupButton
@@ -36,6 +41,8 @@ if (
   || !playButton
   || !pauseButton
   || !stopButton
+  || !previousButton
+  || !nextButton
   || !seekButton
   || !snapshotButton
   || !seekInput
@@ -43,6 +50,7 @@ if (
   || !logNode
   || !eventsNode
   || !snapshotSummaryNode
+  || !capabilitySummaryNode
   || !paritySummaryNode
   || !snapshotJsonNode
 ) {
@@ -72,7 +80,7 @@ const demoTracks: Track[] = [
     artist: 'Samplelib',
     album: 'Legato Remote Parity Fixtures',
     artwork: 'https://samplelib.com/lib/preview/png/sample-bumblebee-400x300.png',
-    duration: 3000,
+    duration: 3239,
     type: 'progressive',
   },
   {
@@ -82,7 +90,7 @@ const demoTracks: Track[] = [
     artist: 'Samplelib',
     album: 'Legato Remote Parity Fixtures',
     artwork: 'https://samplelib.com/lib/preview/png/sample-bumblebee-400x300.png',
-    duration: 6000,
+    duration: 6426,
     type: 'progressive',
   },
 ];
@@ -115,6 +123,56 @@ const summarizeSnapshot = (snapshot: PlaybackSnapshot): string => {
     `buffered=${formatMs(snapshot.bufferedPosition ?? null)}`,
     `queue=${queueLength}`,
     `error=${snapshot.error ? JSON.stringify(snapshot.error) : 'none'}`,
+  ].join(' | ');
+};
+
+type ProjectedCapabilities = {
+  canSkipNext: boolean;
+  canSkipPrevious: boolean;
+  canSeek: boolean;
+  queueLength: number;
+  currentIndex: number | null;
+};
+
+const projectCapabilities = (snapshot: PlaybackSnapshot): ProjectedCapabilities => {
+  const queueItems = (snapshot.queue as { items?: unknown[]; tracks?: unknown[] }).items
+    ?? (snapshot.queue as { items?: unknown[]; tracks?: unknown[] }).tracks
+    ?? [];
+  const queueLength = queueItems.length;
+  const indexValue = snapshot.currentIndex;
+  const currentIndex = typeof indexValue === 'number' && Number.isInteger(indexValue) ? indexValue : null;
+  const hasQueue = queueLength > 0;
+  const isEnded = snapshot.state === 'ended';
+
+  const canSkipNext = hasQueue
+    && !isEnded
+    && currentIndex !== null
+    && currentIndex >= 0
+    && currentIndex < queueLength - 1;
+  const canSkipPrevious = hasQueue
+    && !isEnded
+    && currentIndex !== null
+    && currentIndex > 0
+    && currentIndex < queueLength;
+  const canSeek = hasQueue && !isEnded;
+
+  return {
+    canSkipNext,
+    canSkipPrevious,
+    canSeek,
+    queueLength,
+    currentIndex,
+  };
+};
+
+const renderCapabilitySummary = (snapshot: PlaybackSnapshot): void => {
+  const projection = projectCapabilities(snapshot);
+  capabilitySummaryNode.textContent = [
+    `canSkipNext=${projection.canSkipNext}`,
+    `canSkipPrevious=${projection.canSkipPrevious}`,
+    `canSeek=${projection.canSeek}`,
+    `queue=${projection.queueLength}`,
+    `index=${projection.currentIndex ?? 'null'}`,
   ].join(' | ');
 };
 
@@ -293,6 +351,7 @@ const updateSnapshotViews = (snapshot: PlaybackSnapshot): void => {
   latestSnapshot = snapshot;
   addProgressSample(snapshot);
   snapshotSummaryNode.textContent = summarizeSnapshot(snapshot);
+  renderCapabilitySummary(snapshot);
   snapshotJsonNode.value = JSON.stringify(snapshot, null, 2);
   updateParityInspector(snapshot);
   addRecentEvent(`snapshot summary ${summarizeSnapshot(snapshot)}`);
@@ -402,6 +461,16 @@ const stopAction = async (): Promise<void> => {
   log('stop() ok');
 };
 
+const previousAction = async (): Promise<void> => {
+  await Legato.skipToPrevious();
+  log('skipToPrevious() ok');
+};
+
+const nextAction = async (): Promise<void> => {
+  await Legato.skipToNext();
+  log('skipToNext() ok');
+};
+
 const seekAction = async (): Promise<void> => {
   const value = Number(seekInput.value);
   const targetMs = Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
@@ -457,6 +526,28 @@ const runLetItEndSmokeFlow = async (): Promise<void> => {
   await snapshotAction();
 };
 
+const runBoundarySmokeFlow = async (): Promise<void> => {
+  clearFlows();
+  log('Starting Legato boundary smoke flow...');
+  log('platform:', platform);
+  log('isNativePlatform:', isNative);
+  log('Boundary check: previous on first track should restart to 0; next on last track should end playback.');
+
+  await setupAction();
+  await startSync();
+  await addAction();
+  await playAction();
+
+  await previousAction();
+  await snapshotAction();
+
+  await nextAction();
+  await snapshotAction();
+
+  await nextAction();
+  await snapshotAction();
+};
+
 envStatusNode.textContent = `platform=${platform} | native=${isNative}`;
 log('Legato parity harness ready.');
 log('platform:', platform);
@@ -469,6 +560,10 @@ smokeButton.addEventListener('click', () => {
 
 endSmokeButton.addEventListener('click', () => {
   void runNativeAction('run let-it-end smoke flow', runLetItEndSmokeFlow);
+});
+
+boundarySmokeButton.addEventListener('click', () => {
+  void runNativeAction('run boundary smoke flow', runBoundarySmokeFlow);
 });
 
 setupButton.addEventListener('click', () => {
@@ -499,6 +594,14 @@ stopButton.addEventListener('click', () => {
   void runNativeAction('manual stop()', stopAction);
 });
 
+previousButton.addEventListener('click', () => {
+  void runNativeAction('manual skipToPrevious()', previousAction);
+});
+
+nextButton.addEventListener('click', () => {
+  void runNativeAction('manual skipToNext()', nextAction);
+});
+
 seekButton.addEventListener('click', () => {
   void runNativeAction('manual seekTo()', seekAction);
 });
@@ -524,5 +627,6 @@ if (!isNative) {
 
 if (latestSnapshot == null) {
   snapshotSummaryNode.textContent = 'No snapshot captured yet.';
+  capabilitySummaryNode.textContent = 'No capability projection yet.';
   paritySummaryNode.textContent = 'No parity signals yet.';
 }

--- a/native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidModels.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidModels.kt
@@ -75,6 +75,12 @@ data class LegatoAndroidPlaybackSnapshot(
     val queue: LegatoAndroidQueueSnapshot,
 )
 
+data class LegatoAndroidTransportCapabilities(
+    val canSkipNext: Boolean,
+    val canSkipPrevious: Boolean,
+    val canSeek: Boolean,
+)
+
 data class LegatoAndroidNowPlayingMetadata(
     val trackId: String,
     val title: String? = null,

--- a/native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidPlayerEngine.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidPlayerEngine.kt
@@ -25,6 +25,10 @@ class LegatoAndroidPlayerEngine(
     private val remoteCommandManager: LegatoAndroidRemoteCommandManager,
     private val playbackRuntime: LegatoAndroidPlaybackRuntime,
 ) {
+    private companion object {
+        const val PREVIOUS_RESTART_THRESHOLD_MS: Long = 3_000L
+    }
+
     private var isSetup: Boolean = false
     private var pauseOrigin: LegatoAndroidPauseOrigin = LegatoAndroidPauseOrigin.USER
 
@@ -72,6 +76,55 @@ class LegatoAndroidPlayerEngine(
         }.onFailure(::publishPlatformFailure)
     }
 
+    suspend fun add(tracks: List<LegatoAndroidTrack>, startIndex: Int? = null) {
+        guardSetup()
+
+        runCatching {
+            val mappedTracks = trackMapper.mapContractTracks(tracks)
+            if (mappedTracks.isEmpty() && startIndex == null) {
+                return
+            }
+
+            val previousSnapshot = snapshotStore.getPlaybackSnapshot()
+            val existingQueue = queueManager.getQueueSnapshot()
+            val mergedItems = existingQueue.items + mappedTracks
+            val targetIndex = startIndex ?: previousSnapshot.currentIndex
+            val queueSnapshot = queueManager.replaceQueue(mergedItems, targetIndex)
+            playbackRuntime.replaceQueue(mergedItems.map(::toRuntimeTrackSource), targetIndex)
+
+            val runtimeSnapshot = playbackRuntime.snapshot()
+            val currentTrack = queueManager.getCurrentTrack()
+            val isSameTrack = currentTrack?.id == previousSnapshot.currentTrack?.id
+            val nextState = when {
+                queueSnapshot.items.isEmpty() -> LegatoAndroidPlaybackState.IDLE
+                previousSnapshot.state == LegatoAndroidPlaybackState.IDLE -> LegatoAndroidPlaybackState.READY
+                else -> previousSnapshot.state
+            }
+
+            val snapshot = LegatoAndroidPlaybackSnapshot(
+                state = nextState,
+                currentTrack = currentTrack,
+                currentIndex = runtimeSnapshot.currentIndex ?: queueSnapshot.currentIndex,
+                positionMs = if (isSameTrack) previousSnapshot.positionMs else runtimeSnapshot.progress.positionMs,
+                durationMs = runtimeSnapshot.progress.durationMs ?: currentTrack?.durationMs,
+                bufferedPositionMs = if (isSameTrack) {
+                    previousSnapshot.bufferedPositionMs
+                } else {
+                    runtimeSnapshot.progress.bufferedPositionMs
+                },
+                queue = queueSnapshot,
+            )
+
+            snapshotStore.replacePlaybackSnapshot(snapshot)
+            publishQueueAndTrack(snapshot)
+            publishMetadata(snapshot.currentTrack)
+            publishProgress(snapshot)
+            if (snapshot.state != previousSnapshot.state) {
+                publishState(snapshot.state)
+            }
+        }.onFailure(::publishPlatformFailure)
+    }
+
     suspend fun play() {
         guardSetup()
         executePlay()
@@ -102,6 +155,25 @@ class LegatoAndroidPlayerEngine(
 
     suspend fun seekTo(positionMs: Long) {
         guardSetup()
+        executeSeekTo(positionMs)
+    }
+
+    suspend fun skipToNext() {
+        guardSetup()
+        executeSkipToNext()
+    }
+
+    suspend fun skipTo(index: Int) {
+        guardSetup()
+        executeSkipTo(index)
+    }
+
+    suspend fun skipToPrevious() {
+        guardSetup()
+        executeSkipToPrevious()
+    }
+
+    private fun executeSeekTo(positionMs: Long) {
         if (!runRuntimeOperation {
             playbackRuntime.seekTo(positionMs)
         }) return
@@ -117,9 +189,13 @@ class LegatoAndroidPlayerEngine(
         publishProgress(snapshotStore.getPlaybackSnapshot())
     }
 
-    suspend fun skipToNext() {
-        guardSetup()
-        val movedIndex = queueManager.moveToNext() ?: return
+    private fun executeSkipToNext() {
+        val movedIndex = queueManager.moveToNext()
+        if (movedIndex == null) {
+            endPlaybackAtQueueBoundaryIfNeeded()
+            return
+        }
+
         if (!runRuntimeOperation {
             playbackRuntime.selectIndex(movedIndex)
         }) return
@@ -138,14 +214,55 @@ class LegatoAndroidPlayerEngine(
             )
         }
 
-        val snapshot = snapshotStore.getPlaybackSnapshot()
-        publishQueueAndTrack(snapshot)
+        val updatedSnapshot = snapshotStore.getPlaybackSnapshot()
+        publishQueueAndTrack(updatedSnapshot)
         publishMetadata(track)
-        publishProgress(snapshot)
+        publishProgress(updatedSnapshot)
     }
 
-    suspend fun skipToPrevious() {
-        guardSetup()
+    private fun executeSkipTo(index: Int) {
+        val queueSnapshot = queueManager.getQueueSnapshot()
+        require(index in queueSnapshot.items.indices) { "skipTo.index out of bounds" }
+
+        if (!runRuntimeOperation {
+            playbackRuntime.selectIndex(index)
+        }) return
+
+        val updatedQueue = queueManager.replaceQueue(queueSnapshot.items, index)
+        val runtimeSnapshot = playbackRuntime.snapshot()
+        val track = queueManager.getCurrentTrack()
+
+        snapshotStore.updatePlaybackSnapshot { snapshot ->
+            snapshot.copy(
+                currentTrack = track,
+                currentIndex = runtimeSnapshot.currentIndex ?: index,
+                durationMs = runtimeSnapshot.progress.durationMs ?: track?.durationMs,
+                positionMs = runtimeSnapshot.progress.positionMs,
+                bufferedPositionMs = runtimeSnapshot.progress.bufferedPositionMs,
+                queue = updatedQueue,
+            )
+        }
+
+        val updatedSnapshot = snapshotStore.getPlaybackSnapshot()
+        publishQueueAndTrack(updatedSnapshot)
+        publishMetadata(track)
+        publishProgress(updatedSnapshot)
+    }
+
+    private fun executeSkipToPrevious() {
+        val snapshot = snapshotStore.getPlaybackSnapshot()
+        val currentIndex = snapshot.currentIndex ?: return
+
+        if (snapshot.positionMs > PREVIOUS_RESTART_THRESHOLD_MS) {
+            executeSeekTo(0L)
+            return
+        }
+
+        if (currentIndex <= 0) {
+            executeSeekTo(0L)
+            return
+        }
+
         val movedIndex = queueManager.moveToPrevious() ?: return
         if (!runRuntimeOperation {
             playbackRuntime.selectIndex(movedIndex)
@@ -165,10 +282,27 @@ class LegatoAndroidPlayerEngine(
             )
         }
 
-        val snapshot = snapshotStore.getPlaybackSnapshot()
-        publishQueueAndTrack(snapshot)
+        val updatedSnapshot = snapshotStore.getPlaybackSnapshot()
+        publishQueueAndTrack(updatedSnapshot)
         publishMetadata(track)
-        publishProgress(snapshot)
+        publishProgress(updatedSnapshot)
+    }
+
+    private fun endPlaybackAtQueueBoundaryIfNeeded() {
+        val snapshot = snapshotStore.getPlaybackSnapshot()
+        val currentIndex = snapshot.currentIndex ?: return
+        val queueItems = snapshot.queue.items
+
+        if (queueItems.isEmpty() || currentIndex != queueItems.lastIndex) {
+            return
+        }
+
+        transitionTo(LegatoAndroidStateMachine.LegatoAndroidStateInput.TRACK_ENDED)
+        val endedSnapshot = snapshotStore.getPlaybackSnapshot()
+        eventEmitter.emit(
+            name = LegatoAndroidEventName.PLAYBACK_ENDED,
+            payload = LegatoAndroidEventPayload.PlaybackEnded(endedSnapshot),
+        )
     }
 
     fun getSnapshot(): LegatoAndroidPlaybackSnapshot = snapshotStore.getPlaybackSnapshot()
@@ -176,13 +310,17 @@ class LegatoAndroidPlayerEngine(
     fun getPauseOrigin(): LegatoAndroidPauseOrigin = pauseOrigin
 
     fun getServiceMode(): LegatoAndroidServiceMode {
-        val state = snapshotStore.getPlaybackSnapshot().state
+        val snapshot = snapshotStore.getPlaybackSnapshot()
+        val state = snapshot.state
         return when {
             state == LegatoAndroidPlaybackState.PLAYING || state == LegatoAndroidPlaybackState.BUFFERING ->
                 LegatoAndroidServiceMode.PLAYBACK_ACTIVE
 
             state == LegatoAndroidPlaybackState.PAUSED && pauseOrigin == LegatoAndroidPauseOrigin.INTERRUPTION ->
                 LegatoAndroidServiceMode.RESUME_PENDING_INTERRUPTION
+
+            state == LegatoAndroidPlaybackState.PAUSED && snapshot.currentTrack != null ->
+                LegatoAndroidServiceMode.PLAYBACK_ACTIVE
 
             else -> LegatoAndroidServiceMode.OFF
         }
@@ -203,14 +341,27 @@ class LegatoAndroidPlayerEngine(
 
     private val runtimeListener = object : LegatoAndroidPlaybackRuntimeListener {
         override fun onProgress(progress: LegatoAndroidRuntimeProgress) {
+            val runtimeSnapshot = playbackRuntime.snapshot()
+            var activeItemChanged = false
+
             snapshotStore.updatePlaybackSnapshot { snapshot ->
-                snapshot.copy(
+                val syncedSnapshot = synchronizeActiveItemFromRuntime(snapshot, runtimeSnapshot.currentIndex)
+                activeItemChanged = syncedSnapshot.currentIndex != snapshot.currentIndex ||
+                    syncedSnapshot.currentTrack?.id != snapshot.currentTrack?.id
+
+                syncedSnapshot.copy(
                     positionMs = progress.positionMs,
-                    durationMs = progress.durationMs ?: snapshot.durationMs,
+                    durationMs = progress.durationMs ?: syncedSnapshot.currentTrack?.durationMs ?: syncedSnapshot.durationMs,
                     bufferedPositionMs = progress.bufferedPositionMs,
                 )
             }
-            publishProgress(snapshotStore.getPlaybackSnapshot())
+
+            val updatedSnapshot = snapshotStore.getPlaybackSnapshot()
+            if (activeItemChanged) {
+                publishQueueAndTrack(updatedSnapshot)
+                publishMetadata(updatedSnapshot.currentTrack)
+            }
+            publishProgress(updatedSnapshot)
         }
 
         override fun onBuffering(isBuffering: Boolean) {
@@ -255,6 +406,25 @@ class LegatoAndroidPlayerEngine(
 
         snapshotStore.updatePlaybackSnapshot { it.copy(state = nextState) }
         publishState(nextState)
+    }
+
+    private fun synchronizeActiveItemFromRuntime(
+        snapshot: LegatoAndroidPlaybackSnapshot,
+        runtimeIndex: Int?,
+    ): LegatoAndroidPlaybackSnapshot {
+        val resolvedIndex = runtimeIndex?.takeIf { it in snapshot.queue.items.indices } ?: return snapshot
+        if (resolvedIndex == snapshot.currentIndex) {
+            return snapshot
+        }
+
+        val syncedQueue = queueManager.replaceQueue(snapshot.queue.items, resolvedIndex)
+        val syncedTrack = syncedQueue.items.getOrNull(resolvedIndex)
+        return snapshot.copy(
+            currentTrack = syncedTrack,
+            currentIndex = resolvedIndex,
+            durationMs = syncedTrack?.durationMs,
+            queue = syncedQueue,
+        )
     }
 
     private fun guardSetup() {
@@ -385,17 +555,23 @@ class LegatoAndroidPlayerEngine(
             LegatoAndroidRemoteCommand.Next -> eventEmitter.emit(
                 name = LegatoAndroidEventName.REMOTE_NEXT,
                 payload = LegatoAndroidEventPayload.RemoteNext,
-            )
+            ).also {
+                executeSkipToNext()
+            }
 
             LegatoAndroidRemoteCommand.Previous -> eventEmitter.emit(
                 name = LegatoAndroidEventName.REMOTE_PREVIOUS,
                 payload = LegatoAndroidEventPayload.RemotePrevious,
-            )
+            ).also {
+                executeSkipToPrevious()
+            }
 
             is LegatoAndroidRemoteCommand.Seek -> eventEmitter.emit(
                 name = LegatoAndroidEventName.REMOTE_SEEK,
                 payload = LegatoAndroidEventPayload.RemoteSeek(command.positionMs),
-            )
+            ).also {
+                executeSeekTo(command.positionMs)
+            }
         }
     }
 

--- a/native/android/core/src/main/kotlin/io/legato/core/queue/LegatoAndroidTransportCapabilitiesProjector.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/queue/LegatoAndroidTransportCapabilitiesProjector.kt
@@ -1,0 +1,31 @@
+package io.legato.core.queue
+
+import io.legato.core.core.LegatoAndroidPlaybackSnapshot
+import io.legato.core.core.LegatoAndroidPlaybackState
+import io.legato.core.core.LegatoAndroidTransportCapabilities
+
+object LegatoAndroidTransportCapabilitiesProjector {
+    fun fromSnapshot(snapshot: LegatoAndroidPlaybackSnapshot): LegatoAndroidTransportCapabilities {
+        if (snapshot.state == LegatoAndroidPlaybackState.ENDED) {
+            return LegatoAndroidTransportCapabilities(canSkipNext = false, canSkipPrevious = false, canSeek = false)
+        }
+
+        val queue = snapshot.queue.items
+        if (queue.isEmpty()) {
+            return LegatoAndroidTransportCapabilities(canSkipNext = false, canSkipPrevious = false, canSeek = false)
+        }
+
+        val currentIndex = snapshot.currentIndex ?: snapshot.queue.currentIndex
+        val hasActiveTrack = currentIndex != null && currentIndex in queue.indices
+        if (!hasActiveTrack) {
+            return LegatoAndroidTransportCapabilities(canSkipNext = false, canSkipPrevious = false, canSeek = false)
+        }
+
+        val index = checkNotNull(currentIndex)
+        return LegatoAndroidTransportCapabilities(
+            canSkipNext = index < queue.lastIndex,
+            canSkipPrevious = index > 0,
+            canSeek = true,
+        )
+    }
+}

--- a/native/android/core/src/main/kotlin/io/legato/core/remote/LegatoAndroidMediaSessionBridge.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/remote/LegatoAndroidMediaSessionBridge.kt
@@ -100,6 +100,18 @@ class LegatoAndroidMediaSessionBridge : LegatoAndroidSessionRuntime, LegatoAndro
         remoteDispatch?.invoke(LegatoAndroidRemoteCommand.Pause)
     }
 
+    fun dispatchMediaSessionSkipToNext() {
+        remoteDispatch?.invoke(LegatoAndroidRemoteCommand.Next)
+    }
+
+    fun dispatchMediaSessionSkipToPrevious() {
+        remoteDispatch?.invoke(LegatoAndroidRemoteCommand.Previous)
+    }
+
+    fun dispatchMediaSessionSeekTo(positionMs: Long) {
+        remoteDispatch?.invoke(LegatoAndroidRemoteCommand.Seek(positionMs))
+    }
+
     fun dispatchTransportControl(control: TransportControl) {
         when (control) {
             TransportControl.PLAY -> dispatchMediaSessionPlay()

--- a/native/android/core/src/main/kotlin/io/legato/core/runtime/LegatoAndroidMedia3PlaybackRuntime.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/runtime/LegatoAndroidMedia3PlaybackRuntime.kt
@@ -1,44 +1,54 @@
 package io.legato.core.runtime
 
+import android.os.Handler
+import android.os.Looper
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import io.legato.core.core.LegatoAndroidPlaybackState
 
 class LegatoAndroidMedia3PlaybackRuntime(
     private val player: Player? = null,
+    private val playerCommandExecutor: PlayerCommandExecutor = MainThreadPlayerCommandExecutor,
 ) : LegatoAndroidPlaybackRuntime {
     private var listener: LegatoAndroidPlaybackRuntimeListener? = null
     private var runtimeSnapshot: LegatoAndroidRuntimeSnapshot = LegatoAndroidRuntimeSnapshot()
 
     override fun configure() {
-        player?.addListener(
-            object : Player.Listener {
-                override fun onPlaybackStateChanged(playbackState: Int) {
-                    when (playbackState) {
-                        Player.STATE_BUFFERING -> dispatchBuffering(true)
-                        Player.STATE_ENDED -> dispatchEnded()
+        withPlayer { currentPlayer ->
+            currentPlayer.addListener(
+                object : Player.Listener {
+                    override fun onPlaybackStateChanged(playbackState: Int) {
+                        when (playbackState) {
+                            Player.STATE_BUFFERING -> dispatchBuffering(true)
+                            Player.STATE_ENDED -> dispatchEnded()
+                        }
+                    }
+
+                    override fun onIsLoadingChanged(isLoading: Boolean) {
+                        dispatchBuffering(isLoading)
+                    }
+
+                    override fun onPlayerError(error: androidx.media3.common.PlaybackException) {
+                        dispatchFatalError(error)
+                    }
+
+                    override fun onEvents(player: Player, events: Player.Events) {
+                        if (
+                            events.contains(Player.EVENT_POSITION_DISCONTINUITY) ||
+                            events.contains(Player.EVENT_PLAYBACK_STATE_CHANGED) ||
+                            events.contains(Player.EVENT_MEDIA_ITEM_TRANSITION)
+                        ) {
+                            dispatchProgress(
+                                positionMs = player.currentPosition,
+                                durationMs = player.duration.takeIf { it >= 0L },
+                                bufferedPositionMs = player.bufferedPosition,
+                                currentIndex = player.currentMediaItemIndex.takeIf { it >= 0 },
+                            )
+                        }
                     }
                 }
-
-                override fun onIsLoadingChanged(isLoading: Boolean) {
-                    dispatchBuffering(isLoading)
-                }
-
-                override fun onPlayerError(error: androidx.media3.common.PlaybackException) {
-                    dispatchFatalError(error)
-                }
-
-                override fun onEvents(player: Player, events: Player.Events) {
-                    if (events.contains(Player.EVENT_POSITION_DISCONTINUITY) || events.contains(Player.EVENT_PLAYBACK_STATE_CHANGED)) {
-                        dispatchProgress(
-                            positionMs = player.currentPosition,
-                            durationMs = player.duration.takeIf { it >= 0L },
-                            bufferedPositionMs = player.bufferedPosition,
-                        )
-                    }
-                }
-            },
-        )
+            )
+        }
     }
 
     override fun setListener(listener: LegatoAndroidPlaybackRuntimeListener?) {
@@ -53,38 +63,45 @@ class LegatoAndroidMedia3PlaybackRuntime(
             else -> 0
         }
 
-        player?.setMediaItems(
-            items.map { source -> MediaItem.fromUri(source.url) },
-            selectedIndex ?: 0,
-            0L,
-        )
+        withPlayer { currentPlayer ->
+            currentPlayer.setMediaItems(
+                items.map { source -> MediaItem.fromUri(source.url) },
+                selectedIndex ?: 0,
+                0L,
+            )
+        }
 
         runtimeSnapshot = runtimeSnapshot.copy(
             currentIndex = selectedIndex,
-            progress = runtimeSnapshot.progress.copy(positionMs = 0L, bufferedPositionMs = 0L),
+            progress = runtimeSnapshot.progress.copy(positionMs = 0L, durationMs = null, bufferedPositionMs = 0L),
             stateHint = LegatoAndroidPlaybackState.READY,
             isBufferingHint = false,
         )
     }
 
     override fun selectIndex(index: Int) {
-        player?.seekToDefaultPosition(index)
+        withPlayer { currentPlayer -> currentPlayer.seekToDefaultPosition(index) }
         runtimeSnapshot = runtimeSnapshot.copy(
             currentIndex = index,
-            progress = runtimeSnapshot.progress.copy(positionMs = 0L, bufferedPositionMs = 0L),
+            progress = runtimeSnapshot.progress.copy(positionMs = 0L, durationMs = null, bufferedPositionMs = 0L),
         )
     }
 
     override fun play() {
-        player?.play()
+        withPlayer { currentPlayer ->
+            if (currentPlayer.playbackState == Player.STATE_IDLE) {
+                currentPlayer.prepare()
+            }
+            currentPlayer.play()
+        }
     }
 
     override fun pause() {
-        player?.pause()
+        withPlayer { currentPlayer -> currentPlayer.pause() }
     }
 
     override fun stop(resetPosition: Boolean) {
-        player?.stop()
+        withPlayer { currentPlayer -> currentPlayer.stop() }
         if (resetPosition) {
             runtimeSnapshot = runtimeSnapshot.copy(
                 progress = runtimeSnapshot.progress.copy(positionMs = 0L, bufferedPositionMs = 0L),
@@ -95,7 +112,7 @@ class LegatoAndroidMedia3PlaybackRuntime(
 
     override fun seekTo(positionMs: Long) {
         val safePositionMs = positionMs.coerceAtLeast(0L)
-        player?.seekTo(safePositionMs)
+        withPlayer { currentPlayer -> currentPlayer.seekTo(safePositionMs) }
         runtimeSnapshot = runtimeSnapshot.copy(
             progress = runtimeSnapshot.progress.copy(positionMs = safePositionMs),
         )
@@ -105,17 +122,24 @@ class LegatoAndroidMedia3PlaybackRuntime(
 
     override fun release() {
         listener = null
-        player?.release()
+        withPlayer { currentPlayer -> currentPlayer.release() }
     }
 
-    fun dispatchProgress(positionMs: Long, durationMs: Long?, bufferedPositionMs: Long?) {
+    private inline fun withPlayer(crossinline operation: (Player) -> Unit) {
+        val currentPlayer = player ?: return
+        playerCommandExecutor.execute {
+            operation(currentPlayer)
+        }
+    }
+
+    fun dispatchProgress(positionMs: Long, durationMs: Long?, bufferedPositionMs: Long?, currentIndex: Int? = runtimeSnapshot.currentIndex) {
         val progress = LegatoAndroidRuntimeProgress(
             positionMs = positionMs.coerceAtLeast(0L),
             durationMs = durationMs?.takeIf { it >= 0L },
             bufferedPositionMs = bufferedPositionMs?.coerceAtLeast(0L),
         )
 
-        runtimeSnapshot = runtimeSnapshot.copy(progress = progress)
+        runtimeSnapshot = runtimeSnapshot.copy(currentIndex = currentIndex, progress = progress)
         listener?.onProgress(progress)
     }
 
@@ -141,5 +165,22 @@ class LegatoAndroidMedia3PlaybackRuntime(
             isBufferingHint = false,
         )
         listener?.onFatalError(error)
+    }
+}
+
+fun interface PlayerCommandExecutor {
+    fun execute(operation: () -> Unit)
+}
+
+private object MainThreadPlayerCommandExecutor : PlayerCommandExecutor {
+    private val handler: Handler by lazy { Handler(Looper.getMainLooper()) }
+
+    override fun execute(operation: () -> Unit) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            operation()
+            return
+        }
+
+        handler.post(operation)
     }
 }

--- a/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidCoreCompositionMediaSessionBridgeTest.kt
+++ b/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidCoreCompositionMediaSessionBridgeTest.kt
@@ -110,6 +110,81 @@ class LegatoAndroidCoreCompositionMediaSessionBridgeTest {
 
         assertTrue(events.any { it.name == LegatoAndroidEventName.REMOTE_PAUSE })
     }
+
+    @Test
+    fun `shared media-session bridge dispatches media-session next callback into canonical remote path`() = runBlocking {
+        val playbackRuntime = BridgeRecordingPlaybackRuntime()
+        val eventEmitter = LegatoAndroidEventEmitter()
+        val dependencies = LegatoAndroidCoreDependencies(
+            eventEmitter = eventEmitter,
+            playbackRuntime = playbackRuntime,
+        )
+        val components = LegatoAndroidCoreFactory.create(dependencies)
+        val events = mutableListOf<LegatoAndroidEvent>()
+        eventEmitter.addListener { event: LegatoAndroidEvent -> events += event }
+
+        components.playerEngine.setup()
+        components.playerEngine.load(
+            tracks = listOf(
+                LegatoAndroidTrack(id = "track-1", url = "https://example.com/1.mp3"),
+                LegatoAndroidTrack(id = "track-2", url = "https://example.com/2.mp3"),
+            ),
+        )
+
+        dependencies.mediaSessionBridge.dispatchMediaSessionSkipToNext()
+
+        assertTrue(events.any { it.name == LegatoAndroidEventName.REMOTE_NEXT })
+    }
+
+    @Test
+    fun `shared media-session bridge dispatches media-session previous callback into canonical remote path`() = runBlocking {
+        val playbackRuntime = BridgeRecordingPlaybackRuntime()
+        val eventEmitter = LegatoAndroidEventEmitter()
+        val dependencies = LegatoAndroidCoreDependencies(
+            eventEmitter = eventEmitter,
+            playbackRuntime = playbackRuntime,
+        )
+        val components = LegatoAndroidCoreFactory.create(dependencies)
+        val events = mutableListOf<LegatoAndroidEvent>()
+        eventEmitter.addListener { event: LegatoAndroidEvent -> events += event }
+
+        components.playerEngine.setup()
+        components.playerEngine.load(
+            tracks = listOf(
+                LegatoAndroidTrack(id = "track-1", url = "https://example.com/1.mp3"),
+                LegatoAndroidTrack(id = "track-2", url = "https://example.com/2.mp3"),
+            ),
+        )
+        components.playerEngine.skipToNext()
+
+        dependencies.mediaSessionBridge.dispatchMediaSessionSkipToPrevious()
+
+        assertTrue(events.any { it.name == LegatoAndroidEventName.REMOTE_PREVIOUS })
+    }
+
+    @Test
+    fun `shared media-session bridge dispatches media-session seek callback into canonical remote path`() = runBlocking {
+        val playbackRuntime = BridgeRecordingPlaybackRuntime()
+        val eventEmitter = LegatoAndroidEventEmitter()
+        val dependencies = LegatoAndroidCoreDependencies(
+            eventEmitter = eventEmitter,
+            playbackRuntime = playbackRuntime,
+        )
+        val components = LegatoAndroidCoreFactory.create(dependencies)
+        val events = mutableListOf<LegatoAndroidEvent>()
+        eventEmitter.addListener { event: LegatoAndroidEvent -> events += event }
+
+        components.playerEngine.setup()
+        components.playerEngine.load(
+            tracks = listOf(
+                LegatoAndroidTrack(id = "track-1", url = "https://example.com/1.mp3"),
+            ),
+        )
+
+        dependencies.mediaSessionBridge.dispatchMediaSessionSeekTo(42_000L)
+
+        assertTrue(events.any { it.name == LegatoAndroidEventName.REMOTE_SEEK })
+    }
 }
 
 private class BridgeRecordingPlaybackRuntime : LegatoAndroidPlaybackRuntime {

--- a/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineInterruptionPolicyTest.kt
+++ b/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineInterruptionPolicyTest.kt
@@ -159,6 +159,37 @@ class LegatoAndroidPlayerEngineInterruptionPolicyTest {
         assertEquals(LegatoAndroidPlaybackState.PLAYING, engine.getSnapshot().state)
     }
 
+    @Test
+    fun `runtime progress transition syncs active track index and progress`() = runBlocking {
+        val playbackRuntime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val engine = buildEngine(playbackRuntime, sessionRuntime)
+
+        engine.setup()
+        engine.load(
+            tracks = listOf(
+                LegatoAndroidTrack(id = "track-1", url = "https://example.com/1.mp3", durationMs = 100_000L),
+                LegatoAndroidTrack(id = "track-2", url = "https://example.com/2.mp3", durationMs = 200_000L),
+            ),
+        )
+        engine.play()
+
+        playbackRuntime.emitProgress(
+            currentIndex = 1,
+            positionMs = 3_000L,
+            durationMs = 200_000L,
+            bufferedPositionMs = 9_000L,
+        )
+
+        val snapshot = engine.getSnapshot()
+        assertEquals(1, snapshot.currentIndex)
+        assertEquals("track-2", snapshot.currentTrack?.id)
+        assertEquals(3_000L, snapshot.positionMs)
+        assertEquals(200_000L, snapshot.durationMs)
+        assertEquals(9_000L, snapshot.bufferedPositionMs)
+        assertEquals(1, snapshot.queue.currentIndex)
+    }
+
     private fun buildEngine(
         playbackRuntime: RecordingPlaybackRuntime,
         sessionRuntime: RecordingSessionRuntime,
@@ -227,7 +258,8 @@ private class RecordingPlaybackRuntime : LegatoAndroidPlaybackRuntime {
         listener?.onFatalError(error)
     }
 
-    fun emitProgress(positionMs: Long, durationMs: Long?, bufferedPositionMs: Long?) {
+    fun emitProgress(currentIndex: Int? = snapshot.currentIndex, positionMs: Long, durationMs: Long?, bufferedPositionMs: Long?) {
+        snapshot = snapshot.copy(currentIndex = currentIndex)
         listener?.onProgress(
             io.legato.core.runtime.LegatoAndroidRuntimeProgress(
                 positionMs = positionMs,

--- a/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineRemoteCommandRoutingTest.kt
+++ b/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineRemoteCommandRoutingTest.kt
@@ -33,6 +33,7 @@ class LegatoAndroidPlayerEngineRemoteCommandRoutingTest {
 
         assertEquals(1, playbackRuntime.pauseCalls)
         assertEquals(LegatoAndroidPlaybackState.PAUSED, components.playerEngine.getSnapshot().state)
+        assertEquals(LegatoAndroidServiceMode.PLAYBACK_ACTIVE, components.playerEngine.getServiceMode())
 
         val remoteEvents = events.drop(eventsBeforeRemote)
         assertTrue(remoteEvents.any { it.name == LegatoAndroidEventName.REMOTE_PAUSE })
@@ -42,6 +43,26 @@ class LegatoAndroidPlayerEngineRemoteCommandRoutingTest {
                     (it.payload as? LegatoAndroidEventPayload.PlaybackStateChanged)?.state == LegatoAndroidPlaybackState.PAUSED
             },
         )
+    }
+
+    @Test
+    fun `stop tears down service mode after paused resumable session`() = runBlocking {
+        val playbackRuntime = RemoteRoutingPlaybackRuntime()
+        val dependencies = LegatoAndroidCoreDependencies(
+            playbackRuntime = playbackRuntime,
+        )
+        val components = LegatoAndroidCoreFactory.create(dependencies)
+
+        components.playerEngine.setup()
+        components.playerEngine.load(tracks = listOf(track()))
+        components.playerEngine.play()
+        dependencies.mediaSessionBridge.dispatchRemoteCommandForTesting(LegatoAndroidRemoteCommand.Pause)
+
+        assertEquals(LegatoAndroidServiceMode.PLAYBACK_ACTIVE, components.playerEngine.getServiceMode())
+
+        components.playerEngine.stop()
+
+        assertEquals(LegatoAndroidServiceMode.OFF, components.playerEngine.getServiceMode())
     }
 
     @Test
@@ -77,7 +98,112 @@ class LegatoAndroidPlayerEngineRemoteCommandRoutingTest {
     }
 
     @Test
-    fun `remote next previous and seek stay no-op in v1`() = runBlocking {
+    fun `remote next routes through canonical skip handler`() = runBlocking {
+        val playbackRuntime = RemoteRoutingPlaybackRuntime()
+        val eventEmitter = LegatoAndroidEventEmitter()
+        val dependencies = LegatoAndroidCoreDependencies(
+            eventEmitter = eventEmitter,
+            playbackRuntime = playbackRuntime,
+        )
+        val components = LegatoAndroidCoreFactory.create(dependencies)
+        val events = mutableListOf<LegatoAndroidEvent>()
+        eventEmitter.addListener { event -> events += event }
+
+        components.playerEngine.setup()
+        components.playerEngine.load(tracks = listOf(track(id = "1"), track(id = "2")))
+        components.playerEngine.play()
+        playbackRuntime.resetCommandCounters()
+
+        dependencies.mediaSessionBridge.dispatchRemoteCommandForTesting(LegatoAndroidRemoteCommand.Next)
+
+        assertEquals(1, playbackRuntime.selectIndexCalls)
+        assertEquals(0, playbackRuntime.seekCalls)
+        assertEquals(1, components.playerEngine.getSnapshot().currentIndex)
+        assertTrue(events.any { it.name == LegatoAndroidEventName.REMOTE_NEXT })
+    }
+
+    @Test
+    fun `remote next at end transitions playback to ended and emits playbackEnded`() = runBlocking {
+        val playbackRuntime = RemoteRoutingPlaybackRuntime()
+        val eventEmitter = LegatoAndroidEventEmitter()
+        val dependencies = LegatoAndroidCoreDependencies(
+            eventEmitter = eventEmitter,
+            playbackRuntime = playbackRuntime,
+        )
+        val components = LegatoAndroidCoreFactory.create(dependencies)
+        val events = mutableListOf<LegatoAndroidEvent>()
+        eventEmitter.addListener { event -> events += event }
+
+        components.playerEngine.setup()
+        components.playerEngine.load(tracks = listOf(track(id = "1"), track(id = "2")))
+        components.playerEngine.play()
+        components.playerEngine.skipToNext()
+        playbackRuntime.resetCommandCounters()
+
+        dependencies.mediaSessionBridge.dispatchRemoteCommandForTesting(LegatoAndroidRemoteCommand.Next)
+
+        assertEquals(LegatoAndroidPlaybackState.ENDED, components.playerEngine.getSnapshot().state)
+        assertEquals(0, playbackRuntime.selectIndexCalls)
+        assertTrue(events.any { it.name == LegatoAndroidEventName.PLAYBACK_ENDED })
+        assertTrue(events.any { it.name == LegatoAndroidEventName.REMOTE_NEXT })
+    }
+
+    @Test
+    fun `remote previous seeks to zero when current position is greater than threshold`() = runBlocking {
+        val playbackRuntime = RemoteRoutingPlaybackRuntime()
+        val eventEmitter = LegatoAndroidEventEmitter()
+        val dependencies = LegatoAndroidCoreDependencies(
+            eventEmitter = eventEmitter,
+            playbackRuntime = playbackRuntime,
+        )
+        val components = LegatoAndroidCoreFactory.create(dependencies)
+        val events = mutableListOf<LegatoAndroidEvent>()
+        eventEmitter.addListener { event -> events += event }
+
+        components.playerEngine.setup()
+        components.playerEngine.load(tracks = listOf(track(id = "1"), track(id = "2")))
+        components.playerEngine.skipToNext()
+        components.playerEngine.seekTo(7_500L)
+        playbackRuntime.resetCommandCounters()
+
+        dependencies.mediaSessionBridge.dispatchRemoteCommandForTesting(LegatoAndroidRemoteCommand.Previous)
+
+        assertEquals(1, playbackRuntime.seekCalls)
+        assertEquals(0, playbackRuntime.selectIndexCalls)
+        assertEquals(1, components.playerEngine.getSnapshot().currentIndex)
+        assertEquals(0L, components.playerEngine.getSnapshot().positionMs)
+        assertTrue(events.any { it.name == LegatoAndroidEventName.REMOTE_PREVIOUS })
+    }
+
+    @Test
+    fun `remote previous skips to previous track when position is at or below threshold`() = runBlocking {
+        val playbackRuntime = RemoteRoutingPlaybackRuntime()
+        val eventEmitter = LegatoAndroidEventEmitter()
+        val dependencies = LegatoAndroidCoreDependencies(
+            eventEmitter = eventEmitter,
+            playbackRuntime = playbackRuntime,
+        )
+        val components = LegatoAndroidCoreFactory.create(dependencies)
+        val events = mutableListOf<LegatoAndroidEvent>()
+        eventEmitter.addListener { event -> events += event }
+
+        components.playerEngine.setup()
+        components.playerEngine.load(tracks = listOf(track(id = "1"), track(id = "2"), track(id = "3")))
+        components.playerEngine.skipToNext()
+        components.playerEngine.skipToNext()
+        components.playerEngine.seekTo(2_000L)
+        playbackRuntime.resetCommandCounters()
+
+        dependencies.mediaSessionBridge.dispatchRemoteCommandForTesting(LegatoAndroidRemoteCommand.Previous)
+
+        assertEquals(1, playbackRuntime.selectIndexCalls)
+        assertEquals(0, playbackRuntime.seekCalls)
+        assertEquals(1, components.playerEngine.getSnapshot().currentIndex)
+        assertTrue(events.any { it.name == LegatoAndroidEventName.REMOTE_PREVIOUS })
+    }
+
+    @Test
+    fun `remote previous on first track seeks to zero`() = runBlocking {
         val playbackRuntime = RemoteRoutingPlaybackRuntime()
         val dependencies = LegatoAndroidCoreDependencies(
             playbackRuntime = playbackRuntime,
@@ -85,23 +211,43 @@ class LegatoAndroidPlayerEngineRemoteCommandRoutingTest {
         val components = LegatoAndroidCoreFactory.create(dependencies)
 
         components.playerEngine.setup()
-        components.playerEngine.load(tracks = listOf(track()))
-        components.playerEngine.play()
+        components.playerEngine.load(tracks = listOf(track(id = "1"), track(id = "2")))
+        components.playerEngine.seekTo(2_000L)
         playbackRuntime.resetCommandCounters()
 
-        dependencies.mediaSessionBridge.dispatchRemoteCommandForTesting(LegatoAndroidRemoteCommand.Next)
         dependencies.mediaSessionBridge.dispatchRemoteCommandForTesting(LegatoAndroidRemoteCommand.Previous)
-        dependencies.mediaSessionBridge.dispatchRemoteCommandForTesting(LegatoAndroidRemoteCommand.Seek(45_000L))
 
-        assertEquals(0, playbackRuntime.pauseCalls)
-        assertEquals(0, playbackRuntime.playCalls)
-        assertEquals(0, playbackRuntime.seekCalls)
+        assertEquals(1, playbackRuntime.seekCalls)
         assertEquals(0, playbackRuntime.selectIndexCalls)
-        assertEquals(LegatoAndroidPlaybackState.PLAYING, components.playerEngine.getSnapshot().state)
+        assertEquals(0, components.playerEngine.getSnapshot().currentIndex)
+        assertEquals(0L, components.playerEngine.getSnapshot().positionMs)
     }
 
-    private fun track(): LegatoAndroidTrack = LegatoAndroidTrack(
-        id = "remote-routing-track",
+    @Test
+    fun `remote seek routes through canonical seek handler`() = runBlocking {
+        val playbackRuntime = RemoteRoutingPlaybackRuntime()
+        val eventEmitter = LegatoAndroidEventEmitter()
+        val dependencies = LegatoAndroidCoreDependencies(
+            eventEmitter = eventEmitter,
+            playbackRuntime = playbackRuntime,
+        )
+        val components = LegatoAndroidCoreFactory.create(dependencies)
+        val events = mutableListOf<LegatoAndroidEvent>()
+        eventEmitter.addListener { event -> events += event }
+
+        components.playerEngine.setup()
+        components.playerEngine.load(tracks = listOf(track(id = "1")))
+        playbackRuntime.resetCommandCounters()
+
+        dependencies.mediaSessionBridge.dispatchRemoteCommandForTesting(LegatoAndroidRemoteCommand.Seek(45_000L))
+
+        assertEquals(1, playbackRuntime.seekCalls)
+        assertEquals(45_000L, components.playerEngine.getSnapshot().positionMs)
+        assertTrue(events.any { it.name == LegatoAndroidEventName.REMOTE_SEEK })
+    }
+
+    private fun track(id: String = "remote-routing-track"): LegatoAndroidTrack = LegatoAndroidTrack(
+        id = id,
         url = "https://example.com/audio.mp3",
         title = "Remote Routing",
         artist = "Legato",

--- a/native/android/core/src/test/kotlin/io/legato/core/queue/LegatoAndroidTransportCapabilitiesProjectionTest.kt
+++ b/native/android/core/src/test/kotlin/io/legato/core/queue/LegatoAndroidTransportCapabilitiesProjectionTest.kt
@@ -1,0 +1,86 @@
+package io.legato.core.queue
+
+import io.legato.core.core.LegatoAndroidPlaybackSnapshot
+import io.legato.core.core.LegatoAndroidPlaybackState
+import io.legato.core.core.LegatoAndroidQueueSnapshot
+import io.legato.core.core.LegatoAndroidTrack
+import io.legato.core.core.LegatoAndroidTransportCapabilities
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LegatoAndroidTransportCapabilitiesProjectionTest {
+    @Test
+    fun `projects full transport capabilities for mid queue snapshot`() {
+        val snapshot = playbackSnapshot(
+            state = LegatoAndroidPlaybackState.PLAYING,
+            items = listOf(track("1"), track("2"), track("3")),
+            currentIndex = 1,
+        )
+
+        assertEquals(
+            LegatoAndroidTransportCapabilities(canSkipNext = true, canSkipPrevious = true, canSeek = true),
+            LegatoAndroidTransportCapabilitiesProjector.fromSnapshot(snapshot),
+        )
+    }
+
+    @Test
+    fun `projects no skip capabilities for single track snapshot`() {
+        val snapshot = playbackSnapshot(
+            state = LegatoAndroidPlaybackState.READY,
+            items = listOf(track("1")),
+            currentIndex = 0,
+        )
+
+        assertEquals(
+            LegatoAndroidTransportCapabilities(canSkipNext = false, canSkipPrevious = false, canSeek = true),
+            LegatoAndroidTransportCapabilitiesProjector.fromSnapshot(snapshot),
+        )
+    }
+
+    @Test
+    fun `projects all false for empty queue snapshot`() {
+        val snapshot = playbackSnapshot(
+            state = LegatoAndroidPlaybackState.IDLE,
+            items = emptyList(),
+            currentIndex = null,
+        )
+
+        assertEquals(
+            LegatoAndroidTransportCapabilities(canSkipNext = false, canSkipPrevious = false, canSeek = false),
+            LegatoAndroidTransportCapabilitiesProjector.fromSnapshot(snapshot),
+        )
+    }
+
+    @Test
+    fun `projects all false while ended regardless of queue contents`() {
+        val snapshot = playbackSnapshot(
+            state = LegatoAndroidPlaybackState.ENDED,
+            items = listOf(track("1"), track("2"), track("3")),
+            currentIndex = 2,
+        )
+
+        assertEquals(
+            LegatoAndroidTransportCapabilities(canSkipNext = false, canSkipPrevious = false, canSeek = false),
+            LegatoAndroidTransportCapabilitiesProjector.fromSnapshot(snapshot),
+        )
+    }
+
+    private fun playbackSnapshot(
+        state: LegatoAndroidPlaybackState,
+        items: List<LegatoAndroidTrack>,
+        currentIndex: Int?,
+    ): LegatoAndroidPlaybackSnapshot = LegatoAndroidPlaybackSnapshot(
+        state = state,
+        currentTrack = currentIndex?.let(items::getOrNull),
+        currentIndex = currentIndex,
+        positionMs = 0L,
+        durationMs = null,
+        bufferedPositionMs = null,
+        queue = LegatoAndroidQueueSnapshot(items = items, currentIndex = currentIndex),
+    )
+
+    private fun track(id: String): LegatoAndroidTrack = LegatoAndroidTrack(
+        id = id,
+        url = "https://example.com/$id.mp3",
+    )
+}

--- a/native/android/core/src/test/kotlin/io/legato/core/runtime/LegatoAndroidMedia3PlaybackRuntimeTest.kt
+++ b/native/android/core/src/test/kotlin/io/legato/core/runtime/LegatoAndroidMedia3PlaybackRuntimeTest.kt
@@ -1,10 +1,13 @@
 package io.legato.core.runtime
 
+import androidx.media3.common.Player
 import io.legato.core.core.LegatoAndroidPlaybackState
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Proxy
 
 class LegatoAndroidMedia3PlaybackRuntimeTest {
     @Test
@@ -23,6 +26,22 @@ class LegatoAndroidMedia3PlaybackRuntimeTest {
     }
 
     @Test
+    fun `dispatch progress can update active runtime index`() {
+        val runtime = LegatoAndroidMedia3PlaybackRuntime()
+
+        runtime.dispatchProgress(
+            positionMs = 2_000L,
+            durationMs = 120_000L,
+            bufferedPositionMs = 8_000L,
+            currentIndex = 1,
+        )
+
+        val snapshot = runtime.snapshot()
+        assertEquals(1, snapshot.currentIndex)
+        assertEquals(2_000L, snapshot.progress.positionMs)
+    }
+
+    @Test
     fun `dispatch buffering toggles buffering state and emits callback`() {
         val runtime = LegatoAndroidMedia3PlaybackRuntime()
         val listener = RecordingListener()
@@ -35,6 +54,92 @@ class LegatoAndroidMedia3PlaybackRuntimeTest {
         runtime.dispatchBuffering(isBuffering = false)
         assertFalse(listener.lastBuffering)
     }
+
+    @Test
+    fun `play executes player access through command executor`() {
+        val playerCalls = mutableListOf<String>()
+        val player = recordingPlayer(playerCalls, playbackState = Player.STATE_READY)
+        val executor = QueueingCommandExecutor()
+        val runtime = LegatoAndroidMedia3PlaybackRuntime(player = player, playerCommandExecutor = executor)
+
+        runtime.play()
+
+        assertEquals(1, executor.calls)
+        assertTrue(playerCalls.isEmpty())
+
+        executor.runAll()
+
+        assertEquals(listOf("play"), playerCalls)
+    }
+
+    @Test
+    fun `select index executes player access through command executor`() {
+        val playerCalls = mutableListOf<String>()
+        val player = recordingPlayer(playerCalls)
+        val executor = QueueingCommandExecutor()
+        val runtime = LegatoAndroidMedia3PlaybackRuntime(player = player, playerCommandExecutor = executor)
+
+        runtime.selectIndex(3)
+
+        assertEquals(1, executor.calls)
+        assertTrue(playerCalls.isEmpty())
+
+        executor.runAll()
+
+        assertEquals(listOf("seekToDefaultPosition"), playerCalls)
+    }
+
+    @Test
+    fun `play prepares player when runtime is idle`() {
+        val playerCalls = mutableListOf<String>()
+        val player = recordingPlayer(playerCalls)
+        val executor = QueueingCommandExecutor()
+        val runtime = LegatoAndroidMedia3PlaybackRuntime(player = player, playerCommandExecutor = executor)
+
+        runtime.play()
+
+        executor.runAll()
+
+        assertEquals(listOf("prepare", "play"), playerCalls)
+    }
+}
+
+private class QueueingCommandExecutor : PlayerCommandExecutor {
+    private val queued = mutableListOf<() -> Unit>()
+    var calls: Int = 0
+
+    override fun execute(operation: () -> Unit) {
+        calls += 1
+        queued += operation
+    }
+
+    fun runAll() {
+        queued.toList().forEach { operation -> operation() }
+        queued.clear()
+    }
+}
+
+private fun recordingPlayer(calls: MutableList<String>, playbackState: Int = Player.STATE_IDLE): Player {
+    val handler = InvocationHandler { _, method, _ ->
+        when (method.name) {
+            "play", "seekToDefaultPosition", "prepare" -> calls += method.name
+        }
+
+        if (method.name == "getPlaybackState") {
+            return@InvocationHandler playbackState
+        }
+
+        when (method.returnType) {
+            java.lang.Boolean.TYPE -> false
+            java.lang.Integer.TYPE -> 0
+            java.lang.Long.TYPE -> 0L
+            java.lang.Float.TYPE -> 0f
+            java.lang.Double.TYPE -> 0.0
+            else -> null
+        }
+    }
+
+    return Proxy.newProxyInstance(Player::class.java.classLoader, arrayOf(Player::class.java), handler) as Player
 }
 
 private class RecordingListener : LegatoAndroidPlaybackRuntimeListener {

--- a/native/ios/LegatoCore/Package.swift
+++ b/native/ios/LegatoCore/Package.swift
@@ -16,6 +16,11 @@ let package = Package(
         .target(
             name: "LegatoCore",
             path: "Sources/LegatoCore"
+        ),
+        .testTarget(
+            name: "LegatoCoreTests",
+            dependencies: ["LegatoCore"],
+            path: "Tests/LegatoCoreTests"
         )
     ]
 )

--- a/native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSModels.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSModels.swift
@@ -115,6 +115,18 @@ public struct LegatoiOSPlaybackSnapshot {
     }
 }
 
+public struct LegatoiOSTransportCapabilities: Equatable {
+    public let canSkipNext: Bool
+    public let canSkipPrevious: Bool
+    public let canSeek: Bool
+
+    public init(canSkipNext: Bool, canSkipPrevious: Bool, canSeek: Bool) {
+        self.canSkipNext = canSkipNext
+        self.canSkipPrevious = canSkipPrevious
+        self.canSeek = canSeek
+    }
+}
+
 public struct LegatoiOSNowPlayingMetadata {
     public let trackId: String
     public let title: String?

--- a/native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSPlayerEngine.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSPlayerEngine.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 public final class LegatoiOSPlayerEngine: LegatoiOSPlaybackRuntimeObserver {
+    private static let previousRestartThresholdMs: Int64 = 3_000
+
     private let queueManager: LegatoiOSQueueManager
     private let eventEmitter: LegatoiOSEventEmitter
     private let snapshotStore: LegatoiOSSnapshotStore
@@ -56,6 +58,9 @@ public final class LegatoiOSPlayerEngine: LegatoiOSPlaybackRuntimeObserver {
         registerSessionSignalListenerIfNeeded()
         sessionManager.configureSession()
         remoteCommandManager.bind(handler: onRemoteCommand)
+        remoteCommandManager.updateTransportCapabilities(
+            LegatoiOSTransportCapabilitiesProjector.fromSnapshot(snapshotStore.getPlaybackSnapshot())
+        )
         playbackRuntime.configure()
         playbackRuntime.setObserver(self)
         isSetup = true
@@ -132,6 +137,7 @@ public final class LegatoiOSPlayerEngine: LegatoiOSPlaybackRuntimeObserver {
     public func skipToNext() throws {
         try guardSetup()
         guard let movedIndex = queueManager.moveToNext() else {
+            emitEndedAtQueueBoundaryIfNeeded()
             return
         }
 
@@ -156,6 +162,21 @@ public final class LegatoiOSPlayerEngine: LegatoiOSPlaybackRuntimeObserver {
 
     public func skipToPrevious() throws {
         try guardSetup()
+        let currentSnapshot = snapshotStore.getPlaybackSnapshot()
+        guard let currentIndex = currentSnapshot.currentIndex else {
+            return
+        }
+
+        if currentSnapshot.positionMs > Self.previousRestartThresholdMs {
+            try seek(to: 0)
+            return
+        }
+
+        if currentIndex <= 0 {
+            try seek(to: 0)
+            return
+        }
+
         guard let movedIndex = queueManager.moveToPrevious() else {
             return
         }
@@ -360,6 +381,10 @@ public final class LegatoiOSPlayerEngine: LegatoiOSPlaybackRuntimeObserver {
                 queue: queueOverride ?? previous.queue
             )
         }
+
+        remoteCommandManager.updateTransportCapabilities(
+            LegatoiOSTransportCapabilitiesProjector.fromSnapshot(snapshotStore.getPlaybackSnapshot())
+        )
     }
 
     private func shouldApplyRuntimeStateHint(
@@ -568,17 +593,39 @@ public final class LegatoiOSPlayerEngine: LegatoiOSPlaybackRuntimeObserver {
     private func onRemoteCommand(_ command: LegatoiOSRemoteCommand) {
         switch command {
         case .play:
+            try? play()
             eventEmitter.emit(name: .remotePlay, payload: .remotePlay)
         case .pause:
+            try? pause()
             eventEmitter.emit(name: .remotePause, payload: .remotePause)
         case .next:
+            try? skipToNext()
             eventEmitter.emit(name: .remoteNext, payload: .remoteNext)
         case .previous:
+            try? skipToPrevious()
             eventEmitter.emit(name: .remotePrevious, payload: .remotePrevious)
         case .seek(let positionMs):
+            try? seek(to: positionMs)
             eventEmitter.emit(name: .remoteSeek, payload: .remoteSeek(positionMs: positionMs))
         }
+    }
 
-        // TODO(phase-4): Route remote commands through canonical transport command handlers.
+    private func emitEndedAtQueueBoundaryIfNeeded() {
+        let snapshot = snapshotStore.getPlaybackSnapshot()
+        guard let currentIndex = snapshot.currentIndex else {
+            return
+        }
+
+        let items = snapshot.queue.items
+        guard !items.isEmpty, currentIndex == items.count - 1 else {
+            return
+        }
+
+        transition(event: .trackEnded)
+        let endedSnapshot = snapshotStore.getPlaybackSnapshot()
+        remoteCommandManager.updateTransportCapabilities(
+            LegatoiOSTransportCapabilitiesProjector.fromSnapshot(endedSnapshot)
+        )
+        eventEmitter.emit(name: .playbackEnded, payload: .playbackEnded(snapshot: endedSnapshot))
     }
 }

--- a/native/ios/LegatoCore/Sources/LegatoCore/Queue/LegatoiOSTransportCapabilitiesProjector.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCore/Queue/LegatoiOSTransportCapabilitiesProjector.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public enum LegatoiOSTransportCapabilitiesProjector {
+    public static func fromSnapshot(_ snapshot: LegatoiOSPlaybackSnapshot) -> LegatoiOSTransportCapabilities {
+        if snapshot.state == .ended {
+            return LegatoiOSTransportCapabilities(canSkipNext: false, canSkipPrevious: false, canSeek: false)
+        }
+
+        let queueItems = snapshot.queue.items
+        guard !queueItems.isEmpty else {
+            return LegatoiOSTransportCapabilities(canSkipNext: false, canSkipPrevious: false, canSeek: false)
+        }
+
+        let resolvedIndex = snapshot.currentIndex ?? snapshot.queue.currentIndex
+        guard let index = resolvedIndex, queueItems.indices.contains(index) else {
+            return LegatoiOSTransportCapabilities(canSkipNext: false, canSkipPrevious: false, canSeek: false)
+        }
+
+        return LegatoiOSTransportCapabilities(
+            canSkipNext: index < queueItems.count - 1,
+            canSkipPrevious: index > 0,
+            canSeek: true
+        )
+    }
+}

--- a/native/ios/LegatoCore/Sources/LegatoCore/Remote/LegatoiOSRemoteCommandManager.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCore/Remote/LegatoiOSRemoteCommandManager.swift
@@ -4,7 +4,7 @@ public final class LegatoiOSRemoteCommandManager {
     private let runtime: LegatoiOSRemoteCommandRuntime
     private var commandHandler: ((LegatoiOSRemoteCommand) -> Void)?
 
-    public init(runtime: LegatoiOSRemoteCommandRuntime = LegatoiOSNoopRemoteCommandRuntime()) {
+    public init(runtime: LegatoiOSRemoteCommandRuntime = LegatoiOSMediaPlayerRemoteCommandRuntime()) {
         self.runtime = runtime
     }
 
@@ -15,6 +15,10 @@ public final class LegatoiOSRemoteCommandManager {
 
     public func updatePlaybackState(_ state: LegatoiOSPlaybackState) {
         runtime.updatePlaybackState(state)
+    }
+
+    public func updateTransportCapabilities(_ capabilities: LegatoiOSTransportCapabilities) {
+        runtime.updateTransportCapabilities(capabilities)
     }
 
     public func unbind() {

--- a/native/ios/LegatoCore/Sources/LegatoCore/Remote/LegatoiOSRemoteCommandRuntime.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCore/Remote/LegatoiOSRemoteCommandRuntime.swift
@@ -4,7 +4,98 @@ import Foundation
 public protocol LegatoiOSRemoteCommandRuntime {
     func bind(dispatch: @escaping (LegatoiOSRemoteCommand) -> Void)
     func updatePlaybackState(_ state: LegatoiOSPlaybackState)
+    func updateTransportCapabilities(_ capabilities: LegatoiOSTransportCapabilities)
     func unbind()
+}
+
+public protocol LegatoiOSRemoteCommandCenter {
+    var playCommand: LegatoiOSRemoteCommandHandler { get }
+    var pauseCommand: LegatoiOSRemoteCommandHandler { get }
+    var nextTrackCommand: LegatoiOSRemoteCommandHandler { get }
+    var previousTrackCommand: LegatoiOSRemoteCommandHandler { get }
+    var changePlaybackPositionCommand: LegatoiOSChangePlaybackPositionCommandHandler { get }
+}
+
+public protocol LegatoiOSRemoteCommandHandler: AnyObject {
+    var isEnabled: Bool { get set }
+
+    @discardableResult
+    func addTarget(_ handler: @escaping () -> Void) -> AnyObject
+
+    func removeTarget(_ token: AnyObject)
+}
+
+public protocol LegatoiOSChangePlaybackPositionCommandHandler: AnyObject {
+    var isEnabled: Bool { get set }
+
+    @discardableResult
+    func addTarget(_ handler: @escaping (_ positionTimeSeconds: Double) -> Void) -> AnyObject
+
+    func removeTarget(_ token: AnyObject)
+}
+
+public final class LegatoiOSMediaPlayerRemoteCommandRuntime: LegatoiOSRemoteCommandRuntime {
+    private let commandCenter: LegatoiOSRemoteCommandCenter
+    private var bindings: [Binding] = []
+
+    private struct Binding {
+        let command: LegatoiOSRemoteCommandHandler
+        let token: AnyObject
+    }
+
+    private struct PositionBinding {
+        let command: LegatoiOSChangePlaybackPositionCommandHandler
+        let token: AnyObject
+    }
+
+    private var positionBinding: PositionBinding?
+
+    public init(commandCenter: LegatoiOSRemoteCommandCenter = LegatoiOSLiveRemoteCommandCenter()) {
+        self.commandCenter = commandCenter
+    }
+
+    public func bind(dispatch: @escaping (LegatoiOSRemoteCommand) -> Void) {
+        unbind()
+
+        bindings = [
+            bind(commandCenter.playCommand) { dispatch(.play) },
+            bind(commandCenter.pauseCommand) { dispatch(.pause) },
+            bind(commandCenter.nextTrackCommand) { dispatch(.next) },
+            bind(commandCenter.previousTrackCommand) { dispatch(.previous) }
+        ]
+
+        let token = commandCenter.changePlaybackPositionCommand.addTarget { positionTimeSeconds in
+            let ms = max(0, Int64((positionTimeSeconds * 1_000.0).rounded()))
+            dispatch(.seek(positionMs: ms))
+        }
+        positionBinding = PositionBinding(command: commandCenter.changePlaybackPositionCommand, token: token)
+    }
+
+    public func updatePlaybackState(_ state: LegatoiOSPlaybackState) {
+        commandCenter.playCommand.isEnabled = state != .playing && state != .buffering
+        commandCenter.pauseCommand.isEnabled = state == .playing || state == .buffering
+    }
+
+    public func updateTransportCapabilities(_ capabilities: LegatoiOSTransportCapabilities) {
+        commandCenter.nextTrackCommand.isEnabled = capabilities.canSkipNext
+        commandCenter.previousTrackCommand.isEnabled = capabilities.canSkipPrevious
+        commandCenter.changePlaybackPositionCommand.isEnabled = capabilities.canSeek
+    }
+
+    public func unbind() {
+        bindings.forEach { $0.command.removeTarget($0.token) }
+        bindings.removeAll()
+
+        if let positionBinding {
+            positionBinding.command.removeTarget(positionBinding.token)
+            self.positionBinding = nil
+        }
+    }
+
+    private func bind(_ command: LegatoiOSRemoteCommandHandler, handler: @escaping () -> Void) -> Binding {
+        let token = command.addTarget(handler)
+        return Binding(command: command, token: token)
+    }
 }
 
 public final class LegatoiOSNoopRemoteCommandRuntime: LegatoiOSRemoteCommandRuntime {
@@ -18,7 +109,126 @@ public final class LegatoiOSNoopRemoteCommandRuntime: LegatoiOSRemoteCommandRunt
         // Intentionally no-op.
     }
 
+    public func updateTransportCapabilities(_ capabilities: LegatoiOSTransportCapabilities) {
+        // Intentionally no-op.
+    }
+
     public func unbind() {
         // Intentionally no-op.
     }
 }
+
+#if canImport(MediaPlayer) && os(iOS)
+import MediaPlayer
+
+public final class LegatoiOSLiveRemoteCommandCenter: LegatoiOSRemoteCommandCenter {
+    private let commandCenter: MPRemoteCommandCenter
+
+    public init(commandCenter: MPRemoteCommandCenter = .shared()) {
+        self.commandCenter = commandCenter
+    }
+
+    public var playCommand: LegatoiOSRemoteCommandHandler {
+        LegatoiOSLiveRemoteCommand(command: commandCenter.playCommand)
+    }
+
+    public var pauseCommand: LegatoiOSRemoteCommandHandler {
+        LegatoiOSLiveRemoteCommand(command: commandCenter.pauseCommand)
+    }
+
+    public var nextTrackCommand: LegatoiOSRemoteCommandHandler {
+        LegatoiOSLiveRemoteCommand(command: commandCenter.nextTrackCommand)
+    }
+
+    public var previousTrackCommand: LegatoiOSRemoteCommandHandler {
+        LegatoiOSLiveRemoteCommand(command: commandCenter.previousTrackCommand)
+    }
+
+    public var changePlaybackPositionCommand: LegatoiOSChangePlaybackPositionCommandHandler {
+        LegatoiOSLiveChangePlaybackPositionCommand(command: commandCenter.changePlaybackPositionCommand)
+    }
+}
+
+private final class LegatoiOSLiveRemoteCommand: LegatoiOSRemoteCommandHandler {
+    private let command: MPRemoteCommand
+
+    init(command: MPRemoteCommand) {
+        self.command = command
+    }
+
+    var isEnabled: Bool {
+        get { command.isEnabled }
+        set { command.isEnabled = newValue }
+    }
+
+    @discardableResult
+    func addTarget(_ handler: @escaping () -> Void) -> AnyObject {
+        command.addTarget { _ in
+            handler()
+            return .success
+        }
+    }
+
+    func removeTarget(_ token: AnyObject) {
+        command.removeTarget(token)
+    }
+}
+
+private final class LegatoiOSLiveChangePlaybackPositionCommand: LegatoiOSChangePlaybackPositionCommandHandler {
+    private let command: MPChangePlaybackPositionCommand
+
+    init(command: MPChangePlaybackPositionCommand) {
+        self.command = command
+    }
+
+    var isEnabled: Bool {
+        get { command.isEnabled }
+        set { command.isEnabled = newValue }
+    }
+
+    @discardableResult
+    func addTarget(_ handler: @escaping (Double) -> Void) -> AnyObject {
+        command.addTarget { event in
+            guard let positionEvent = event as? MPChangePlaybackPositionCommandEvent else {
+                return .commandFailed
+            }
+            handler(positionEvent.positionTime)
+            return .success
+        }
+    }
+
+    func removeTarget(_ token: AnyObject) {
+        command.removeTarget(token)
+    }
+}
+#else
+public final class LegatoiOSLiveRemoteCommandCenter: LegatoiOSRemoteCommandCenter {
+    public init() {}
+
+    public var playCommand: LegatoiOSRemoteCommandHandler { NoopRemoteCommand() }
+    public var pauseCommand: LegatoiOSRemoteCommandHandler { NoopRemoteCommand() }
+    public var nextTrackCommand: LegatoiOSRemoteCommandHandler { NoopRemoteCommand() }
+    public var previousTrackCommand: LegatoiOSRemoteCommandHandler { NoopRemoteCommand() }
+    public var changePlaybackPositionCommand: LegatoiOSChangePlaybackPositionCommandHandler {
+        NoopChangePlaybackPositionCommand()
+    }
+}
+
+private final class NoopRemoteCommand: LegatoiOSRemoteCommandHandler {
+    var isEnabled: Bool = false
+
+    @discardableResult
+    func addTarget(_ handler: @escaping () -> Void) -> AnyObject { NSObject() }
+
+    func removeTarget(_ token: AnyObject) {}
+}
+
+private final class NoopChangePlaybackPositionCommand: LegatoiOSChangePlaybackPositionCommandHandler {
+    var isEnabled: Bool = false
+
+    @discardableResult
+    func addTarget(_ handler: @escaping (Double) -> Void) -> AnyObject { NSObject() }
+
+    func removeTarget(_ token: AnyObject) {}
+}
+#endif

--- a/native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSNowPlayingManager.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSNowPlayingManager.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class LegatoiOSNowPlayingManager {
     private let runtime: LegatoiOSNowPlayingRuntime
 
-    public init(runtime: LegatoiOSNowPlayingRuntime = LegatoiOSNoopNowPlayingRuntime()) {
+    public init(runtime: LegatoiOSNowPlayingRuntime = LegatoiOSMediaPlayerNowPlayingRuntime()) {
         self.runtime = runtime
     }
 

--- a/native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSNowPlayingRuntime.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSNowPlayingRuntime.swift
@@ -7,6 +7,67 @@ public protocol LegatoiOSNowPlayingRuntime {
     func clear()
 }
 
+public protocol LegatoiOSNowPlayingInfoCenter: AnyObject {
+    var nowPlayingInfo: [String: Any]? { get set }
+}
+
+public enum LegatoiOSNowPlayingInfoKey {
+    public static let trackIdentifier = "legato.track.id"
+    public static let title = "title"
+    public static let artist = "artist"
+    public static let album = "albumTitle"
+    public static let duration = "playbackDuration"
+    public static let elapsedTime = "elapsedPlaybackTime"
+}
+
+public final class LegatoiOSMediaPlayerNowPlayingRuntime: LegatoiOSNowPlayingRuntime {
+    private let infoCenter: LegatoiOSNowPlayingInfoCenter
+
+    public init(infoCenter: LegatoiOSNowPlayingInfoCenter = LegatoiOSLiveNowPlayingInfoCenter()) {
+        self.infoCenter = infoCenter
+    }
+
+    public func updateMetadata(_ metadata: LegatoiOSNowPlayingMetadata?) {
+        guard let metadata else {
+            clear()
+            return
+        }
+
+        var info = infoCenter.nowPlayingInfo ?? [:]
+        info[LegatoiOSNowPlayingInfoKey.trackIdentifier] = metadata.trackId
+        info[LegatoiOSNowPlayingInfoKey.title] = metadata.title
+        info[LegatoiOSNowPlayingInfoKey.artist] = metadata.artist
+        info[LegatoiOSNowPlayingInfoKey.album] = metadata.album
+
+        if let durationMs = metadata.durationMs {
+            info[LegatoiOSNowPlayingInfoKey.duration] = Self.seconds(fromMs: durationMs)
+        } else {
+            info.removeValue(forKey: LegatoiOSNowPlayingInfoKey.duration)
+        }
+
+        infoCenter.nowPlayingInfo = info
+    }
+
+    public func updateProgress(_ progress: LegatoiOSProgressUpdate) {
+        var info = infoCenter.nowPlayingInfo ?? [:]
+        info[LegatoiOSNowPlayingInfoKey.elapsedTime] = Self.seconds(fromMs: progress.positionMs)
+
+        if let durationMs = progress.durationMs {
+            info[LegatoiOSNowPlayingInfoKey.duration] = Self.seconds(fromMs: durationMs)
+        }
+
+        infoCenter.nowPlayingInfo = info
+    }
+
+    public func clear() {
+        infoCenter.nowPlayingInfo = nil
+    }
+
+    private static func seconds(fromMs value: Int64) -> Double {
+        Double(max(0, value)) / 1_000.0
+    }
+}
+
 public final class LegatoiOSNoopNowPlayingRuntime: LegatoiOSNowPlayingRuntime {
     public init() {}
 
@@ -22,3 +83,26 @@ public final class LegatoiOSNoopNowPlayingRuntime: LegatoiOSNowPlayingRuntime {
         // Intentionally no-op.
     }
 }
+
+#if canImport(MediaPlayer) && os(iOS)
+import MediaPlayer
+
+public final class LegatoiOSLiveNowPlayingInfoCenter: LegatoiOSNowPlayingInfoCenter {
+    private let infoCenter: MPNowPlayingInfoCenter
+
+    public init(infoCenter: MPNowPlayingInfoCenter = .default()) {
+        self.infoCenter = infoCenter
+    }
+
+    public var nowPlayingInfo: [String: Any]? {
+        get { infoCenter.nowPlayingInfo }
+        set { infoCenter.nowPlayingInfo = newValue }
+    }
+}
+#else
+public final class LegatoiOSLiveNowPlayingInfoCenter: LegatoiOSNowPlayingInfoCenter {
+    public var nowPlayingInfo: [String: Any]?
+
+    public init() {}
+}
+#endif

--- a/native/ios/LegatoCore/Tests/LegatoCoreTests/Remote/LegatoiOSRemoteCommandRuntimeTests.swift
+++ b/native/ios/LegatoCore/Tests/LegatoCoreTests/Remote/LegatoiOSRemoteCommandRuntimeTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+@testable import LegatoCore
+
+final class LegatoiOSRemoteCommandRuntimeTests: XCTestCase {
+    func testBindRegistersAllHandlersAndDispatchesCommands() {
+        let center = FakeRemoteCommandCenter()
+        let runtime = LegatoiOSMediaPlayerRemoteCommandRuntime(commandCenter: center)
+        var received: [LegatoiOSRemoteCommand] = []
+
+        runtime.bind { received.append($0) }
+
+        center.playCommand.trigger()
+        center.pauseCommand.trigger()
+        center.nextTrackCommand.trigger()
+        center.previousTrackCommand.trigger()
+        center.changePlaybackPositionCommand.trigger(positionTimeSeconds: 42.5)
+
+        XCTAssertEqual(received.count, 5)
+        if case .play = received[0] {} else { XCTFail("Expected play command") }
+        if case .pause = received[1] {} else { XCTFail("Expected pause command") }
+        if case .next = received[2] {} else { XCTFail("Expected next command") }
+        if case .previous = received[3] {} else { XCTFail("Expected previous command") }
+
+        if case let .seek(positionMs) = received[4] {
+            XCTAssertEqual(positionMs, 42_500)
+        } else {
+            XCTFail("Expected seek command")
+        }
+    }
+
+    func testUpdateTransportCapabilitiesTogglesNextPreviousSeek() {
+        let center = FakeRemoteCommandCenter()
+        let runtime = LegatoiOSMediaPlayerRemoteCommandRuntime(commandCenter: center)
+
+        runtime.bind { _ in }
+        runtime.updateTransportCapabilities(.init(canSkipNext: false, canSkipPrevious: true, canSeek: false))
+
+        XCTAssertFalse(center.nextTrackCommand.isEnabled)
+        XCTAssertTrue(center.previousTrackCommand.isEnabled)
+        XCTAssertFalse(center.changePlaybackPositionCommand.isEnabled)
+    }
+
+    func testUnbindRemovesRegisteredHandlers() {
+        let center = FakeRemoteCommandCenter()
+        let runtime = LegatoiOSMediaPlayerRemoteCommandRuntime(commandCenter: center)
+
+        runtime.bind { _ in }
+        runtime.unbind()
+
+        XCTAssertEqual(center.playCommand.removeTargetCount, 1)
+        XCTAssertEqual(center.pauseCommand.removeTargetCount, 1)
+        XCTAssertEqual(center.nextTrackCommand.removeTargetCount, 1)
+        XCTAssertEqual(center.previousTrackCommand.removeTargetCount, 1)
+        XCTAssertEqual(center.changePlaybackPositionCommand.removeTargetCount, 1)
+    }
+}
+
+private final class FakeRemoteCommandCenter: LegatoiOSRemoteCommandCenter {
+    let playCommand = FakeButtonCommand()
+    let pauseCommand = FakeButtonCommand()
+    let nextTrackCommand = FakeButtonCommand()
+    let previousTrackCommand = FakeButtonCommand()
+    let changePlaybackPositionCommand = FakePositionCommand()
+}
+
+private final class FakeButtonCommand: LegatoiOSRemoteCommandHandler {
+    var isEnabled: Bool = false
+    private var handlerByToken: [UUID: () -> Void] = [:]
+    private(set) var removeTargetCount = 0
+
+    @discardableResult
+    func addTarget(_ handler: @escaping () -> Void) -> AnyObject {
+        let token = UUID()
+        handlerByToken[token] = handler
+        return token as NSUUID
+    }
+
+    func removeTarget(_ token: AnyObject) {
+        removeTargetCount += 1
+        if let uuid = token as? NSUUID {
+            handlerByToken.removeValue(forKey: uuid as UUID)
+        }
+    }
+
+    func trigger() {
+        handlerByToken.values.forEach { $0() }
+    }
+}
+
+private final class FakePositionCommand: LegatoiOSChangePlaybackPositionCommandHandler {
+    var isEnabled: Bool = false
+    private var handlerByToken: [UUID: (Double) -> Void] = [:]
+    private(set) var removeTargetCount = 0
+
+    @discardableResult
+    func addTarget(_ handler: @escaping (Double) -> Void) -> AnyObject {
+        let token = UUID()
+        handlerByToken[token] = handler
+        return token as NSUUID
+    }
+
+    func removeTarget(_ token: AnyObject) {
+        removeTargetCount += 1
+        if let uuid = token as? NSUUID {
+            handlerByToken.removeValue(forKey: uuid as UUID)
+        }
+    }
+
+    func trigger(positionTimeSeconds: Double) {
+        handlerByToken.values.forEach { $0(positionTimeSeconds) }
+    }
+}

--- a/native/ios/LegatoCore/Tests/LegatoCoreTests/Session/LegatoiOSNowPlayingRuntimeTests.swift
+++ b/native/ios/LegatoCore/Tests/LegatoCoreTests/Session/LegatoiOSNowPlayingRuntimeTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import LegatoCore
+
+final class LegatoiOSNowPlayingRuntimeTests: XCTestCase {
+    func testUpdateMetadataWritesTextFieldsAndDuration() {
+        let center = FakeNowPlayingInfoCenter()
+        let runtime = LegatoiOSMediaPlayerNowPlayingRuntime(infoCenter: center)
+
+        runtime.updateMetadata(
+            .init(
+                trackId: "track-1",
+                title: "Song",
+                artist: "Artist",
+                album: "Album",
+                durationMs: 90_000
+            )
+        )
+
+        let info = center.nowPlayingInfo
+        XCTAssertEqual(info?[LegatoiOSNowPlayingInfoKey.trackIdentifier] as? String, "track-1")
+        XCTAssertEqual(info?[LegatoiOSNowPlayingInfoKey.title] as? String, "Song")
+        XCTAssertEqual(info?[LegatoiOSNowPlayingInfoKey.artist] as? String, "Artist")
+        XCTAssertEqual(info?[LegatoiOSNowPlayingInfoKey.album] as? String, "Album")
+        XCTAssertEqual(info?[LegatoiOSNowPlayingInfoKey.duration] as? Double, 90)
+    }
+
+    func testUpdateProgressWritesElapsedAndUpdatesDurationWhenPresent() {
+        let center = FakeNowPlayingInfoCenter()
+        let runtime = LegatoiOSMediaPlayerNowPlayingRuntime(infoCenter: center)
+
+        runtime.updateProgress(.init(positionMs: 15_500, durationMs: 120_000, bufferedPositionMs: nil))
+
+        let info = center.nowPlayingInfo
+        XCTAssertEqual(info?[LegatoiOSNowPlayingInfoKey.elapsedTime] as? Double, 15.5)
+        XCTAssertEqual(info?[LegatoiOSNowPlayingInfoKey.duration] as? Double, 120)
+    }
+
+    func testClearRemovesNowPlayingInfo() {
+        let center = FakeNowPlayingInfoCenter()
+        center.nowPlayingInfo = [LegatoiOSNowPlayingInfoKey.title: "Song"]
+        let runtime = LegatoiOSMediaPlayerNowPlayingRuntime(infoCenter: center)
+
+        runtime.clear()
+
+        XCTAssertNil(center.nowPlayingInfo)
+    }
+}
+
+private final class FakeNowPlayingInfoCenter: LegatoiOSNowPlayingInfoCenter {
+    var nowPlayingInfo: [String: Any]?
+}

--- a/packages/capacitor/android/build.gradle
+++ b/packages/capacitor/android/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation project(':capacitor-android')
     // Explicitly pinned for now to keep coroutine behavior stable in this monorepo.
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1'
+    implementation 'androidx.media3:media3-exoplayer:1.4.1'
 
     testImplementation 'junit:junit:4.13.2'
 }

--- a/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoAndroidPlaybackCoordinator.kt
+++ b/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoAndroidPlaybackCoordinator.kt
@@ -3,11 +3,15 @@ package io.legato.capacitor
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import androidx.media3.exoplayer.ExoPlayer
 import io.legato.core.core.LegatoAndroidCoreComponents
+import io.legato.core.core.LegatoAndroidCoreDependencies
 import io.legato.core.core.LegatoAndroidCoreFactory
 import io.legato.core.core.LegatoAndroidPauseOrigin
 import io.legato.core.core.LegatoAndroidPlaybackState
 import io.legato.core.core.LegatoAndroidServiceMode
+import io.legato.core.core.LegatoAndroidTrack
+import io.legato.core.runtime.LegatoAndroidMedia3PlaybackRuntime
 import java.util.concurrent.atomic.AtomicLong
 
 internal fun interface LegatoAndroidCoordinatorServiceRuntime {
@@ -75,6 +79,14 @@ internal class LegatoAndroidPlaybackCoordinator(
         projectPlaybackState()
     }
 
+    fun add(tracks: List<LegatoAndroidTrack>, startIndex: Int? = null) {
+        kotlinx.coroutines.runBlocking {
+            core.playerEngine.add(tracks = tracks, startIndex = startIndex)
+        }
+        projectServiceMode()
+        projectPlaybackState()
+    }
+
     fun play() {
         kotlinx.coroutines.runBlocking { core.playerEngine.play() }
         projectServiceMode()
@@ -107,6 +119,12 @@ internal class LegatoAndroidPlaybackCoordinator(
 
     fun skipToPrevious() {
         kotlinx.coroutines.runBlocking { core.playerEngine.skipToPrevious() }
+        projectServiceMode()
+        projectPlaybackState()
+    }
+
+    fun skipTo(index: Int) {
+        kotlinx.coroutines.runBlocking { core.playerEngine.skipTo(index) }
         projectServiceMode()
         projectPlaybackState()
     }
@@ -202,8 +220,16 @@ internal object LegatoAndroidPlaybackCoordinatorStore {
     private val lock = Any()
     private var coordinator: LegatoAndroidPlaybackCoordinator? = null
 
-    fun getOrCreate(): LegatoAndroidPlaybackCoordinator = synchronized(lock) {
-        coordinator ?: LegatoAndroidPlaybackCoordinator(core = LegatoAndroidCoreFactory.create()).also {
+    fun getOrCreate(appContext: Context): LegatoAndroidPlaybackCoordinator = synchronized(lock) {
+        coordinator ?: LegatoAndroidPlaybackCoordinator(
+            core = LegatoAndroidCoreFactory.create(
+                dependencies = LegatoAndroidCoreDependencies(
+                    playbackRuntime = LegatoAndroidMedia3PlaybackRuntime(
+                        player = ExoPlayer.Builder(appContext).build(),
+                    ),
+                ),
+            ),
+        ).also {
             coordinator = it
         }
     }

--- a/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackNotificationTransport.kt
+++ b/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackNotificationTransport.kt
@@ -1,11 +1,21 @@
 package io.legato.capacitor
 
+import android.media.session.PlaybackState
 import io.legato.core.core.LegatoAndroidPlaybackState
+import io.legato.core.core.LegatoAndroidRemoteCommand
+import io.legato.core.core.LegatoAndroidTransportCapabilities
 import io.legato.core.remote.LegatoAndroidMediaSessionBridge
 
 internal object LegatoPlaybackNotificationTransport {
+    data class NotificationActionModel(
+        val intentAction: String,
+        val label: String,
+    )
+
     const val ACTION_PLAY: String = "io.legato.capacitor.action.PLAY"
     const val ACTION_PAUSE: String = "io.legato.capacitor.action.PAUSE"
+    const val ACTION_NEXT: String = "io.legato.capacitor.action.NEXT"
+    const val ACTION_PREVIOUS: String = "io.legato.capacitor.action.PREVIOUS"
 
     fun projectedControlFor(state: LegatoAndroidPlaybackState): LegatoAndroidMediaSessionBridge.TransportControl {
         return if (state == LegatoAndroidPlaybackState.PLAYING || state == LegatoAndroidPlaybackState.BUFFERING) {
@@ -21,5 +31,53 @@ internal object LegatoPlaybackNotificationTransport {
             ACTION_PAUSE -> LegatoAndroidMediaSessionBridge.TransportControl.PAUSE
             else -> null
         }
+    }
+
+    fun remoteCommandFromIntentAction(action: String?): LegatoAndroidRemoteCommand? {
+        return when (action) {
+            ACTION_PLAY -> LegatoAndroidRemoteCommand.Play
+            ACTION_PAUSE -> LegatoAndroidRemoteCommand.Pause
+            ACTION_NEXT -> LegatoAndroidRemoteCommand.Next
+            ACTION_PREVIOUS -> LegatoAndroidRemoteCommand.Previous
+            else -> null
+        }
+    }
+
+    fun playbackStateActionsFor(
+        state: LegatoAndroidPlaybackState,
+        capabilities: LegatoAndroidTransportCapabilities,
+    ): Long {
+        var actions = PlaybackState.ACTION_PLAY or PlaybackState.ACTION_PAUSE
+        if (capabilities.canSeek) {
+            actions = actions or PlaybackState.ACTION_SEEK_TO
+        }
+        if (capabilities.canSkipNext) {
+            actions = actions or PlaybackState.ACTION_SKIP_TO_NEXT
+        }
+        if (capabilities.canSkipPrevious) {
+            actions = actions or PlaybackState.ACTION_SKIP_TO_PREVIOUS
+        }
+        return actions
+    }
+
+    fun notificationActionModelFor(
+        state: LegatoAndroidPlaybackState,
+        capabilities: LegatoAndroidTransportCapabilities,
+    ): List<NotificationActionModel> {
+        val actions = mutableListOf<NotificationActionModel>()
+        if (capabilities.canSkipPrevious) {
+            actions += NotificationActionModel(intentAction = ACTION_PREVIOUS, label = "Previous")
+        }
+
+        val projectedControl = projectedControlFor(state)
+        actions += NotificationActionModel(
+            intentAction = if (projectedControl == LegatoAndroidMediaSessionBridge.TransportControl.PAUSE) ACTION_PAUSE else ACTION_PLAY,
+            label = if (projectedControl == LegatoAndroidMediaSessionBridge.TransportControl.PAUSE) "Pause" else "Play",
+        )
+
+        if (capabilities.canSkipNext) {
+            actions += NotificationActionModel(intentAction = ACTION_NEXT, label = "Next")
+        }
+        return actions
     }
 }

--- a/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackService.kt
+++ b/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackService.kt
@@ -13,21 +13,25 @@ import android.os.Build
 import android.os.IBinder
 import io.legato.core.core.LegatoAndroidPlaybackState
 import io.legato.core.core.LegatoAndroidServiceMode
+import io.legato.core.queue.LegatoAndroidTransportCapabilitiesProjector
 import io.legato.core.remote.LegatoAndroidMediaSessionBridge
 
 class LegatoPlaybackService : Service() {
-    private val coordinator = LegatoAndroidPlaybackCoordinatorStore.getOrCreate()
+    private lateinit var coordinator: LegatoAndroidPlaybackCoordinator
     private var modeListenerId: Long? = null
     private var playbackStateListenerId: Long? = null
     private var foregroundActive: Boolean = false
-    private var currentMode: LegatoAndroidServiceMode = coordinator.currentServiceMode()
-    private var currentPlaybackState: LegatoAndroidPlaybackState = coordinator.currentPlaybackState()
+    private var currentMode: LegatoAndroidServiceMode = LegatoAndroidServiceMode.OFF
+    private var currentPlaybackState: LegatoAndroidPlaybackState = LegatoAndroidPlaybackState.IDLE
     private var mediaSession: MediaSession? = null
 
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onCreate() {
         super.onCreate()
+        coordinator = LegatoAndroidPlaybackCoordinatorStore.getOrCreate(applicationContext)
+        currentMode = coordinator.currentServiceMode()
+        currentPlaybackState = coordinator.currentPlaybackState()
         modeListenerId = coordinator.addServiceModeListener(::onServiceModeChanged)
         playbackStateListenerId = coordinator.addPlaybackStateListener(::onPlaybackStateChanged)
 
@@ -41,6 +45,18 @@ class LegatoPlaybackService : Service() {
                     override fun onPause() {
                         coordinator.core.mediaSessionBridge.dispatchMediaSessionPause()
                     }
+
+                    override fun onSkipToNext() {
+                        coordinator.core.mediaSessionBridge.dispatchMediaSessionSkipToNext()
+                    }
+
+                    override fun onSkipToPrevious() {
+                        coordinator.core.mediaSessionBridge.dispatchMediaSessionSkipToPrevious()
+                    }
+
+                    override fun onSeekTo(pos: Long) {
+                        coordinator.core.mediaSessionBridge.dispatchMediaSessionSeekTo(pos)
+                    }
                 },
             )
             setFlags(MediaSession.FLAG_HANDLES_MEDIA_BUTTONS or MediaSession.FLAG_HANDLES_TRANSPORT_CONTROLS)
@@ -50,9 +66,9 @@ class LegatoPlaybackService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        LegatoPlaybackNotificationTransport.transportControlFromIntentAction(intent?.action)
-            ?.let { control ->
-                coordinator.core.mediaSessionBridge.dispatchTransportControl(control)
+        LegatoPlaybackNotificationTransport.remoteCommandFromIntentAction(intent?.action)
+            ?.let { command ->
+                dispatchNotificationRemoteCommand(command)
                 return START_STICKY
             }
 
@@ -131,17 +147,10 @@ class LegatoPlaybackService : Service() {
             )
         }
 
-        val projectedControl = LegatoPlaybackNotificationTransport.projectedControlFor(currentPlaybackState)
-        val transportPendingIntent = PendingIntent.getService(
-            this,
-            REQUEST_CODE_TRANSPORT,
-            Intent(this, LegatoPlaybackService::class.java).apply {
-                action = when (projectedControl) {
-                    LegatoAndroidMediaSessionBridge.TransportControl.PLAY -> LegatoPlaybackNotificationTransport.ACTION_PLAY
-                    LegatoAndroidMediaSessionBridge.TransportControl.PAUSE -> LegatoPlaybackNotificationTransport.ACTION_PAUSE
-                }
-            },
-            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        val capabilities = LegatoAndroidTransportCapabilitiesProjector.fromSnapshot(coordinator.core.playerEngine.getSnapshot())
+        val notificationActions = LegatoPlaybackNotificationTransport.notificationActionModelFor(
+            state = currentPlaybackState,
+            capabilities = capabilities,
         )
 
         val contentText = when (mode) {
@@ -164,23 +173,31 @@ class LegatoPlaybackService : Service() {
             .setOnlyAlertOnce(true)
             .setCategory(Notification.CATEGORY_TRANSPORT)
             .setContentIntent(launchPendingIntent)
-            .addAction(
+
+        notificationActions.forEachIndexed { index, model ->
+            val actionPendingIntent = PendingIntent.getService(
+                this,
+                REQUEST_CODE_TRANSPORT_BASE + index,
+                Intent(this, LegatoPlaybackService::class.java).apply {
+                    action = model.intentAction
+                },
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
+            builder.addAction(
                 Notification.Action.Builder(
-                    if (projectedControl == LegatoAndroidMediaSessionBridge.TransportControl.PAUSE) {
-                        android.R.drawable.ic_media_pause
-                    } else {
-                        android.R.drawable.ic_media_play
-                    },
-                    if (projectedControl == LegatoAndroidMediaSessionBridge.TransportControl.PAUSE) "Pause" else "Play",
-                    transportPendingIntent,
+                    iconForAction(model.intentAction),
+                    model.label,
+                    actionPendingIntent,
                 ).build(),
             )
+        }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            val compactIndexes = IntArray(minOf(notificationActions.size, MAX_COMPACT_ACTIONS)) { it }
             builder.setStyle(
                 Notification.MediaStyle()
                     .setMediaSession(mediaSession?.sessionToken)
-                    .setShowActionsInCompactView(0),
+                    .setShowActionsInCompactView(*compactIndexes),
             )
         }
 
@@ -188,8 +205,9 @@ class LegatoPlaybackService : Service() {
     }
 
     private fun syncMediaSessionPlaybackState(state: LegatoAndroidPlaybackState) {
+        val capabilities = LegatoAndroidTransportCapabilitiesProjector.fromSnapshot(coordinator.core.playerEngine.getSnapshot())
         val playbackState = PlaybackState.Builder()
-            .setActions(PlaybackState.ACTION_PLAY or PlaybackState.ACTION_PAUSE)
+            .setActions(LegatoPlaybackNotificationTransport.playbackStateActionsFor(state, capabilities))
             .setState(
                 when (state) {
                     LegatoAndroidPlaybackState.PLAYING,
@@ -217,13 +235,36 @@ class LegatoPlaybackService : Service() {
         mediaSession?.setPlaybackState(playbackState)
     }
 
+    private fun iconForAction(action: String): Int {
+        return when (action) {
+            LegatoPlaybackNotificationTransport.ACTION_PLAY -> android.R.drawable.ic_media_play
+            LegatoPlaybackNotificationTransport.ACTION_PAUSE -> android.R.drawable.ic_media_pause
+            LegatoPlaybackNotificationTransport.ACTION_NEXT -> android.R.drawable.ic_media_next
+            LegatoPlaybackNotificationTransport.ACTION_PREVIOUS -> android.R.drawable.ic_media_previous
+            else -> android.R.drawable.ic_media_play
+        }
+    }
+
+    private fun dispatchNotificationRemoteCommand(command: io.legato.core.core.LegatoAndroidRemoteCommand) {
+        when (command) {
+            io.legato.core.core.LegatoAndroidRemoteCommand.Play -> coordinator.core.mediaSessionBridge.dispatchMediaSessionPlay()
+            io.legato.core.core.LegatoAndroidRemoteCommand.Pause -> coordinator.core.mediaSessionBridge.dispatchMediaSessionPause()
+            io.legato.core.core.LegatoAndroidRemoteCommand.Next -> coordinator.core.mediaSessionBridge.dispatchMediaSessionSkipToNext()
+            io.legato.core.core.LegatoAndroidRemoteCommand.Previous -> coordinator.core.mediaSessionBridge.dispatchMediaSessionSkipToPrevious()
+            is io.legato.core.core.LegatoAndroidRemoteCommand.Seek -> {
+                coordinator.core.mediaSessionBridge.dispatchMediaSessionSeekTo(command.positionMs)
+            }
+        }
+    }
+
     companion object {
         internal const val EXTRA_SERVICE_MODE: String = "legato.service_mode"
         private const val CHANNEL_ID: String = "legato.playback"
         private const val CHANNEL_NAME: String = "Legato playback"
         private const val NOTIFICATION_ID: Int = 4242
         private const val REQUEST_CODE_OPEN_APP: Int = 1001
-        private const val REQUEST_CODE_TRANSPORT: Int = 1002
+        private const val REQUEST_CODE_TRANSPORT_BASE: Int = 1002
+        private const val MAX_COMPACT_ACTIONS: Int = 3
         private const val MEDIA_SESSION_TAG: String = "legato.playback"
     }
 }

--- a/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlugin.kt
+++ b/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlugin.kt
@@ -15,12 +15,13 @@ import io.legato.core.core.LegatoAndroidErrorCode
 @CapacitorPlugin(name = "Legato")
 class LegatoPlugin : Plugin() {
     private val mapper = LegatoCapacitorMapper()
-    private val coordinator = LegatoAndroidPlaybackCoordinatorStore.getOrCreate()
+    private lateinit var coordinator: LegatoAndroidPlaybackCoordinator
     private val core get() = coordinator.core
     private var coreListenerId: Long? = null
 
     override fun load() {
         super.load()
+        coordinator = LegatoAndroidPlaybackCoordinatorStore.getOrCreate(context.applicationContext)
         coordinator.bindServiceRuntime(LegatoAndroidAppServiceRuntime(context.applicationContext))
         coreListenerId = coordinator.addCoreEventListener { event ->
             notifyListeners(event.name.wireValue, mapper.eventPayloadToJs(event.payload))
@@ -47,29 +48,8 @@ class LegatoPlugin : Plugin() {
             val tracks = mapper.tracksFromJs(call.getArray("tracks"))
             val startIndex = call.getInt("startIndex")
 
-            val mappedTracks = core.trackMapper.mapContractTracks(tracks)
-            val queueSnapshot = if (startIndex != null) {
-                val mergedItems = core.queueManager.getQueueSnapshot().items + mappedTracks
-                core.queueManager.replaceQueue(mergedItems, startIndex)
-            } else {
-                core.queueManager.addToQueue(mappedTracks)
-            }
-
-            val previous = core.snapshotStore.getPlaybackSnapshot()
-            val next = snapshotWithQueue(previous, queueSnapshot)
-            core.snapshotStore.replacePlaybackSnapshot(next)
-
-            publishQueueTrackProgress(next)
-            if (previous.state != next.state) {
-                core.eventEmitter.emit(
-                    name = LegatoAndroidEventName.PLAYBACK_STATE_CHANGED,
-                    payload = LegatoAndroidEventPayload.PlaybackStateChanged(next.state),
-                )
-            }
-
-            coordinator.projectServiceMode()
-
-            call.resolve(snapshotResult(next))
+            coordinator.add(tracks = tracks, startIndex = startIndex)
+            call.resolve(snapshotResult(core.playerEngine.getSnapshot()))
         }.onFailure { reject(call, it) }
     }
 
@@ -189,16 +169,8 @@ class LegatoPlugin : Plugin() {
     fun skipTo(call: PluginCall) {
         runCatching {
             val index = call.getInt("index") ?: error("skipTo.index is required")
-            val queueSnapshot = core.queueManager.getQueueSnapshot()
-            require(index in queueSnapshot.items.indices) { "skipTo.index out of bounds" }
-
-            val nextQueue = core.queueManager.replaceQueue(queueSnapshot.items, index)
-            val previous = core.snapshotStore.getPlaybackSnapshot()
-            val next = snapshotWithQueue(previous, nextQueue)
-            core.snapshotStore.replacePlaybackSnapshot(next)
-            publishQueueTrackProgress(next)
-            coordinator.projectServiceMode()
-            call.resolve(snapshotResult(next))
+            coordinator.skipTo(index)
+            call.resolve(snapshotResult(core.playerEngine.getSnapshot()))
         }.onFailure { reject(call, it) }
     }
 

--- a/packages/capacitor/android/src/test/kotlin/io/legato/capacitor/LegatoAndroidPlaybackCoordinatorTest.kt
+++ b/packages/capacitor/android/src/test/kotlin/io/legato/capacitor/LegatoAndroidPlaybackCoordinatorTest.kt
@@ -26,6 +26,7 @@ import io.legato.core.state.LegatoAndroidStateMachine
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 
 class LegatoAndroidPlaybackCoordinatorTest {
@@ -117,6 +118,102 @@ class LegatoAndroidPlaybackCoordinatorTest {
         assertTrue(projectedStates.contains(LegatoAndroidPlaybackState.PAUSED))
     }
 
+    @Test
+    fun `coordinator add rebinds merged queue through runtime`() = runBlocking {
+        val runtime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val coordinator = LegatoAndroidPlaybackCoordinator(
+            core = buildCore(runtime, sessionRuntime),
+            serviceRuntime = RecordingCoordinatorServiceRuntime(),
+        )
+
+        coordinator.setup()
+        coordinator.load(
+            listOf(
+                LegatoAndroidTrack(id = "track-1", url = "https://example.com/1.mp3"),
+            ),
+        )
+
+        coordinator.add(
+            tracks = listOf(
+                LegatoAndroidTrack(id = "track-2", url = "https://example.com/2.mp3"),
+            ),
+        )
+
+        assertEquals(2, runtime.replaceQueueCalls)
+        assertEquals(listOf("track-1", "track-2"), runtime.lastReplacedQueueIds)
+        assertEquals(2, coordinator.core.playerEngine.getSnapshot().queue.items.size)
+    }
+
+    @Test
+    fun `coordinator add with empty tracks keeps runtime queue untouched`() = runBlocking {
+        val runtime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val coordinator = LegatoAndroidPlaybackCoordinator(
+            core = buildCore(runtime, sessionRuntime),
+            serviceRuntime = RecordingCoordinatorServiceRuntime(),
+        )
+
+        coordinator.setup()
+        coordinator.load(
+            listOf(
+                LegatoAndroidTrack(id = "track-1", url = "https://example.com/1.mp3"),
+            ),
+        )
+
+        coordinator.add(tracks = emptyList())
+
+        assertEquals(1, runtime.replaceQueueCalls)
+        assertEquals(listOf("track-1"), runtime.lastReplacedQueueIds)
+    }
+
+    @Test
+    fun `coordinator skipTo routes index selection through runtime`() = runBlocking {
+        val runtime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val coordinator = LegatoAndroidPlaybackCoordinator(
+            core = buildCore(runtime, sessionRuntime),
+            serviceRuntime = RecordingCoordinatorServiceRuntime(),
+        )
+
+        coordinator.setup()
+        coordinator.load(
+            listOf(
+                LegatoAndroidTrack(id = "track-1", url = "https://example.com/1.mp3"),
+                LegatoAndroidTrack(id = "track-2", url = "https://example.com/2.mp3"),
+            ),
+        )
+
+        coordinator.skipTo(1)
+
+        assertEquals(listOf(1), runtime.selectedIndices)
+        assertEquals(1, coordinator.core.playerEngine.getSnapshot().currentIndex)
+    }
+
+    @Test
+    fun `coordinator skipTo rejects out of bounds index`() = runBlocking {
+        val runtime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val coordinator = LegatoAndroidPlaybackCoordinator(
+            core = buildCore(runtime, sessionRuntime),
+            serviceRuntime = RecordingCoordinatorServiceRuntime(),
+        )
+
+        coordinator.setup()
+        coordinator.load(
+            listOf(
+                LegatoAndroidTrack(id = "track-1", url = "https://example.com/1.mp3"),
+            ),
+        )
+
+        try {
+            coordinator.skipTo(5)
+            fail("Expected skipTo to reject out of bounds index")
+        } catch (_: IllegalArgumentException) {
+            assertTrue(runtime.selectedIndices.isEmpty())
+        }
+    }
+
     private fun buildCore(
         runtime: RecordingPlaybackRuntime,
         sessionRuntime: RecordingSessionRuntime,
@@ -156,6 +253,15 @@ private class RecordingPlaybackRuntime : LegatoAndroidPlaybackRuntime {
     var playCallCount: Int = 0
         private set
 
+    var replaceQueueCalls: Int = 0
+        private set
+
+    var lastReplacedQueueIds: List<String> = emptyList()
+        private set
+
+    var selectedIndices: List<Int> = emptyList()
+        private set
+
     override fun configure() = Unit
 
     override fun setListener(listener: LegatoAndroidPlaybackRuntimeListener?) {
@@ -163,10 +269,13 @@ private class RecordingPlaybackRuntime : LegatoAndroidPlaybackRuntime {
     }
 
     override fun replaceQueue(items: List<LegatoAndroidRuntimeTrackSource>, startIndex: Int?) {
+        replaceQueueCalls += 1
+        lastReplacedQueueIds = items.map { it.id }
         snapshot = snapshot.copy(currentIndex = if (items.isEmpty()) null else (startIndex ?: 0))
     }
 
     override fun selectIndex(index: Int) {
+        selectedIndices = selectedIndices + index
         snapshot = snapshot.copy(currentIndex = index)
     }
 

--- a/packages/capacitor/android/src/test/kotlin/io/legato/capacitor/LegatoPlaybackNotificationTransportTest.kt
+++ b/packages/capacitor/android/src/test/kotlin/io/legato/capacitor/LegatoPlaybackNotificationTransportTest.kt
@@ -1,9 +1,11 @@
 package io.legato.capacitor
 
 import io.legato.core.core.LegatoAndroidPlaybackState
+import io.legato.core.core.LegatoAndroidTransportCapabilities
 import io.legato.core.remote.LegatoAndroidMediaSessionBridge
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class LegatoPlaybackNotificationTransportTest {
@@ -40,5 +42,73 @@ class LegatoPlaybackNotificationTransportTest {
             ),
         )
         assertNull(LegatoPlaybackNotificationTransport.transportControlFromIntentAction("unsupported"))
+    }
+
+    @Test
+    fun `playback-state actions include next previous and seek when capabilities allow`() {
+        val actions = LegatoPlaybackNotificationTransport.playbackStateActionsFor(
+            state = LegatoAndroidPlaybackState.PLAYING,
+            capabilities = LegatoAndroidTransportCapabilities(
+                canSkipNext = true,
+                canSkipPrevious = true,
+                canSeek = true,
+            ),
+        )
+
+        assertTrue(actions and android.media.session.PlaybackState.ACTION_SKIP_TO_NEXT != 0L)
+        assertTrue(actions and android.media.session.PlaybackState.ACTION_SKIP_TO_PREVIOUS != 0L)
+        assertTrue(actions and android.media.session.PlaybackState.ACTION_SEEK_TO != 0L)
+    }
+
+    @Test
+    fun `playback-state actions omit next when capability is false`() {
+        val actions = LegatoPlaybackNotificationTransport.playbackStateActionsFor(
+            state = LegatoAndroidPlaybackState.PAUSED,
+            capabilities = LegatoAndroidTransportCapabilities(
+                canSkipNext = false,
+                canSkipPrevious = true,
+                canSeek = true,
+            ),
+        )
+
+        assertEquals(0L, actions and android.media.session.PlaybackState.ACTION_SKIP_TO_NEXT)
+        assertTrue(actions and android.media.session.PlaybackState.ACTION_SKIP_TO_PREVIOUS != 0L)
+    }
+
+    @Test
+    fun `notification actions include capability-driven previous and next around projected transport control`() {
+        val actions = LegatoPlaybackNotificationTransport.notificationActionModelFor(
+            state = LegatoAndroidPlaybackState.PAUSED,
+            capabilities = LegatoAndroidTransportCapabilities(
+                canSkipNext = true,
+                canSkipPrevious = true,
+                canSeek = true,
+            ),
+        )
+
+        assertEquals(
+            listOf(
+                LegatoPlaybackNotificationTransport.ACTION_PREVIOUS,
+                LegatoPlaybackNotificationTransport.ACTION_PLAY,
+                LegatoPlaybackNotificationTransport.ACTION_NEXT,
+            ),
+            actions.map { it.intentAction },
+        )
+    }
+
+    @Test
+    fun `notification intent action maps previous and next to remote commands`() {
+        assertEquals(
+            io.legato.core.core.LegatoAndroidRemoteCommand.Previous,
+            LegatoPlaybackNotificationTransport.remoteCommandFromIntentAction(
+                LegatoPlaybackNotificationTransport.ACTION_PREVIOUS,
+            ),
+        )
+        assertEquals(
+            io.legato.core.core.LegatoAndroidRemoteCommand.Next,
+            LegatoPlaybackNotificationTransport.remoteCommandFromIntentAction(
+                LegatoPlaybackNotificationTransport.ACTION_NEXT,
+            ),
+        )
     }
 }


### PR DESCRIPTION
Closes #17

## Summary
- implement canonical queue-aware remote transport semantics (`next`, `previous`, `seek`) plus capability projection in core
- add injectable iOS wrappers/runtime adapters for `MPRemoteCommandCenter` and `MPNowPlayingInfoCenter` to support richer transport + now-playing sync
- complete Android MediaSession/notification callback binding for next/previous/seek and fix real playback issues found during device validation
- update the Capacitor demo harness so transport richness v2 can be observed and validated on both platforms

## Changes
| File | Change |
|------|--------|
| `native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidPlayerEngine.kt` | canonical next/previous/seek semantics, queue-boundary behavior, capability projection consumption, Android playback correctness fixes |
| `native/android/core/src/main/kotlin/io/legato/core/queue/LegatoAndroidTransportCapabilitiesProjector.kt` | Android core transport capability projection |
| `native/android/core/src/main/kotlin/io/legato/core/remote/LegatoAndroidMediaSessionBridge.kt` | shared Android MediaSession bridge extended for richer transport dispatch |
| `native/android/core/src/main/kotlin/io/legato/core/runtime/LegatoAndroidMedia3PlaybackRuntime.kt` | real player dispatch fixes (main thread, prepare-on-play, item/progress synchronization) |
| `native/ios/LegatoCore/Sources/LegatoCore/Remote/LegatoiOSRemoteCommandRuntime.swift` | injectable iOS remote command wrappers/runtime |
| `native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSNowPlayingRuntime.swift` | injectable iOS now-playing wrappers/runtime |
| `native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSPlayerEngine.swift` | canonical remote transport + capability publication on iOS |
| `native/ios/LegatoCore/Sources/LegatoCore/Queue/LegatoiOSTransportCapabilitiesProjector.swift` | iOS core transport capability projection |
| `packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackService.kt` | Android notification/media transport binding and paused-notification persistence policy |
| `packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlugin.kt` / `LegatoAndroidPlaybackCoordinator.kt` | canonical routing into real runtime + shared owner path |
| `apps/capacitor-demo/index.html`, `apps/capacitor-demo/src/main.ts`, `apps/capacitor-demo/README.md` | remote parity inspector, boundary smoke flow, richer transport validation guidance |
| Android/iOS test files under `native/android/core/src/test/`, `packages/capacitor/android/src/test/`, and `native/ios/LegatoCore/Tests/` | coverage for routing, capabilities, wrappers, transport mapping, and harness contract |

## Test Plan
- [x] Strict-TDD cycles executed for multiple batches on targeted Android tests
- [x] `bash ./gradlew :native:android:core:testDebugUnitTest` targeted suites passed during implementation
- [x] `bash ./gradlew :legato-capacitor:testDebugUnitTest` targeted suites passed during implementation
- [x] `bash ./gradlew test` from `apps/capacitor-demo/android` passed for harness batch
- [x] Manual Android device validation confirmed: real audio playback, remote play/pause/next/previous behavior, notification persistence on pause, and coherent currentTrack/currentIndex sync after fixes
- [ ] iOS wrapper tests are added, but executable GREEN for SwiftPM iOS wrappers is still constrained by host/test infra (`AVAudioSession` availability) and needs later infra hardening

## Notes
- This closes v2 scope only; shuffle/repeat, broad artwork strategy, and rich transport UX beyond the minimal parity target remain future work.
- The PR also includes Android bugfixes discovered during manual validation because they were blockers for proving the v2 milestone on real device.
