### PR TITLE
fix(android): dedupe ended progress noise

### DIFF
--- a/apps/capacitor-demo/src/main.ts
+++ b/apps/capacitor-demo/src/main.ts
@@ -72,6 +72,7 @@ if (
 const nativeActionButtons = Array.from(document.querySelectorAll<HTMLButtonElement>('.native-action'));
 const playbackSmokeDelayMs = 1500;
 const endSmokeDelayMs = 6500;
+const boundarySettleDelayMs = 300;
 const recentEventsLimit = 24;
 const progressSamplesLimit = 8;
 
@@ -598,12 +599,15 @@ const runBoundarySmokeFlow = async (): Promise<void> => {
   await playAction();
 
   await previousAction();
+  await new Promise((resolve) => setTimeout(resolve, boundarySettleDelayMs));
   await snapshotAction();
 
   await nextAction();
+  await new Promise((resolve) => setTimeout(resolve, boundarySettleDelayMs));
   await snapshotAction();
 
   await nextAction();
+  await new Promise((resolve) => setTimeout(resolve, boundarySettleDelayMs));
   await snapshotAction();
   completeSmokeVerdict();
 };

--- a/native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidPlayerEngine.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidPlayerEngine.kt
@@ -297,7 +297,11 @@ class LegatoAndroidPlayerEngine(
             return
         }
 
-        transitionTo(LegatoAndroidStateMachine.LegatoAndroidStateInput.TRACK_ENDED)
+        val transitioned = transitionTo(LegatoAndroidStateMachine.LegatoAndroidStateInput.TRACK_ENDED)
+        if (!transitioned) {
+            return
+        }
+
         val endedSnapshot = snapshotStore.getPlaybackSnapshot()
         eventEmitter.emit(
             name = LegatoAndroidEventName.PLAYBACK_ENDED,
@@ -341,6 +345,10 @@ class LegatoAndroidPlayerEngine(
 
     private val runtimeListener = object : LegatoAndroidPlaybackRuntimeListener {
         override fun onProgress(progress: LegatoAndroidRuntimeProgress) {
+            if (snapshotStore.getPlaybackSnapshot().state == LegatoAndroidPlaybackState.ENDED) {
+                return
+            }
+
             val runtimeSnapshot = playbackRuntime.snapshot()
             var activeItemChanged = false
 
@@ -378,7 +386,11 @@ class LegatoAndroidPlayerEngine(
         }
 
         override fun onEnded() {
-            transitionTo(LegatoAndroidStateMachine.LegatoAndroidStateInput.TRACK_ENDED)
+            val transitioned = transitionTo(LegatoAndroidStateMachine.LegatoAndroidStateInput.TRACK_ENDED)
+            if (!transitioned) {
+                return
+            }
+
             eventEmitter.emit(
                 name = LegatoAndroidEventName.PLAYBACK_ENDED,
                 payload = LegatoAndroidEventPayload.PlaybackEnded(snapshotStore.getPlaybackSnapshot()),
@@ -401,15 +413,16 @@ class LegatoAndroidPlayerEngine(
     private inline fun runRuntimeOperation(block: () -> Unit): Boolean =
         runCatching(block).onFailure(::publishPlatformFailure).isSuccess
 
-    private fun transitionTo(input: LegatoAndroidStateMachine.LegatoAndroidStateInput) {
+    private fun transitionTo(input: LegatoAndroidStateMachine.LegatoAndroidStateInput): Boolean {
         val previous = snapshotStore.getPlaybackSnapshot()
         val nextState = stateMachine.reduce(previous.state, input)
         if (nextState == previous.state) {
-            return
+            return false
         }
 
         snapshotStore.updatePlaybackSnapshot { it.copy(state = nextState) }
         publishState(nextState)
+        return true
     }
 
     private fun synchronizeActiveItemFromRuntime(

--- a/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineInterruptionPolicyTest.kt
+++ b/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineInterruptionPolicyTest.kt
@@ -115,6 +115,38 @@ class LegatoAndroidPlayerEngineInterruptionPolicyTest {
     }
 
     @Test
+    fun `runtime ended callback is deduped and ignores late progress callbacks`() = runBlocking {
+        val playbackRuntime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val eventEmitter = LegatoAndroidEventEmitter()
+        val events = mutableListOf<LegatoAndroidEvent>()
+        eventEmitter.addListener { event -> events += event }
+        val engine = buildEngine(playbackRuntime, sessionRuntime, eventEmitter)
+
+        engine.setup()
+        engine.load(tracks = listOf(LegatoAndroidTrack(id = "track-1", url = "https://example.com/audio.mp3")))
+        engine.play()
+        playbackRuntime.emitProgress(positionMs = 12_000L, durationMs = 120_000L, bufferedPositionMs = 24_000L)
+
+        events.clear()
+        playbackRuntime.emitEnded()
+        val endedSnapshot = engine.getSnapshot()
+
+        playbackRuntime.emitEnded()
+        playbackRuntime.emitProgress(positionMs = 15_000L, durationMs = 120_000L, bufferedPositionMs = 30_000L)
+
+        val finalSnapshot = engine.getSnapshot()
+        val endedEvents = events.count { it.name == LegatoAndroidEventName.PLAYBACK_ENDED }
+        val progressEvents = events.count { it.name == LegatoAndroidEventName.PLAYBACK_PROGRESS }
+
+        assertEquals(1, endedEvents)
+        assertEquals(0, progressEvents)
+        assertEquals(LegatoAndroidPlaybackState.ENDED, finalSnapshot.state)
+        assertEquals(endedSnapshot.positionMs, finalSnapshot.positionMs)
+        assertEquals(endedSnapshot.bufferedPositionMs, finalSnapshot.bufferedPositionMs)
+    }
+
+    @Test
     fun `runtime buffering callbacks cannot rebound state after ended`() = runBlocking {
         val playbackRuntime = RecordingPlaybackRuntime()
         val sessionRuntime = RecordingSessionRuntime()

--- a/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineRemoteCommandRoutingTest.kt
+++ b/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineRemoteCommandRoutingTest.kt
@@ -169,6 +169,31 @@ class LegatoAndroidPlayerEngineRemoteCommandRoutingTest {
     }
 
     @Test
+    fun `remote next at end does not duplicate playbackEnded when runtime ended callback arrives late`() = runBlocking {
+        val playbackRuntime = RemoteRoutingPlaybackRuntime()
+        val eventEmitter = LegatoAndroidEventEmitter()
+        val dependencies = LegatoAndroidCoreDependencies(
+            eventEmitter = eventEmitter,
+            playbackRuntime = playbackRuntime,
+        )
+        val components = LegatoAndroidCoreFactory.create(dependencies)
+        val events = mutableListOf<LegatoAndroidEvent>()
+        eventEmitter.addListener { event -> events += event }
+
+        components.playerEngine.setup()
+        components.playerEngine.load(tracks = listOf(track(id = "1"), track(id = "2")))
+        components.playerEngine.play()
+        components.playerEngine.skipToNext()
+
+        dependencies.mediaSessionBridge.dispatchRemoteCommandForTesting(LegatoAndroidRemoteCommand.Next)
+        playbackRuntime.emitEnded()
+
+        val playbackEndedCount = events.count { it.name == LegatoAndroidEventName.PLAYBACK_ENDED }
+        assertEquals(LegatoAndroidPlaybackState.ENDED, components.playerEngine.getSnapshot().state)
+        assertEquals(1, playbackEndedCount)
+    }
+
+    @Test
     fun `remote previous seeks to zero when current position is greater than threshold`() = runBlocking {
         val playbackRuntime = RemoteRoutingPlaybackRuntime()
         val eventEmitter = LegatoAndroidEventEmitter()
@@ -336,5 +361,9 @@ private class RemoteRoutingPlaybackRuntime : LegatoAndroidPlaybackRuntime {
 
     fun emitBuffering(isBuffering: Boolean) {
         listener?.onBuffering(isBuffering)
+    }
+
+    fun emitEnded() {
+        listener?.onEnded()
     }
 }


### PR DESCRIPTION
Closes #20

## Summary
- suppress duplicate `playback-ended` emissions after terminal transitions
- ignore stale runtime `playback-progress` callbacks once the canonical snapshot is already `ended`
- keep final terminal snapshot/state semantics unchanged

## Changes
| File | Change |
|------|--------|
| `native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidPlayerEngine.kt` | adds terminal-state dedupe/suppression for ended/progress noise |
| `native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineInterruptionPolicyTest.kt` | adds regression coverage for ended/progress suppression after terminal transition |
| `native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineRemoteCommandRoutingTest.kt` | adds regression coverage for remote-next-at-end dedupe path |

## Test Plan
- [ ] Targeted unit execution in standalone `native/android/core` Gradle context is currently constrained by environment/plugin resolution
- [x] Manual Android logs previously reproduced duplicate `playback-ended` + late `playback-progress`; this patch removes those terminal noise paths at engine level
- [ ] Optional follow-up manual device validation: boundary smoke on Android should now show a single `playback-ended` and no late progress after `ended`

## Notes
- This is a polish-only follow-up; no core transport semantics changed.
