### PR TITLE
test(ios): harden SwiftPM host testability

### DIFF
--- a/native/ios/LegatoCore/Package.swift
+++ b/native/ios/LegatoCore/Package.swift
@@ -9,7 +9,10 @@ let package = Package(
     products: [
         .library(
             name: "LegatoCore",
-            targets: ["LegatoCore"]
+            targets: [
+                "LegatoCore",
+                "LegatoCoreSessionRuntimeiOS"
+            ]
         )
     ],
     targets: [
@@ -17,10 +20,23 @@ let package = Package(
             name: "LegatoCore",
             path: "Sources/LegatoCore"
         ),
+        .target(
+            name: "LegatoCoreSessionRuntimeiOS",
+            dependencies: ["LegatoCore"],
+            path: "Sources/LegatoCoreSessionRuntimeiOS"
+        ),
         .testTarget(
             name: "LegatoCoreTests",
             dependencies: ["LegatoCore"],
             path: "Tests/LegatoCoreTests"
+        ),
+        .testTarget(
+            name: "LegatoCoreSessionRuntimeiOSTests",
+            dependencies: [
+                "LegatoCore",
+                "LegatoCoreSessionRuntimeiOS"
+            ],
+            path: "Tests/LegatoCoreSessionRuntimeiOSTests"
         )
     ]
 )

