### PR TITLE
chore(demo): align fixture durations

### DIFF
--- a/apps/capacitor-demo/src/main.ts
+++ b/apps/capacitor-demo/src/main.ts
@@ -94,7 +94,7 @@ const demoTracks: Track[] = [
     artist: 'Samplelib',
     album: 'Legato Remote Parity Fixtures',
     artwork: 'https://samplelib.com/lib/preview/png/sample-bumblebee-400x300.png',
-    duration: 3000,
+    duration: 3239,
     type: 'progressive',
   },
   {
@@ -104,7 +104,7 @@ const demoTracks: Track[] = [
     artist: 'Samplelib',
     album: 'Legato Remote Parity Fixtures',
     artwork: 'https://samplelib.com/lib/preview/png/sample-bumblebee-400x300.png',
-    duration: 6000,
+    duration: 6426,
     type: 'progressive',
   },
 ];


### PR DESCRIPTION
Closes #19

## Summary
- align the demo fixture durations with the actual Samplelib MP3 asset durations observed in native runtime logs
- reduce confusion in smoke snapshots/logs where runtime corrected `3000/6000ms` to `3239/6426ms`

## Changes
| File | Change |
|------|--------|
| `apps/capacitor-demo/src/main.ts` | updates fixture durations from `3000/6000` to `3239/6426` |

## Test Plan
- [x] Verified manually in prior device validation that runtime-reported durations are approximately `3239ms` and `6426ms`
- [ ] Optional smoke rerun after `npm run build && npm run cap:sync` to confirm logs no longer jump from fixture duration to runtime duration

## Notes
- This is a small follow-up polish only; no runtime behavior changed.
