### PR TITLE
test(native): harden lifecycle validation

### DIFF
--- a/apps/capacitor-demo/SMOKE_VALIDATION_TEMPLATE.md
+++ b/apps/capacitor-demo/SMOKE_VALIDATION_TEMPLATE.md
@@ -1,0 +1,27 @@
+# Native Smoke Validation Template
+
+Use this checklist after syncing the demo app to native hosts.
+
+## Preconditions
+- Run `npm run build` and `npm run cap:sync` from `apps/capacitor-demo`.
+- Launch the app from Android Studio or Xcode (native bridge required).
+- Confirm harness header shows `native=true`.
+
+## Flow Results
+| Flow | Verdict | Snapshot Summary | Key Checks | Evidence |
+|---|---|---|---|---|
+| smoke | PASS/FAIL | `state=... | track=... | position=... | duration=...` | `current track present`, `state is present`, `position available`, `duration available`, `smoke flow ends paused` | Paste from **Copy recent events** + screenshot of verdict panel |
+| let-end | PASS/FAIL | `state=... | track=... | position=... | duration=...` | same base checks + `let-end reaches active playback lifecycle` | Paste from **Copy recent events** + screenshot of verdict panel |
+| boundary | PASS/FAIL | `state=... | track=... | position=... | duration=...` | same base checks + `boundary flow reaches ended state` | Paste from **Copy recent events** + screenshot of verdict panel |
+
+## Manual Controls Regression
+- [ ] `setup()` still works after smoke runs
+- [ ] `add()` still works after smoke runs
+- [ ] `play()` / `pause()` / `stop()` still work after smoke runs
+- [ ] `seekTo()` still works after smoke runs
+- [ ] `getSnapshot()` still updates summary/json after smoke runs
+- [ ] `Copy raw log` and `Copy recent events` remain usable
+
+## Notes
+- If any smoke run shows `PASS` without at least one snapshot update, record as **FAIL** and attach events/logs.
+- Capture both a verdict screenshot and copied events so native regressions are reproducible outside IDE logs.

--- a/apps/capacitor-demo/index.html
+++ b/apps/capacitor-demo/index.html
@@ -149,6 +149,41 @@
       #log {
         min-height: 220px;
       }
+
+      #verdict-status {
+        font-weight: 700;
+        border: 1px solid #cbd5e1;
+        border-radius: 8px;
+        padding: 0.45rem 0.6rem;
+      }
+
+      #verdict-status[data-status='PASS'] {
+        border-color: #15803d;
+        color: #15803d;
+      }
+
+      #verdict-status[data-status='FAIL'] {
+        border-color: #b91c1c;
+        color: #b91c1c;
+      }
+
+      #verdict-summary {
+        margin: 0;
+        padding: 0.65rem;
+        border: 1px solid #d1d5db;
+        border-radius: 8px;
+        min-height: 74px;
+        white-space: pre-wrap;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+        font-size: 0.82rem;
+      }
+
+      #verdict-checks {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.28rem;
+      }
     </style>
   </head>
   <body>
@@ -167,6 +202,11 @@
             <button id="copy-events" type="button">Copy recent events</button>
           </div>
           <div id="env-status">Detecting platform…</div>
+          <div id="verdict-status" data-status="IDLE">Smoke verdict: IDLE</div>
+          <pre id="verdict-summary">flow=none
+status=IDLE
+No smoke run yet.</pre>
+          <ul id="verdict-checks"></ul>
         </section>
 
         <section class="card stack">

--- a/apps/capacitor-demo/src/main.ts
+++ b/apps/capacitor-demo/src/main.ts
@@ -1,5 +1,11 @@
 import { Capacitor } from '@capacitor/core';
 import { Legato, createLegatoSync, type PlaybackSnapshot, type Track } from '@legato/capacitor';
+import {
+  createInitialSmokeVerdict,
+  reduceSmokeVerdict,
+  summarizeSmokeVerdict,
+  type SmokeFlow,
+} from './smoke-verdict.js';
 
 type LegatoSyncController = ReturnType<typeof createLegatoSync>;
 
@@ -21,6 +27,9 @@ const seekButton = document.querySelector<HTMLButtonElement>('#action-seek');
 const snapshotButton = document.querySelector<HTMLButtonElement>('#action-snapshot');
 const seekInput = document.querySelector<HTMLInputElement>('#seek-ms');
 const envStatusNode = document.querySelector<HTMLDivElement>('#env-status');