--- a/native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSCoreComposition.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSCoreComposition.swift
@@ -19,6 +19,8 @@ public struct LegatoiOSCoreDependencies {
         trackMapper: LegatoiOSTrackMapper = LegatoiOSTrackMapper(),
         errorMapper: LegatoiOSErrorMapper = LegatoiOSErrorMapper(),
         stateMachine: LegatoiOSStateMachine = LegatoiOSStateMachine(),
+        // Session runtime resolution is centralized in LegatoiOSSessionManager defaults.
+        // This keeps plugin-facing composition unchanged while remaining host-safe.
         sessionManager: LegatoiOSSessionManager = LegatoiOSSessionManager(),
         nowPlayingManager: LegatoiOSNowPlayingManager = LegatoiOSNowPlayingManager(),
         remoteCommandManager: LegatoiOSRemoteCommandManager = LegatoiOSRemoteCommandManager(),
@@ -35,6 +37,7 @@ public struct LegatoiOSCoreDependencies {
         self.remoteCommandManager = remoteCommandManager
         self.playbackRuntime = playbackRuntime
     }
+
 }
 
 public struct LegatoiOSCoreComponents {

--- a/native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSSessionManager.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSSessionManager.swift
@@ -7,8 +7,9 @@ public final class LegatoiOSSessionManager {
     private let runtime: LegatoiOSSessionRuntime
     private var listeners: [UUID: SignalListener] = [:]
 
-    public init(runtime: LegatoiOSSessionRuntime = LegatoiOSAVAudioSessionRuntime()) {
-        self.runtime = runtime
+    public init(runtime: LegatoiOSSessionRuntime? = nil) {
+        let resolvedRuntime = runtime ?? LegatoiOSSessionRuntimeFactory.makeDefault()
+        self.runtime = resolvedRuntime
         self.runtime.onSignal = { [weak self] signal in
             self?.publish(signal)
         }

--- a/native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSSessionRuntime.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSSessionRuntime.swift
@@ -1,4 +1,3 @@
-import AVFAudio
 import Foundation
 
 public enum LegatoiOSSessionSignal {
@@ -35,138 +34,30 @@ public final class LegatoiOSNoopSessionRuntime: LegatoiOSSessionRuntime {
 }
 
 public final class LegatoiOSAVAudioSessionRuntime: LegatoiOSSessionRuntime {
-    public var onSignal: ((LegatoiOSSessionSignal) -> Void)?
+    public var onSignal: ((LegatoiOSSessionSignal) -> Void)? {
+        didSet {
+            runtime.onSignal = onSignal
+        }
+    }
 
-    private let audioSession: AVAudioSession
-    private let notificationCenter: NotificationCenter
+    private let runtime: any LegatoiOSSessionRuntime
 
-    private var isConfigured = false
-    private var isSessionActive = false
-    private var interruptionObserver: NSObjectProtocol?
-    private var routeChangeObserver: NSObjectProtocol?
-
-    public init(
-        audioSession: AVAudioSession = .sharedInstance(),
-        notificationCenter: NotificationCenter = .default
-    ) {
-        self.audioSession = audioSession
-        self.notificationCenter = notificationCenter
+    /// Milestone 1 scope guard: Session runtime extraction only.
+    /// No changes in Now Playing / Remote Command / AVPlayer adapters.
+    public init() {
+        runtime = LegatoiOSSessionRuntimeFactory.makeDefault()
+        runtime.onSignal = onSignal
     }
 
     public func configureSession() {
-        guard !isConfigured else {
-            return
-        }
-
-        do {
-            try audioSession.setCategory(.playback, mode: .default, options: [])
-            registerNotificationsIfNeeded()
-            isConfigured = true
-        } catch {
-            onSignal?(.runtimeError(message: "Failed to configure AVAudioSession: \(error.localizedDescription)"))
-        }
+        runtime.configureSession()
     }
 
     public func updatePlaybackState(_ state: LegatoiOSPlaybackState) {
-        switch state {
-        case .loading, .ready, .playing, .paused, .buffering:
-            setSessionActive(true)
-        case .idle, .ended, .error:
-            setSessionActive(false)
-        }
+        runtime.updatePlaybackState(state)
     }
 
     public func releaseSession() {
-        removeObservers()
-        setSessionActive(false)
-        isConfigured = false
-    }
-
-    private func setSessionActive(_ shouldBeActive: Bool) {
-        guard shouldBeActive != isSessionActive else {
-            return
-        }
-
-        do {
-            if shouldBeActive {
-                try audioSession.setActive(true)
-            } else {
-                try audioSession.setActive(false, options: [.notifyOthersOnDeactivation])
-            }
-            isSessionActive = shouldBeActive
-        } catch {
-            let action = shouldBeActive ? "activate" : "deactivate"
-            onSignal?(.runtimeError(message: "Failed to \(action) AVAudioSession: \(error.localizedDescription)"))
-        }
-    }
-
-    private func registerNotificationsIfNeeded() {
-        if interruptionObserver == nil {
-            interruptionObserver = notificationCenter.addObserver(
-                forName: AVAudioSession.interruptionNotification,
-                object: audioSession,
-                queue: nil
-            ) { [weak self] notification in
-                self?.handleInterruptionNotification(notification)
-            }
-        }
-
-        if routeChangeObserver == nil {
-            routeChangeObserver = notificationCenter.addObserver(
-                forName: AVAudioSession.routeChangeNotification,
-                object: audioSession,
-                queue: nil
-            ) { [weak self] notification in
-                self?.handleRouteChangeNotification(notification)
-            }
-        }
-    }
-
-    private func handleInterruptionNotification(_ notification: Notification) {
-        guard
-            let typeRaw = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
-            let type = AVAudioSession.InterruptionType(rawValue: typeRaw)
-        else {
-            return
-        }
-
-        switch type {
-        case .began:
-            onSignal?(.interruptionBegan)
-        case .ended:
-            let optionsRaw = notification.userInfo?[AVAudioSessionInterruptionOptionKey] as? UInt ?? 0
-            let options = AVAudioSession.InterruptionOptions(rawValue: optionsRaw)
-            onSignal?(.interruptionEnded(shouldResume: options.contains(.shouldResume)))
-        @unknown default:
-            break
-        }
-    }
-
-    private func handleRouteChangeNotification(_ notification: Notification) {
-        guard
-            let reasonRaw = notification.userInfo?[AVAudioSessionRouteChangeReasonKey] as? UInt,
-            let reason = AVAudioSession.RouteChangeReason(rawValue: reasonRaw)
-        else {
-            return
-        }
-
-        switch reason {
-        case .oldDeviceUnavailable, .noSuitableRouteForCategory:
-            onSignal?(.outputRouteRemoved)
-        default:
-            break
-        }
-    }
-
-    private func removeObservers() {
-        if let interruptionObserver {
-            notificationCenter.removeObserver(interruptionObserver)
-            self.interruptionObserver = nil
-        }
-
-        if let routeChangeObserver {
-            notificationCenter.removeObserver(routeChangeObserver)
-            self.routeChangeObserver = nil
-        }
+        runtime.releaseSession()
     }
 }

--- a/native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSSessionRuntimeFactory.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSSessionRuntimeFactory.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+internal enum LegatoiOSSessionRuntimeFactory {
+    static func makeDefault() -> any LegatoiOSSessionRuntime {
+        #if os(iOS)
+        let className = "LegatoCoreSessionRuntimeiOS.LegatoiOSAVAudioSessionRuntime"
+        if
+            let runtimeType = NSClassFromString(className) as? NSObject.Type,
+            let runtime = runtimeType.init() as? LegatoiOSSessionRuntime
+        {
+            return runtime
+        }
+        #endif
+
+        return LegatoiOSNoopSessionRuntime()
+    }
+}

--- a/native/ios/LegatoCore/Sources/LegatoCoreSessionRuntimeiOS/LegatoiOSAVAudioSessionRuntime.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCoreSessionRuntimeiOS/LegatoiOSAVAudioSessionRuntime.swift
@@ -1,0 +1,169 @@
+import Foundation
+import LegatoCore
+
+#if canImport(AVFAudio) && os(iOS)
+import AVFAudio
+#endif
+
+internal func legatoShouldActivateSession(for state: LegatoiOSPlaybackState) -> Bool {
+    switch state {
+    case .loading, .ready, .playing, .paused, .buffering:
+        return true
+    case .idle, .ended, .error:
+        return false
+    }
+}
+
+#if canImport(AVFAudio) && os(iOS)
+public final class LegatoiOSAVAudioSessionRuntime: NSObject, LegatoiOSSessionRuntime {
+    public var onSignal: ((LegatoiOSSessionSignal) -> Void)?
+
+    private let audioSession: AVAudioSession
+    private let notificationCenter: NotificationCenter
+
+    private var isConfigured = false
+    private var isSessionActive = false
+    private var interruptionObserver: NSObjectProtocol?
+    private var routeChangeObserver: NSObjectProtocol?
+
+    public init(
+        audioSession: AVAudioSession = .sharedInstance(),
+        notificationCenter: NotificationCenter = .default
+    ) {
+        self.audioSession = audioSession
+        self.notificationCenter = notificationCenter
+    }
+
+    public func configureSession() {
+        guard !isConfigured else {
+            return
+        }
+
+        do {
+            try audioSession.setCategory(.playback, mode: .default, options: [])
+            registerNotificationsIfNeeded()
+            isConfigured = true
+        } catch {
+            onSignal?(.runtimeError(message: "Failed to configure AVAudioSession: \(error.localizedDescription)"))
+        }
+    }
+
+    public func updatePlaybackState(_ state: LegatoiOSPlaybackState) {
+        setSessionActive(legatoShouldActivateSession(for: state))
+    }
+
+    public func releaseSession() {
+        removeObservers()
+        setSessionActive(false)
+        isConfigured = false
+    }
+
+    private func setSessionActive(_ shouldBeActive: Bool) {
+        guard shouldBeActive != isSessionActive else {
+            return
+        }
+
+        do {
+            if shouldBeActive {
+                try audioSession.setActive(true)
+            } else {
+                try audioSession.setActive(false, options: [.notifyOthersOnDeactivation])
+            }
+            isSessionActive = shouldBeActive
+        } catch {
+            let action = shouldBeActive ? "activate" : "deactivate"
+            onSignal?(.runtimeError(message: "Failed to \(action) AVAudioSession: \(error.localizedDescription)"))
+        }
+    }
+
+    private func registerNotificationsIfNeeded() {
+        if interruptionObserver == nil {
+            interruptionObserver = notificationCenter.addObserver(
+                forName: AVAudioSession.interruptionNotification,
+                object: audioSession,
+                queue: nil
+            ) { [weak self] notification in
+                self?.handleInterruptionNotification(notification)
+            }
+        }
+
+        if routeChangeObserver == nil {
+            routeChangeObserver = notificationCenter.addObserver(
+                forName: AVAudioSession.routeChangeNotification,
+                object: audioSession,
+                queue: nil
+            ) { [weak self] notification in
+                self?.handleRouteChangeNotification(notification)
+            }
+        }
+    }
+
+    private func handleInterruptionNotification(_ notification: Notification) {
+        guard
+            let typeRaw = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
+            let type = AVAudioSession.InterruptionType(rawValue: typeRaw)
+        else {
+            return
+        }
+
+        switch type {
+        case .began:
+            onSignal?(.interruptionBegan)
+        case .ended:
+            let optionsRaw = notification.userInfo?[AVAudioSessionInterruptionOptionKey] as? UInt ?? 0
+            let options = AVAudioSession.InterruptionOptions(rawValue: optionsRaw)
+            onSignal?(.interruptionEnded(shouldResume: options.contains(.shouldResume)))
+        @unknown default:
+            break
+        }
+    }
+
+    private func handleRouteChangeNotification(_ notification: Notification) {
+        guard
+            let reasonRaw = notification.userInfo?[AVAudioSessionRouteChangeReasonKey] as? UInt,
+            let reason = AVAudioSession.RouteChangeReason(rawValue: reasonRaw)
+        else {
+            return
+        }
+
+        switch reason {
+        case .oldDeviceUnavailable, .noSuitableRouteForCategory:
+            onSignal?(.outputRouteRemoved)
+        default:
+            break
+        }
+    }
+
+    private func removeObservers() {
+        if let interruptionObserver {
+            notificationCenter.removeObserver(interruptionObserver)
+            self.interruptionObserver = nil
+        }
+
+        if let routeChangeObserver {
+            notificationCenter.removeObserver(routeChangeObserver)
+            self.routeChangeObserver = nil
+        }
+    }
+}
+#else
+public final class LegatoiOSAVAudioSessionRuntime: NSObject, LegatoiOSSessionRuntime {
+    public var onSignal: ((LegatoiOSSessionSignal) -> Void)?
+
+    public override init() {
+        super.init()
+    }
+
+    public func configureSession() {
+        // Host-safe no-op fallback.
+    }
+
+    public func updatePlaybackState(_ state: LegatoiOSPlaybackState) {
+        _ = legatoShouldActivateSession(for: state)
+    }
+
+    public func releaseSession() {
+        // Host-safe no-op fallback.
+    }
+}
+#endif

--- a/native/ios/LegatoCore/Sources/LegatoCoreSessionRuntimeiOS/LegatoiOSSessionRuntimeiOSBoundary.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCoreSessionRuntimeiOS/LegatoiOSSessionRuntimeiOSBoundary.swift
@@ -1,0 +1,11 @@
+import Foundation
+import LegatoCore
+
+/// Placeholder boundary target for the iOS-only Session runtime split.
+/// Milestone 1 scope guard: this target only hosts Session runtime extraction.
+/// Now Playing, Remote Command, and AVPlayer adapters remain unchanged.
+internal enum LegatoiOSSessionRuntimeiOSBoundary {
+    static func makeHostSafePlaceholder() -> any LegatoiOSSessionRuntime {
+        LegatoiOSNoopSessionRuntime()
+    }
+}

--- a/native/ios/LegatoCore/Tests/LegatoCoreSessionRuntimeiOSTests/LegatoiOSAVAudioSessionRuntimeExtractionTests.swift
+++ b/native/ios/LegatoCore/Tests/LegatoCoreSessionRuntimeiOSTests/LegatoiOSAVAudioSessionRuntimeExtractionTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import LegatoCoreSessionRuntimeiOS
+import LegatoCore
+
+final class LegatoiOSAVAudioSessionRuntimeExtractionTests: XCTestCase {
+    func testSessionActivationMappingReturnsTrueForPlaying() {
+        XCTAssertTrue(legatoShouldActivateSession(for: .playing))
+    }
+
+    func testSessionActivationMappingReturnsFalseForIdleAndError() {
+        XCTAssertFalse(legatoShouldActivateSession(for: .idle))
+        XCTAssertFalse(legatoShouldActivateSession(for: .error))
+    }
+}

--- a/native/ios/LegatoCore/Tests/LegatoCoreSessionRuntimeiOSTests/LegatoiOSSessionRuntimeFactoryTests.swift
+++ b/native/ios/LegatoCore/Tests/LegatoCoreSessionRuntimeiOSTests/LegatoiOSSessionRuntimeFactoryTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import LegatoCore
+
+final class LegatoiOSSessionRuntimeFactoryTests: XCTestCase {
+    func testMakeDefaultReturnsNoopRuntimeOnNonIOSHosts() {
+        let runtime = LegatoiOSSessionRuntimeFactory.makeDefault()
+
+        #if os(iOS)
+        XCTAssertFalse(runtime is LegatoiOSNoopSessionRuntime)
+        #else
+        XCTAssertTrue(runtime is LegatoiOSNoopSessionRuntime)
+        #endif
+    }
+
+    func testSessionManagerDefaultUsesFactoryResolvedRuntime() {
+        let manager = LegatoiOSSessionManager()
+        let runtime = extractRuntime(from: manager)
+
+        #if os(iOS)
+        XCTAssertFalse(runtime is LegatoiOSNoopSessionRuntime)
+        #else
+        XCTAssertTrue(runtime is LegatoiOSNoopSessionRuntime)
+        #endif
+    }
+
+    func testCoreDependencyDefaultsUseFactoryResolvedSessionManager() {
+        let dependencies = LegatoiOSCoreDependencies()
+        let runtime = extractRuntime(from: dependencies.sessionManager)
+
+        #if os(iOS)
+        XCTAssertFalse(runtime is LegatoiOSNoopSessionRuntime)
+        #else
+        XCTAssertTrue(runtime is LegatoiOSNoopSessionRuntime)
+        #endif
+    }
+
+    private func extractRuntime(from manager: LegatoiOSSessionManager) -> Any {
+        guard let runtime = Mirror(reflecting: manager)
+            .children
+            .first(where: { $0.label == "runtime" })?
+            .value
+        else {
+            XCTFail("Expected LegatoiOSSessionManager runtime storage")
+            return LegatoiOSNoopSessionRuntime()
+        }
+
+        return runtime
+    }
+}

--- a/native/ios/LegatoCore/Tests/LegatoCoreTests/Remote/LegatoiOSRemoteCommandRuntimeTests.swift
+++ b/native/ios/LegatoCore/Tests/LegatoCoreTests/Remote/LegatoiOSRemoteCommandRuntimeTests.swift
@@ -9,11 +9,11 @@ final class LegatoiOSRemoteCommandRuntimeTests: XCTestCase {
 
         runtime.bind { received.append($0) }
 
-        center.playCommand.trigger()
-        center.pauseCommand.trigger()
-        center.nextTrackCommand.trigger()
-        center.previousTrackCommand.trigger()
-        center.changePlaybackPositionCommand.trigger(positionTimeSeconds: 42.5)
+        center.play.trigger()
+        center.pause.trigger()
+        center.next.trigger()
+        center.previous.trigger()
+        center.position.trigger(positionTimeSeconds: 42.5)
 
         XCTAssertEqual(received.count, 5)
         if case .play = received[0] {} else { XCTFail("Expected play command") }
@@ -35,9 +35,9 @@ final class LegatoiOSRemoteCommandRuntimeTests: XCTestCase {
         runtime.bind { _ in }
         runtime.updateTransportCapabilities(.init(canSkipNext: false, canSkipPrevious: true, canSeek: false))
 
-        XCTAssertFalse(center.nextTrackCommand.isEnabled)
-        XCTAssertTrue(center.previousTrackCommand.isEnabled)
-        XCTAssertFalse(center.changePlaybackPositionCommand.isEnabled)
+        XCTAssertFalse(center.next.isEnabled)
+        XCTAssertTrue(center.previous.isEnabled)
+        XCTAssertFalse(center.position.isEnabled)
     }
 
     func testUnbindRemovesRegisteredHandlers() {
@@ -47,20 +47,26 @@ final class LegatoiOSRemoteCommandRuntimeTests: XCTestCase {
         runtime.bind { _ in }
         runtime.unbind()
 
-        XCTAssertEqual(center.playCommand.removeTargetCount, 1)
-        XCTAssertEqual(center.pauseCommand.removeTargetCount, 1)
-        XCTAssertEqual(center.nextTrackCommand.removeTargetCount, 1)
-        XCTAssertEqual(center.previousTrackCommand.removeTargetCount, 1)
-        XCTAssertEqual(center.changePlaybackPositionCommand.removeTargetCount, 1)
+        XCTAssertEqual(center.play.removeTargetCount, 1)
+        XCTAssertEqual(center.pause.removeTargetCount, 1)
+        XCTAssertEqual(center.next.removeTargetCount, 1)
+        XCTAssertEqual(center.previous.removeTargetCount, 1)
+        XCTAssertEqual(center.position.removeTargetCount, 1)
     }
 }
 
 private final class FakeRemoteCommandCenter: LegatoiOSRemoteCommandCenter {
-    let playCommand = FakeButtonCommand()
-    let pauseCommand = FakeButtonCommand()
-    let nextTrackCommand = FakeButtonCommand()
-    let previousTrackCommand = FakeButtonCommand()
-    let changePlaybackPositionCommand = FakePositionCommand()
+    let play = FakeButtonCommand()
+    let pause = FakeButtonCommand()
+    let next = FakeButtonCommand()
+    let previous = FakeButtonCommand()
+    let position = FakePositionCommand()
+
+    var playCommand: any LegatoiOSRemoteCommandHandler { play }
+    var pauseCommand: any LegatoiOSRemoteCommandHandler { pause }
+    var nextTrackCommand: any LegatoiOSRemoteCommandHandler { next }
+    var previousTrackCommand: any LegatoiOSRemoteCommandHandler { previous }
+    var changePlaybackPositionCommand: any LegatoiOSChangePlaybackPositionCommandHandler { position }
 }
 
 private final class FakeButtonCommand: LegatoiOSRemoteCommandHandler {

--- a/native/ios/LegatoCore/Tests/LegatoCoreTests/Session/LegatoiOSSessionManagerTests.swift
+++ b/native/ios/LegatoCore/Tests/LegatoCoreTests/Session/LegatoiOSSessionManagerTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import LegatoCore
+
+final class LegatoiOSSessionManagerTests: XCTestCase {
+    func testDefaultManagerUsesNoopRuntimeOnNonIOSHosts() {
+        let manager = LegatoiOSSessionManager()
+        let runtime = extractRuntime(from: manager)
+
+        #if os(iOS)
+        XCTAssertFalse(runtime is LegatoiOSNoopSessionRuntime)
+        #else
+        XCTAssertTrue(runtime is LegatoiOSNoopSessionRuntime)
+        #endif
+    }
+
+    func testRuntimeSignalsAreForwardedToRegisteredListeners() {
+        let runtime = FakeSessionRuntime()
+        let manager = LegatoiOSSessionManager(runtime: runtime)
+        let expectation = expectation(description: "manager forwards runtime signal")
+
+        _ = manager.addSignalListener { signal in
+            if case .outputRouteRemoved = signal {
+                expectation.fulfill()
+            }
+        }
+
+        runtime.emit(.outputRouteRemoved)
+
+        wait(for: [expectation], timeout: 0.1)
+    }
+
+    private func extractRuntime(from manager: LegatoiOSSessionManager) -> Any {
+        guard let runtime = Mirror(reflecting: manager)
+            .children
+            .first(where: { $0.label == "runtime" })?
+            .value
+        else {
+            XCTFail("Expected LegatoiOSSessionManager runtime storage")
+            return LegatoiOSNoopSessionRuntime()
+        }
+
+        return runtime
+    }
+}
+
+private final class FakeSessionRuntime: LegatoiOSSessionRuntime {
+    var onSignal: ((LegatoiOSSessionSignal) -> Void)?
+
+    func configureSession() {}
+    func updatePlaybackState(_ state: LegatoiOSPlaybackState) {}
+    func releaseSession() {}
+
+    func emit(_ signal: LegatoiOSSessionSignal) {
+        onSignal?(signal)
+    }
+}


### PR DESCRIPTION
Closes #28

## Summary
- split concrete AVAudioSession-backed Session runtime out of the host-testable `LegatoCore` base target into an internal iOS-only target
- keep protocol/signal/noop Session surface in `LegatoCore` while preserving the public product/API and plugin call sites
- add host-safe Session manager/factory/extraction tests and fix the remaining package test blockers so `swift test` can run on macOS hosts

## Changes
| File | Change |
|------|--------|
| `native/ios/LegatoCore/Package.swift` | adds internal `LegatoCoreSessionRuntimeiOS` target and test target while keeping `LegatoCore` as the sole public product |
| `native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSSessionRuntime.swift` | leaves protocol/noop/delegating wrapper in base target and removes direct AVFAudio implementation from host-testable sources |
| `native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSSessionRuntimeFactory.swift` | centralizes default Session runtime resolution (iOS real runtime vs host-safe noop) |
| `native/ios/LegatoCore/Sources/LegatoCoreSessionRuntimeiOS/LegatoiOSAVAudioSessionRuntime.swift` | new internal iOS-only concrete AVAudioSession runtime |
| `native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSCoreComposition.swift` / `LegatoiOSSessionManager.swift` | preserve plugin-facing default behavior through factory-backed composition |
| `native/ios/LegatoCore/Tests/LegatoCoreSessionRuntimeiOSTests/*` | extraction/factory-focused tests for the new internal runtime target |
| `native/ios/LegatoCore/Tests/LegatoCoreTests/Session/LegatoiOSSessionManagerTests.swift` | host-safe SessionManager default/runtime signal tests |
| `native/ios/LegatoCore/Tests/LegatoCoreTests/Remote/LegatoiOSRemoteCommandRuntimeTests.swift` | fixes conformance blocker so package tests compile again |

## Test Plan
- [x] `swift build` in `native/ios/LegatoCore` passes
- [x] `swift test` in `native/ios/LegatoCore` now passes after resolving the unrelated remaining blockers
- [x] mandated baseline runner `bash ./gradlew test` from `apps/capacitor-demo/android` remains green
- [x] iOS demo host smoke build (`xcodebuild ... build`) previously confirmed during the batch sequence

## Notes
- This milestone is intentionally Session-only hardening. It does not modularize Now Playing, Remote Command, or AVPlayer runtime families.
- The public `LegatoCore` product/API stays stable; the new Session runtime target is internal support for host testability.