+const verdictStatusNode = document.querySelector<HTMLDivElement>('#verdict-status');
+const verdictSummaryNode = document.querySelector<HTMLPreElement>('#verdict-summary');
+const verdictChecksNode = document.querySelector<HTMLUListElement>('#verdict-checks');
 const logNode = document.querySelector<HTMLTextAreaElement>('#log');
 const eventsNode = document.querySelector<HTMLTextAreaElement>('#events');
 const snapshotSummaryNode = document.querySelector<HTMLPreElement>('#snapshot-summary');
@@ -47,6 +56,9 @@ if (
   || !snapshotButton
   || !seekInput
   || !envStatusNode
+  || !verdictStatusNode
+  || !verdictSummaryNode
+  || !verdictChecksNode
   || !logNode
   || !eventsNode
   || !snapshotSummaryNode
@@ -70,6 +82,8 @@ let syncController: LegatoSyncController | null = null;
 let latestSnapshot: PlaybackSnapshot | null = null;
 let recentEvents: string[] = [];
 let recentProgressSamples: Array<{ state: string; positionMs: number }> = [];
+let smokeVerdict = createInitialSmokeVerdict();
+let activeSmokeFlow: SmokeFlow | null = null;
 const observedSyncEvents = new Set<string>();
 
 const demoTracks: Track[] = [
@@ -80,7 +94,7 @@ const demoTracks: Track[] = [
     artist: 'Samplelib',
     album: 'Legato Remote Parity Fixtures',
     artwork: 'https://samplelib.com/lib/preview/png/sample-bumblebee-400x300.png',
-    duration: 3239,
+    duration: 3000,
     type: 'progressive',
   },
   {
@@ -90,7 +104,7 @@ const demoTracks: Track[] = [
     artist: 'Samplelib',
     album: 'Legato Remote Parity Fixtures',
     artwork: 'https://samplelib.com/lib/preview/png/sample-bumblebee-400x300.png',
-    duration: 6426,
+    duration: 6000,
     type: 'progressive',
   },
 ];
@@ -341,6 +355,38 @@ const renderRecentEvents = (): void => {
   eventsNode.scrollTop = eventsNode.scrollHeight;
 };
 
+const renderSmokeVerdict = (): void => {
+  verdictStatusNode.textContent = `Smoke verdict: ${smokeVerdict.status}`;
+  verdictStatusNode.dataset.status = smokeVerdict.status;
+  verdictSummaryNode.textContent = summarizeSmokeVerdict(smokeVerdict);
+  verdictChecksNode.innerHTML = '';
+
+  smokeVerdict.checks.forEach((check) => {
+    const item = document.createElement('li');
+    const icon = check.ok ? '✅' : '❌';
+    item.textContent = `${icon} ${check.label} — ${check.detail}`;
+    verdictChecksNode.appendChild(item);
+  });
+};
+
+const startSmokeVerdict = (flow: SmokeFlow): void => {
+  activeSmokeFlow = flow;
+  smokeVerdict = reduceSmokeVerdict(smokeVerdict, { type: 'start', flow });
+  renderSmokeVerdict();
+};
+
+const completeSmokeVerdict = (): void => {
+  smokeVerdict = reduceSmokeVerdict(smokeVerdict, { type: 'complete' });
+  activeSmokeFlow = null;
+  renderSmokeVerdict();
+};
+
+const failSmokeVerdict = (errorSummary: string): void => {
+  smokeVerdict = reduceSmokeVerdict(smokeVerdict, { type: 'error', message: errorSummary });
+  activeSmokeFlow = null;
+  renderSmokeVerdict();
+};
+
 const addRecentEvent = (message: string): void => {
   const prefix = `[${new Date().toLocaleTimeString()}]`;
   recentEvents = [...recentEvents.slice(-recentEventsLimit + 1), `${prefix} ${message}`];
@@ -355,6 +401,11 @@ const updateSnapshotViews = (snapshot: PlaybackSnapshot): void => {
   snapshotJsonNode.value = JSON.stringify(snapshot, null, 2);
   updateParityInspector(snapshot);
   addRecentEvent(`snapshot summary ${summarizeSnapshot(snapshot)}`);
+
+  if (activeSmokeFlow) {
+    smokeVerdict = reduceSmokeVerdict(smokeVerdict, { type: 'snapshot', snapshot });
+    renderSmokeVerdict();
+  }
 };
 
 const setRunning = (running: boolean): void => {
@@ -373,6 +424,9 @@ const runNativeAction = async (name: string, action: () => Promise<void>): Promi
   } catch (error) {
     log(`${name} failed:`, error);
     addRecentEvent(`${name} failed ${summarizePayload(error)}`);
+    if (activeSmokeFlow) {
+      failSmokeVerdict(summarizePayload(error));
+    }
   } finally {
     setRunning(false);
   }
@@ -491,6 +545,7 @@ const clearFlows = (): void => {
 };
 
 const runSmokeFlow = async (): Promise<void> => {
+  startSmokeVerdict('smoke');
   clearFlows();
   log('Starting Legato smoke flow...');
   log('platform:', platform);
@@ -507,9 +562,11 @@ const runSmokeFlow = async (): Promise<void> => {
 
   await pauseAction();
   await snapshotAction();
+  completeSmokeVerdict();
 };
 
 const runLetItEndSmokeFlow = async (): Promise<void> => {
+  startSmokeVerdict('let-end');
   clearFlows();
   log('Starting Legato let-it-end flow...');
   log('platform:', platform);
@@ -524,9 +581,11 @@ const runLetItEndSmokeFlow = async (): Promise<void> => {
 
   await new Promise((resolve) => setTimeout(resolve, endSmokeDelayMs));
   await snapshotAction();
+  completeSmokeVerdict();
 };
 
 const runBoundarySmokeFlow = async (): Promise<void> => {
+  startSmokeVerdict('boundary');
   clearFlows();
   log('Starting Legato boundary smoke flow...');
   log('platform:', platform);
@@ -546,6 +605,7 @@ const runBoundarySmokeFlow = async (): Promise<void> => {
 
   await nextAction();
   await snapshotAction();
+  completeSmokeVerdict();
 };
 
 envStatusNode.textContent = `platform=${platform} | native=${isNative}`;
@@ -630,3 +690,5 @@ if (latestSnapshot == null) {
   capabilitySummaryNode.textContent = 'No capability projection yet.';
   paritySummaryNode.textContent = 'No parity signals yet.';
 }
+
+renderSmokeVerdict();

--- a/apps/capacitor-demo/src/smoke-verdict.d.ts
+++ b/apps/capacitor-demo/src/smoke-verdict.d.ts
@@ -1,0 +1,27 @@
+export type SmokeFlow = 'smoke' | 'let-end' | 'boundary';
+
+export type SmokeVerdictStatus = 'IDLE' | 'RUNNING' | 'PASS' | 'FAIL';
+
+export type SmokeVerdictCheck = {
+  label: string;
+  ok: boolean;
+  detail: string;
+};
+
+export type SmokeVerdict = {
+  flow: SmokeFlow | null;
+  status: SmokeVerdictStatus;
+  checks: SmokeVerdictCheck[];
+  snapshotSummary: string;
+  errorSummary: string | null;
+};
+
+export type SmokeVerdictAction =
+  | { type: 'start'; flow: SmokeFlow }
+  | { type: 'snapshot'; snapshot: unknown }
+  | { type: 'error'; message: string }
+  | { type: 'complete' };
+
+export function createInitialSmokeVerdict(): SmokeVerdict;
+export function reduceSmokeVerdict(state: SmokeVerdict, action: SmokeVerdictAction): SmokeVerdict;
+export function summarizeSmokeVerdict(verdict: SmokeVerdict): string;

--- a/apps/capacitor-demo/src/smoke-verdict.js
+++ b/apps/capacitor-demo/src/smoke-verdict.js
@@ -1,0 +1,134 @@
+const PASS = 'PASS';
+const FAIL = 'FAIL';
+const RUNNING = 'RUNNING';
+const IDLE = 'IDLE';
+
+const FLOW_SMOKE = 'smoke';
+const FLOW_LET_END = 'let-end';
+const FLOW_BOUNDARY = 'boundary';
+
+const createCheck = (label, ok, detail) => ({ label, ok, detail });
+
+const asNumberOrNull = (value) => (typeof value === 'number' && Number.isFinite(value) ? value : null);
+
+const readSnapshotMetrics = (snapshot) => ({
+  state: typeof snapshot?.state === 'string' ? snapshot.state : 'unknown',
+  currentTrack: typeof snapshot?.currentTrack?.title === 'string' && snapshot.currentTrack.title.trim() !== ''
+    ? snapshot.currentTrack.title
+    : '(none)',
+  position: asNumberOrNull(snapshot?.position),
+  duration: asNumberOrNull(snapshot?.duration),
+});
+
+const createBaseChecks = (metrics) => [
+  createCheck('current track present', metrics.currentTrack !== '(none)', `track=${metrics.currentTrack}`),
+  createCheck('state is present', metrics.state !== 'unknown', `state=${metrics.state}`),
+  createCheck(
+    'position available',
+    metrics.position !== null && metrics.position >= 0,
+    `position=${metrics.position ?? 'n/a'}`,
+  ),
+  createCheck(
+    'duration available',
+    metrics.duration !== null && metrics.duration > 0,
+    `duration=${metrics.duration ?? 'n/a'}`,
+  ),
+];
+
+const createFlowChecks = (flow, metrics) => {
+  switch (flow) {
+    case FLOW_SMOKE:
+      return [createCheck('smoke flow ends paused', metrics.state === 'paused', `state=${metrics.state}`)];
+    case FLOW_LET_END:
+      return [createCheck('let-end reaches active playback lifecycle', metrics.state !== 'idle', `state=${metrics.state}`)];
+    case FLOW_BOUNDARY:
+      return [createCheck('boundary flow reaches ended state', metrics.state === 'ended', `state=${metrics.state}`)];
+    default:
+      return [createCheck('known flow selected', false, `flow=${flow ?? 'none'}`)];
+  }
+};
+
+const statusFromChecks = (checks) => {
+  if (!Array.isArray(checks) || checks.length === 0) {
+    return FAIL;
+  }
+
+  return checks.every((check) => check.ok) ? PASS : FAIL;
+};
+
+const formatSnapshotSummary = (metrics) => [
+  `state=${metrics.state}`,
+  `track=${metrics.currentTrack}`,
+  `position=${metrics.position ?? 'n/a'}`,
+  `duration=${metrics.duration ?? 'n/a'}`,
+].join(' | ');
+
+export const createInitialSmokeVerdict = () => ({
+  flow: null,
+  status: IDLE,
+  checks: [],
+  snapshotSummary: 'No smoke run yet.',
+  errorSummary: null,
+});
+
+export const reduceSmokeVerdict = (state, action) => {
+  if (!action || typeof action !== 'object') {
+    return state;
+  }
+
+  switch (action.type) {
+    case 'start':
+      return {
+        flow: action.flow,
+        status: RUNNING,
+        checks: [],
+        snapshotSummary: 'Awaiting snapshot…',
+        errorSummary: null,
+      };
+
+    case 'snapshot': {
+      const metrics = readSnapshotMetrics(action.snapshot);
+      const checks = [...createBaseChecks(metrics), ...createFlowChecks(state.flow, metrics)];
+      return {
+        ...state,
+        checks,
+        snapshotSummary: formatSnapshotSummary(metrics),
+      };
+    }
+
+    case 'error':
+      return {
+        ...state,
+        status: FAIL,
+        errorSummary: action.message,
+      };
+
+    case 'complete': {
+      if (state.status === FAIL) {
+        return state;
+      }
+
+      return {
+        ...state,
+        status: statusFromChecks(state.checks),
+      };
+    }
+
+    default:
+      return state;
+  }
+};
+
+export const summarizeSmokeVerdict = (verdict) => {
+  const lines = [
+    `flow=${verdict.flow ?? 'none'}`,
+    `status=${verdict.status}`,
+    verdict.snapshotSummary,
+  ];
+
+  if (verdict.errorSummary) {
+    lines.push(`error=${verdict.errorSummary}`);
+  }
+
+  return lines.join('\n');
+};

--- a/apps/capacitor-demo/src/smoke-verdict.test.mjs
+++ b/apps/capacitor-demo/src/smoke-verdict.test.mjs
@@ -1,0 +1,78 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  createInitialSmokeVerdict,
+  reduceSmokeVerdict,
+  summarizeSmokeVerdict,
+} from './smoke-verdict.js';
+
+const snapshot = {
+  state: 'paused',
+  currentTrack: { title: 'Demo Track 1' },
+  position: 1425,
+  duration: 3000,
+};
+
+test('start action marks verdict as RUNNING and stores flow', () => {
+  const initial = createInitialSmokeVerdict();
+  const next = reduceSmokeVerdict(initial, { type: 'start', flow: 'smoke' });
+
+  assert.equal(next.status, 'RUNNING');
+  assert.equal(next.flow, 'smoke');
+  assert.equal(next.errorSummary, null);
+  assert.deepEqual(initial.checks, []);
+});
+
+test('snapshot + complete marks smoke flow PASS when checks hold', () => {
+  const started = reduceSmokeVerdict(createInitialSmokeVerdict(), { type: 'start', flow: 'smoke' });
+  const withSnapshot = reduceSmokeVerdict(started, { type: 'snapshot', snapshot });
+  const completed = reduceSmokeVerdict(withSnapshot, { type: 'complete' });
+
+  assert.equal(completed.status, 'PASS');
+  assert.match(completed.snapshotSummary, /state=paused/);
+  assert.match(completed.snapshotSummary, /track=Demo Track 1/);
+  assert.match(completed.snapshotSummary, /position=1425/);
+  assert.match(completed.snapshotSummary, /duration=3000/);
+});
+
+test('error action finalizes verdict as FAIL and preserves reason', () => {
+  const started = reduceSmokeVerdict(createInitialSmokeVerdict(), { type: 'start', flow: 'boundary' });
+  const withError = reduceSmokeVerdict(started, { type: 'error', message: 'native playback failed' });
+
+  assert.equal(withError.status, 'FAIL');
+  assert.equal(withError.errorSummary, 'native playback failed');
+});
+
+test('boundary flow fails when final snapshot state is not ended', () => {
+  const started = reduceSmokeVerdict(createInitialSmokeVerdict(), { type: 'start', flow: 'boundary' });
+  const withSnapshot = reduceSmokeVerdict(started, {
+    type: 'snapshot',
+    snapshot: { ...snapshot, state: 'paused' },
+  });
+  const completed = reduceSmokeVerdict(withSnapshot, { type: 'complete' });
+
+  assert.equal(completed.status, 'FAIL');
+  assert.ok(completed.checks.some((check) => check.label.includes('ended')));
+});
+
+test('summarize helper returns readable multi-line output', () => {
+  const started = reduceSmokeVerdict(createInitialSmokeVerdict(), { type: 'start', flow: 'let-end' });
+  const withSnapshot = reduceSmokeVerdict(started, {
+    type: 'snapshot',
+    snapshot: { ...snapshot, state: 'playing' },
+  });
+  const summary = summarizeSmokeVerdict(withSnapshot);
+
+  assert.match(summary, /flow=let-end/);
+  assert.match(summary, /state=playing/);
+  assert.match(summary, /track=Demo Track 1/);
+});
+
+test('complete without snapshot does not report PASS', () => {
+  const started = reduceSmokeVerdict(createInitialSmokeVerdict(), { type: 'start', flow: 'smoke' });
+  const completed = reduceSmokeVerdict(started, { type: 'complete' });
+
+  assert.equal(completed.status, 'FAIL');
+  assert.match(summarizeSmokeVerdict(completed), /Awaiting snapshot/);
+});

--- a/native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidPlayerEngine.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidPlayerEngine.kt
@@ -365,6 +365,10 @@ class LegatoAndroidPlayerEngine(
         }
 
         override fun onBuffering(isBuffering: Boolean) {
+            if (snapshotStore.getPlaybackSnapshot().state == LegatoAndroidPlaybackState.ENDED) {
+                return
+            }
+
             val input = if (isBuffering) {
                 LegatoAndroidStateMachine.LegatoAndroidStateInput.BUFFERING_STARTED
             } else {

--- a/native/android/core/src/main/kotlin/io/legato/core/state/LegatoAndroidStateMachine.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/state/LegatoAndroidStateMachine.kt
@@ -53,6 +53,7 @@ class LegatoAndroidStateMachine {
             LegatoAndroidPlaybackState.BUFFERING to setOf(
                 LegatoAndroidPlaybackState.PLAYING,
                 LegatoAndroidPlaybackState.PAUSED,
+                LegatoAndroidPlaybackState.ENDED,
                 LegatoAndroidPlaybackState.READY,
                 LegatoAndroidPlaybackState.LOADING,
                 LegatoAndroidPlaybackState.IDLE,

--- a/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineInterruptionPolicyTest.kt
+++ b/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineInterruptionPolicyTest.kt
@@ -115,6 +115,26 @@ class LegatoAndroidPlayerEngineInterruptionPolicyTest {
     }
 
     @Test
+    fun `runtime buffering callbacks cannot rebound state after ended`() = runBlocking {
+        val playbackRuntime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val engine = buildEngine(playbackRuntime, sessionRuntime)
+
+        engine.setup()
+        engine.load(tracks = listOf(LegatoAndroidTrack(id = "track-1", url = "https://example.com/audio.mp3")))
+        engine.play()
+
+        playbackRuntime.emitBuffering(true)
+        assertEquals(LegatoAndroidPlaybackState.BUFFERING, engine.getSnapshot().state)
+
+        playbackRuntime.emitEnded()
+        assertEquals(LegatoAndroidPlaybackState.ENDED, engine.getSnapshot().state)
+
+        playbackRuntime.emitBuffering(false)
+        assertEquals(LegatoAndroidPlaybackState.ENDED, engine.getSnapshot().state)
+    }
+
+    @Test
     fun `runtime fatal error callback transitions state and emits playback error`() = runBlocking {
         val playbackRuntime = RecordingPlaybackRuntime()
         val sessionRuntime = RecordingSessionRuntime()
@@ -188,6 +208,53 @@ class LegatoAndroidPlayerEngineInterruptionPolicyTest {
         assertEquals(200_000L, snapshot.durationMs)
         assertEquals(9_000L, snapshot.bufferedPositionMs)
         assertEquals(1, snapshot.queue.currentIndex)
+    }
+
+    @Test
+    fun `user paused with active track remains playback active for service projection`() = runBlocking {
+        val playbackRuntime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val engine = buildEngine(playbackRuntime, sessionRuntime)
+
+        engine.setup()
+        engine.load(tracks = listOf(LegatoAndroidTrack(id = "track-1", url = "https://example.com/audio.mp3")))
+        engine.play()
+        engine.pause()
+
+        assertEquals(LegatoAndroidPlaybackState.PAUSED, engine.getSnapshot().state)
+        assertEquals(LegatoAndroidPauseOrigin.USER, engine.getPauseOrigin())
+        assertEquals(LegatoAndroidServiceMode.PLAYBACK_ACTIVE, engine.getServiceMode())
+    }
+
+    @Test
+    fun `runtime progress ignores out of bounds index while still publishing progress`() = runBlocking {
+        val playbackRuntime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val engine = buildEngine(playbackRuntime, sessionRuntime)
+
+        engine.setup()
+        engine.load(
+            tracks = listOf(
+                LegatoAndroidTrack(id = "track-1", url = "https://example.com/1.mp3", durationMs = 100_000L),
+                LegatoAndroidTrack(id = "track-2", url = "https://example.com/2.mp3", durationMs = 200_000L),
+            ),
+        )
+        engine.play()
+
+        playbackRuntime.emitProgress(
+            currentIndex = 99,
+            positionMs = 7_500L,
+            durationMs = 333_000L,
+            bufferedPositionMs = 11_000L,
+        )
+
+        val snapshot = engine.getSnapshot()
+        assertEquals(0, snapshot.currentIndex)
+        assertEquals("track-1", snapshot.currentTrack?.id)
+        assertEquals(7_500L, snapshot.positionMs)
+        assertEquals(333_000L, snapshot.durationMs)
+        assertEquals(11_000L, snapshot.bufferedPositionMs)
+        assertEquals(0, snapshot.queue.currentIndex)
     }
 
     private fun buildEngine(

--- a/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineRemoteCommandRoutingTest.kt
+++ b/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineRemoteCommandRoutingTest.kt
@@ -149,6 +149,26 @@ class LegatoAndroidPlayerEngineRemoteCommandRoutingTest {
     }
 
     @Test
+    fun `remote next at end ignores stale buffering callbacks after ended`() = runBlocking {
+        val playbackRuntime = RemoteRoutingPlaybackRuntime()
+        val dependencies = LegatoAndroidCoreDependencies(
+            playbackRuntime = playbackRuntime,
+        )
+        val components = LegatoAndroidCoreFactory.create(dependencies)
+
+        components.playerEngine.setup()
+        components.playerEngine.load(tracks = listOf(track(id = "1"), track(id = "2")))
+        components.playerEngine.play()
+        components.playerEngine.skipToNext()
+
+        dependencies.mediaSessionBridge.dispatchRemoteCommandForTesting(LegatoAndroidRemoteCommand.Next)
+        assertEquals(LegatoAndroidPlaybackState.ENDED, components.playerEngine.getSnapshot().state)
+
+        playbackRuntime.emitBuffering(false)
+        assertEquals(LegatoAndroidPlaybackState.ENDED, components.playerEngine.getSnapshot().state)
+    }
+
+    @Test
     fun `remote previous seeks to zero when current position is greater than threshold`() = runBlocking {
         val playbackRuntime = RemoteRoutingPlaybackRuntime()
         val eventEmitter = LegatoAndroidEventEmitter()
@@ -312,5 +332,9 @@ private class RemoteRoutingPlaybackRuntime : LegatoAndroidPlaybackRuntime {
         pauseCalls = 0
         seekCalls = 0
         selectIndexCalls = 0
+    }
+
+    fun emitBuffering(isBuffering: Boolean) {
+        listener?.onBuffering(isBuffering)
     }
 }

--- a/native/ios/LegatoCore/Tests/LegatoCoreTests/Queue/LegatoiOSQueueManagerTests.swift
+++ b/native/ios/LegatoCore/Tests/LegatoCoreTests/Queue/LegatoiOSQueueManagerTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import LegatoCore
+
+final class LegatoiOSQueueManagerTests: XCTestCase {
+    func testReplaceQueueThrowsInvalidIndexWhenStartIndexIsOutOfBounds() {
+        let queueManager = LegatoiOSQueueManager()
+        let tracks = [makeTrack(id: "track-1"), makeTrack(id: "track-2")]
+
+        XCTAssertThrowsError(try queueManager.replaceQueue(tracks, startIndex: 5)) { error in
+            guard let queueError = error as? LegatoiOSError else {
+                return XCTFail("Expected LegatoiOSError")
+            }
+
+            XCTAssertEqual(queueError.code, .invalidIndex)
+        }
+    }
+
+    func testReplaceQueueThrowsInvalidIndexWhenEmptyQueueHasStartIndex() {
+        let queueManager = LegatoiOSQueueManager()
+
+        XCTAssertThrowsError(try queueManager.replaceQueue([], startIndex: 0)) { error in
+            guard let queueError = error as? LegatoiOSError else {
+                return XCTFail("Expected LegatoiOSError")
+            }
+
+            XCTAssertEqual(queueError.code, .invalidIndex)
+        }
+    }
+
+    func testMoveToNextReturnsNilWhenQueueIsEmpty() {
+        let queueManager = LegatoiOSQueueManager()
+
+        XCTAssertNil(queueManager.moveToNext())
+    }
+
+    func testMoveToPreviousReturnsNilWhenQueueIsEmpty() {
+        let queueManager = LegatoiOSQueueManager()
+
+        XCTAssertNil(queueManager.moveToPrevious())
+    }
+
+    func testMoveToNextReturnsNilAtQueueBoundary() throws {
+        let queueManager = LegatoiOSQueueManager()
+        let tracks = [makeTrack(id: "track-1"), makeTrack(id: "track-2")]
+        _ = try queueManager.replaceQueue(tracks, startIndex: 1)
+
+        XCTAssertNil(queueManager.moveToNext())
+        XCTAssertEqual(queueManager.getQueueSnapshot().currentIndex, 1)
+    }
+
+    private func makeTrack(id: String) -> LegatoiOSTrack {
+        LegatoiOSTrack(id: id, url: "https://example.com/\(id).mp3")
+    }
+}

--- a/native/ios/LegatoCore/Tests/LegatoCoreTests/State/LegatoiOSStateMachineTests.swift
+++ b/native/ios/LegatoCore/Tests/LegatoCoreTests/State/LegatoiOSStateMachineTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import LegatoCore
+
+final class LegatoiOSStateMachineTests: XCTestCase {
+    func testCanTransitionReturnsTrueForAllowedTransition() {
+        let stateMachine = LegatoiOSStateMachine()
+
+        XCTAssertTrue(stateMachine.canTransition(from: .idle, to: .loading))
+        XCTAssertTrue(stateMachine.canTransition(from: .playing, to: .paused))
+    }
+
+    func testCanTransitionReturnsFalseForDisallowedTransition() {
+        let stateMachine = LegatoiOSStateMachine()
+
+        XCTAssertFalse(stateMachine.canTransition(from: .idle, to: .playing))
+        XCTAssertFalse(stateMachine.canTransition(from: .error, to: .playing))
+    }
+
+    func testReduceMovesToMappedStateWhenTransitionAllowed() {
+        let stateMachine = LegatoiOSStateMachine()
+
+        XCTAssertEqual(stateMachine.reduce(current: .idle, event: .prepare), .loading)
+        XCTAssertEqual(stateMachine.reduce(current: .ready, event: .play), .playing)
+    }
+
+    func testReduceKeepsCurrentStateWhenTransitionIsNotAllowed() {
+        let stateMachine = LegatoiOSStateMachine()
+
+        XCTAssertEqual(stateMachine.reduce(current: .idle, event: .pause), .idle)
+        XCTAssertEqual(stateMachine.reduce(current: .error, event: .trackEnded), .error)
+    }
+}

--- a/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackService.kt
+++ b/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackService.kt
@@ -29,7 +29,10 @@ class LegatoPlaybackService : Service() {
 
     override fun onCreate() {
         super.onCreate()
-        coordinator = LegatoAndroidPlaybackCoordinatorStore.getOrCreate(applicationContext)
+        coordinator = resolveOnCreateDependency(
+            contextProvider = { applicationContext },
+            resolver = LegatoAndroidPlaybackCoordinatorStore::getOrCreate,
+        )
         currentMode = coordinator.currentServiceMode()
         currentPlaybackState = coordinator.currentPlaybackState()
         modeListenerId = coordinator.addServiceModeListener(::onServiceModeChanged)
@@ -267,4 +270,8 @@ class LegatoPlaybackService : Service() {
         private const val MAX_COMPACT_ACTIONS: Int = 3
         private const val MEDIA_SESSION_TAG: String = "legato.playback"
     }
+}
+
+internal fun <C, R> resolveOnCreateDependency(contextProvider: () -> C, resolver: (C) -> R): R {
+    return resolver(contextProvider())
 }

--- a/packages/capacitor/android/src/test/kotlin/io/legato/capacitor/LegatoPlaybackServiceBootstrapTest.kt
+++ b/packages/capacitor/android/src/test/kotlin/io/legato/capacitor/LegatoPlaybackServiceBootstrapTest.kt
@@ -1,0 +1,54 @@
+package io.legato.capacitor
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LegatoPlaybackServiceBootstrapTest {
+    @Test
+    fun `bootstrap helper resolves context lazily and exactly once`() {
+        var providerCalls = 0
+        var resolverCalls = 0
+        var providerRan = false
+
+        val resolved = resolveOnCreateDependency(
+            contextProvider = {
+                providerCalls += 1
+                providerRan = true
+                "app-context"
+            },
+            resolver = { providedContext ->
+                resolverCalls += 1
+                assertTrue(providerRan)
+                "coordinator-for-$providedContext"
+            },
+        )
+
+        assertEquals("coordinator-for-app-context", resolved)
+        assertEquals(1, providerCalls)
+        assertEquals(1, resolverCalls)
+    }
+
+    @Test
+    fun `bootstrap helper forwards exact provider value into resolver`() {
+        data class FakeAppContext(val id: String)
+
+        val provided = FakeAppContext("ctx-1")
+        var observed: FakeAppContext? = null
+        val expectedCoordinator = Any()
+
+        val resolved = resolveOnCreateDependency(
+            contextProvider = { provided },
+            resolver = { context ->
+                observed = context
+                expectedCoordinator
+            },
+        )
+
+        assertSame(provided, observed)
+        assertFalse(observed === null)
+        assertSame(expectedCoordinator, resolved)
+    }
+}


### PR DESCRIPTION
Closes #21

## Summary
- add deterministic iOS pure-logic tests for state-machine and queue manager behavior
- add Android lifecycle edge-case coverage plus service bootstrap testability
- add a read-only PASS/FAIL verdict layer to the Capacitor smoke harness without removing manual controls or raw logs
- include the Android end-of-queue/service lifecycle hardening fixes discovered during validation in this confidence-focused closeout

## Changes
| File | Change |
|------|--------|
| `native/ios/LegatoCore/Tests/LegatoCoreTests/State/LegatoiOSStateMachineTests.swift` | deterministic iOS pure-logic state-machine coverage |
| `native/ios/LegatoCore/Tests/LegatoCoreTests/Queue/LegatoiOSQueueManagerTests.swift` | deterministic iOS pure-logic queue-manager coverage |
| `native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineInterruptionPolicyTest.kt` | Android edge-case coverage for lifecycle/service-mode policy |
| `native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineRemoteCommandRoutingTest.kt` | Android edge-case coverage for remote routing + boundary stability |
| `packages/capacitor/android/src/test/kotlin/io/legato/capacitor/LegatoPlaybackServiceBootstrapTest.kt` | service bootstrap testability/edge-case coverage |
| `apps/capacitor-demo/src/smoke-verdict.js` and tests | pure PASS/FAIL verdict reducer for smoke flows |
| `apps/capacitor-demo/index.html`, `apps/capacitor-demo/src/main.ts` | verdict layer UI while preserving logs, events, snapshots, and manual controls |
| `apps/capacitor-demo/SMOKE_VALIDATION_TEMPLATE.md` | reusable evidence capture template for native validation |
| `native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidPlayerEngine.kt` / `packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackService.kt` | small hardening fixes discovered during validation (stable end-of-queue terminal state, paused notification persistence, service bootstrap seam) |

## Test Plan
- [x] `bash ./gradlew test` from `apps/capacitor-demo/android` remained green for the hardening batches that targeted Android/JVM scope
- [x] `node --test src/smoke-verdict.test.mjs` used for verdict reducer RED→GREEN
- [x] Targeted Android tests were added for edge cases and lifecycle seams
- [ ] iOS pure-logic tests are added but still need an iOS-capable execution path beyond the current host limitations
- [ ] Manual native validation still uses `apps/capacitor-demo/SMOKE_VALIDATION_TEMPLATE.md` as evidence capture template

## Notes
- This PR is hardening-only: no new product feature scope beyond the small Android fixes discovered during validation.
- The known iOS host test-infra limitation remains: SwiftPM execution of some targets is constrained by iOS-only framework availability on this host.
