### PR TITLE
fix(native): improve media surface fidelity

### DIFF
--- a/apps/capacitor-demo/android/app/src/test/java/com/getcapacitor/myapp/HarnessValidationContractTest.java
+++ b/apps/capacitor-demo/android/app/src/test/java/com/getcapacitor/myapp/HarnessValidationContractTest.java
@@ -41,6 +41,14 @@ public class HarnessValidationContractTest {
         assertTrue("Missing remote next/previous checklist item", html.contains("Remote next/previous parity"));
         assertTrue("Missing remote seek checklist item", html.contains("Remote seek parity"));
         assertTrue("Missing boundary checklist item", html.contains("Boundary behavior parity"));
+        assertTrue(
+                "Missing Android position fidelity checklist item",
+                html.contains("Android lockscreen/notification position from real snapshot")
+        );
+        assertTrue(
+                "Missing iOS playbackRate fidelity checklist item",
+                html.contains("iOS now-playing playbackRate fidelity")
+        );
         assertTrue("Missing now-playing checklist item", html.contains("Now-playing metadata parity"));
         assertTrue("Missing recent events node", html.contains("id=\"events\""));
         assertTrue("Missing snapshot summary node", html.contains("id=\"snapshot-summary\""));
@@ -62,6 +70,14 @@ public class HarnessValidationContractTest {
         assertTrue("Expected capability projection renderer", mainTs.contains("renderCapabilitySummary"));
         assertTrue("Expected boundary smoke flow helper", mainTs.contains("runBoundarySmokeFlow"));
         assertTrue("Expected recent events rendering helper", mainTs.contains("renderRecentEvents"));
+        assertTrue(
+                "Expected parity inspector reminder for Android snapshot-based rebasing",
+                mainTs.contains("Android lockscreen/notification position rebases from real snapshot")
+        );
+        assertTrue(
+                "Expected parity inspector reminder for iOS playbackRate fidelity",
+                mainTs.contains("iOS now-playing playbackRate mirrors play/pause")
+        );
         assertTrue("Expected smoke marker prefix", smokeAutomation.contains("LEGATO_SMOKE_REPORT"));
         assertTrue("Expected smoke report emission", mainTs.contains("buildSmokeMarkerLine"));
     }

--- a/apps/capacitor-demo/index.html
+++ b/apps/capacitor-demo/index.html
@@ -312,7 +312,8 @@ errors=none</pre>
             <li>Remote seek parity: lock-screen/notification seek must match seekTo() and keep snapshot position aligned.</li>
             <li>Boundary behavior parity: previous at first track restarts to 0, next at last track transitions to ended + playbackEnded event.</li>
             <li>Capability projection parity: canSkipNext/canSkipPrevious/canSeek summary must align with queue index + ended/empty states.</li>
-            <li>Progress parity: while playing, lock-screen/notification progress advances; after pause it stays frozen at pause point.</li>
+            <li>Android lockscreen/notification position from real snapshot: on resume/seek, projected position should rebase near snapshot target (no transient 0 reset).</li>
+            <li>iOS now-playing playbackRate fidelity: expect playbackRate=1.0 while playing and playbackRate=0.0 when paused/stopped/non-playing.</li>
             <li>Now-playing metadata parity: verify title/artist/album/artwork/duration are visible in lock screen / media notification.</li>
             <li>Artwork replacement/stale guard: run <code>Run artwork race</code>, then verify lock-screen/notification artwork matches the final active track (no stale previous image).</li>
             <li>Artwork fallback clear: during the race flow, track 3 has no artwork; verify lock-screen/notification clears artwork before switching back to an artwork track.</li>

--- a/apps/capacitor-demo/src/main.ts
+++ b/apps/capacitor-demo/src/main.ts
@@ -119,21 +119,21 @@ const demoTracks: Track[] = [
   },
   {
     id: 'track-demo-2',
-    url: 'https://samplelib.com/mp3/sample-6s.mp3',
-    title: 'Demo Track 2 (6s sample)',
+    url: 'https://samplelib.com/mp3/sample-15s.mp3',
+    title: 'Demo Track 2 (15s sample)',
     artist: 'Samplelib',
     album: 'Legato Artwork Fixture B',
     artwork: 'https://i.pravatar.cc/300',
-    duration: 6426,
+    duration: 19200,
     type: 'progressive',
   },
   {
     id: 'track-demo-3',
-    url: 'https://samplelib.com/mp3/sample-3s.mp3',
-    title: 'Demo Track 3 (3s no-artwork fallback)',
+    url: 'https://samplelib.com/mp3/sample-9s.mp3',
+    title: 'Demo Track 3 (9s no-artwork fallback)',
     artist: 'Samplelib',
     album: 'Legato Artwork Fallback Fixture',
-    duration: 3239,
+    duration: 9613,
     type: 'progressive',
   },
 ];
@@ -399,7 +399,7 @@ const updateParityInspector = (snapshot: PlaybackSnapshot): void => {
     `metadata signal: ${formatRequiredMetadataSignal(snapshot)}`,
     `artwork signal: ${artworkSignal}`,
     `observed sync events: ${summarizeObservedEventSignals()}`,
-    'manual remote check: background app, toggle lock-screen/notification play↔pause, then tap getSnapshot().',
+    'manual fidelity check: Android lockscreen/notification position rebases from real snapshot after resume/seek, and iOS now-playing playbackRate mirrors play/pause (1.0 vs 0.0).',
   ];
 
   paritySummaryNode.textContent = lines.join('\n');
@@ -640,8 +640,25 @@ const clearFlows = (): void => {
   logNode.value = '';
   recentEvents = [];
   latestSmokeReport = null;
+  observedSyncEvents.clear();
   renderRecentEvents();
   renderAutomationPanel();
+};
+
+const resetSmokeBaseline = async (): Promise<void> => {
+  if (syncController) {
+    await stopSync();
+  }
+
+  try {
+    await Legato.stop();
+    log('preflight stop() ok');
+  } catch {
+    // Ignore if playback was not active yet.
+  }
+
+  latestSnapshot = null;
+  recentProgressSamples = [];
 };
 
 const runSmokeFlow = async (): Promise<void> => {
@@ -653,6 +670,7 @@ const runSmokeFlow = async (): Promise<void> => {
   log('Background check: start play(), send app to background, verify playback continues and notification remains active.');
 
   await setupAction();
+  await resetSmokeBaseline();
   await startSync();
   await addAction();
   await playAction();
@@ -674,6 +692,7 @@ const runLetItEndSmokeFlow = async (): Promise<void> => {
   log('Background check: keep app in background and watch for playback-ended event plus service teardown after stop/idle.');
 
   await setupAction();
+  await resetSmokeBaseline();
   await startSync();
   await addAction();
   await playAction();
@@ -693,6 +712,7 @@ const runBoundarySmokeFlow = async (): Promise<void> => {
   log('Boundary check: previous on first track should restart to 0; next on last track should end playback.');
 
   await setupAction();
+  await resetSmokeBaseline();
   await startSync();
   await addAction();
   await playAction();
@@ -717,6 +737,7 @@ const runArtworkRaceFlow = async (): Promise<void> => {
   log('Expected behavior: artwork should track active item, stale fetches should not overwrite latest track, and no-artwork track should clear artwork.');
 
   await setupAction();
+  await resetSmokeBaseline();
   await startSync();
   await addAction();
   await playAction();

--- a/native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidPlayerEngine.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidPlayerEngine.kt
@@ -357,10 +357,18 @@ class LegatoAndroidPlayerEngine(
                 activeItemChanged = syncedSnapshot.currentIndex != snapshot.currentIndex ||
                     syncedSnapshot.currentTrack?.id != snapshot.currentTrack?.id
 
+                val projectedProgress = if (activeItemChanged) {
+                    runtimeSnapshot.progress
+                } else {
+                    progress
+                }
+
                 syncedSnapshot.copy(
-                    positionMs = progress.positionMs,
-                    durationMs = progress.durationMs ?: syncedSnapshot.currentTrack?.durationMs ?: syncedSnapshot.durationMs,
-                    bufferedPositionMs = progress.bufferedPositionMs,
+                    positionMs = projectedProgress.positionMs,
+                    durationMs = projectedProgress.durationMs
+                        ?: syncedSnapshot.currentTrack?.durationMs
+                        ?: syncedSnapshot.durationMs,
+                    bufferedPositionMs = projectedProgress.bufferedPositionMs,
                 )
             }
 

--- a/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineInterruptionPolicyTest.kt
+++ b/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineInterruptionPolicyTest.kt
@@ -243,6 +243,39 @@ class LegatoAndroidPlayerEngineInterruptionPolicyTest {
     }
 
     @Test
+    fun `runtime progress item transition rebases stale callback progress to new active item snapshot`() = runBlocking {
+        val playbackRuntime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val engine = buildEngine(playbackRuntime, sessionRuntime)
+
+        engine.setup()
+        engine.load(
+            tracks = listOf(
+                LegatoAndroidTrack(id = "track-1", url = "https://example.com/1.mp3", durationMs = 100_000L),
+                LegatoAndroidTrack(id = "track-2", url = "https://example.com/2.mp3", durationMs = 200_000L),
+            ),
+        )
+        engine.play()
+
+        playbackRuntime.emitProgress(
+            currentIndex = 1,
+            positionMs = 100_000L,
+            durationMs = 100_000L,
+            bufferedPositionMs = 100_000L,
+            runtimePositionMs = 0L,
+            runtimeDurationMs = null,
+            runtimeBufferedPositionMs = 0L,
+        )
+
+        val snapshot = engine.getSnapshot()
+        assertEquals(1, snapshot.currentIndex)
+        assertEquals("track-2", snapshot.currentTrack?.id)
+        assertEquals(0L, snapshot.positionMs)
+        assertEquals(200_000L, snapshot.durationMs)
+        assertEquals(0L, snapshot.bufferedPositionMs)
+    }
+
+    @Test
     fun `user paused with active track remains playback active for service projection`() = runBlocking {
         val playbackRuntime = RecordingPlaybackRuntime()
         val sessionRuntime = RecordingSessionRuntime()
@@ -357,8 +390,23 @@ private class RecordingPlaybackRuntime : LegatoAndroidPlaybackRuntime {
         listener?.onFatalError(error)
     }
 
-    fun emitProgress(currentIndex: Int? = snapshot.currentIndex, positionMs: Long, durationMs: Long?, bufferedPositionMs: Long?) {
-        snapshot = snapshot.copy(currentIndex = currentIndex)
+    fun emitProgress(
+        currentIndex: Int? = snapshot.currentIndex,
+        positionMs: Long,
+        durationMs: Long?,
+        bufferedPositionMs: Long?,
+        runtimePositionMs: Long = positionMs,
+        runtimeDurationMs: Long? = durationMs,
+        runtimeBufferedPositionMs: Long? = bufferedPositionMs,
+    ) {
+        snapshot = snapshot.copy(
+            currentIndex = currentIndex,
+            progress = snapshot.progress.copy(
+                positionMs = runtimePositionMs,
+                durationMs = runtimeDurationMs,
+                bufferedPositionMs = runtimeBufferedPositionMs,
+            ),
+        )
         listener?.onProgress(
             io.legato.core.runtime.LegatoAndroidRuntimeProgress(
                 positionMs = positionMs,

--- a/native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSPlayerEngine.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSPlayerEngine.swift
@@ -233,11 +233,41 @@ public final class LegatoiOSPlayerEngine: LegatoiOSPlaybackRuntimeObserver {
             return
         }
 
+        if let movedIndex = queueManager.moveToNext() {
+            do {
+                try performRuntimeOperation {
+                    try playbackRuntime.selectIndex(movedIndex)
+                    try playbackRuntime.play()
+                }
+            } catch {
+                return
+            }
+
+            let runtimeSnapshot = normalizedAutoAdvanceRuntimeSnapshot(
+                playbackRuntime.snapshot(),
+                expectedIndex: movedIndex
+            )
+            let track = queueManager.getCurrentTrack()
+            applyRuntimeSnapshot(
+                runtimeSnapshot,
+                currentTrackOverride: track,
+                currentIndexFallback: movedIndex,
+                queueOverride: queueManager.getQueueSnapshot()
+            )
+
+            let updatedSnapshot = snapshotStore.getPlaybackSnapshot()
+            publishQueueAndTrack(updatedSnapshot)
+            publishMetadata(track)
+            publishProgress(updatedSnapshot)
+            return
+        }
+
         applyRuntimeSnapshot(snapshot)
         transition(event: .trackEnded)
 
         let endedSnapshot = snapshotStore.getPlaybackSnapshot()
         publishProgress(endedSnapshot)
+        nowPlayingManager.clear()
         eventEmitter.emit(name: .playbackEnded, payload: .playbackEnded(snapshot: endedSnapshot))
     }
 
@@ -289,6 +319,7 @@ public final class LegatoiOSPlayerEngine: LegatoiOSPlaybackRuntimeObserver {
         eventEmitter.emit(name: .playbackStateChanged, payload: .playbackStateChanged(state: state))
         sessionManager.updatePlaybackState(state)
         remoteCommandManager.updatePlaybackState(state)
+        nowPlayingManager.updatePlaybackState(state)
     }
 
     private func publishProgress(_ snapshot: LegatoiOSPlaybackSnapshot) {
@@ -460,6 +491,27 @@ public final class LegatoiOSPlayerEngine: LegatoiOSPlaybackRuntimeObserver {
         }
     }
 
+    private func normalizedAutoAdvanceRuntimeSnapshot(
+        _ runtimeSnapshot: LegatoiOSRuntimeSnapshot,
+        expectedIndex: Int
+    ) -> LegatoiOSRuntimeSnapshot {
+        guard runtimeSnapshot.stateHint == .ended,
+              (runtimeSnapshot.currentIndex ?? expectedIndex) == expectedIndex
+        else {
+            return runtimeSnapshot
+        }
+
+        return LegatoiOSRuntimeSnapshot(
+            stateHint: .playing,
+            currentIndex: runtimeSnapshot.currentIndex,
+            progress: LegatoiOSRuntimeProgress(
+                positionMs: 0,
+                durationMs: runtimeSnapshot.progress.durationMs,
+                bufferedPositionMs: 0
+            )
+        )
+    }
+
     private func normalizedPositionMs(
         _ positionMs: Int64,
         durationMs: Int64?,
@@ -626,6 +678,7 @@ public final class LegatoiOSPlayerEngine: LegatoiOSPlaybackRuntimeObserver {
         remoteCommandManager.updateTransportCapabilities(
             LegatoiOSTransportCapabilitiesProjector.fromSnapshot(endedSnapshot)
         )
+        nowPlayingManager.clear()
         eventEmitter.emit(name: .playbackEnded, payload: .playbackEnded(snapshot: endedSnapshot))
     }
 }

--- a/native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSNowPlayingManager.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSNowPlayingManager.swift
@@ -15,6 +15,10 @@ public final class LegatoiOSNowPlayingManager {
         runtime.updateProgress(progress)
     }
 
+    public func updatePlaybackState(_ state: LegatoiOSPlaybackState) {
+        runtime.updatePlaybackState(state)
+    }
+
     public func clear() {
         runtime.clear()
     }

--- a/native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSNowPlayingRuntime.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSNowPlayingRuntime.swift
@@ -12,6 +12,7 @@ import MediaPlayer
 public protocol LegatoiOSNowPlayingRuntime {
     func updateMetadata(_ metadata: LegatoiOSNowPlayingMetadata?)
     func updateProgress(_ progress: LegatoiOSProgressUpdate)
+    func updatePlaybackState(_ state: LegatoiOSPlaybackState)
     func clear()
 }
 
@@ -49,18 +50,33 @@ public final class LegatoiOSURLSessionArtworkLoader: LegatoiOSArtworkLoader {
 
 public enum LegatoiOSNowPlayingInfoKey {
     public static let trackIdentifier = "legato.track.id"
+
+    #if canImport(MediaPlayer) && os(iOS)
+    public static let title = MPMediaItemPropertyTitle
+    public static let artist = MPMediaItemPropertyArtist
+    public static let album = MPMediaItemPropertyAlbumTitle
+    public static let duration = MPMediaItemPropertyPlaybackDuration
+    public static let elapsedTime = MPNowPlayingInfoPropertyElapsedPlaybackTime
+    public static let playbackRate = MPNowPlayingInfoPropertyPlaybackRate
+    public static let defaultPlaybackRate = MPNowPlayingInfoPropertyDefaultPlaybackRate
+    public static let artwork = MPMediaItemPropertyArtwork
+    #else
     public static let title = "title"
     public static let artist = "artist"
     public static let album = "albumTitle"
     public static let duration = "playbackDuration"
     public static let elapsedTime = "elapsedPlaybackTime"
+    public static let playbackRate = "playbackRate"
+    public static let defaultPlaybackRate = "defaultPlaybackRate"
     public static let artwork = "artwork"
+    #endif
 }
 
 public final class LegatoiOSMediaPlayerNowPlayingRuntime: LegatoiOSNowPlayingRuntime {
     private let infoCenter: LegatoiOSNowPlayingInfoCenter
     private let artworkLoader: LegatoiOSArtworkLoader
     private let artworkDispatch: (@escaping () -> Void) -> Void
+    private var projectedNowPlayingInfo: [String: Any]
     internal private(set) var activeArtworkToken: UUID?
 
     public init(
@@ -71,6 +87,7 @@ public final class LegatoiOSMediaPlayerNowPlayingRuntime: LegatoiOSNowPlayingRun
         self.infoCenter = infoCenter
         self.artworkLoader = artworkLoader
         self.artworkDispatch = artworkDispatch
+        projectedNowPlayingInfo = infoCenter.nowPlayingInfo ?? [:]
     }
 
     public func updateMetadata(_ metadata: LegatoiOSNowPlayingMetadata?) {
@@ -83,7 +100,7 @@ public final class LegatoiOSMediaPlayerNowPlayingRuntime: LegatoiOSNowPlayingRun
         let token = UUID()
         activeArtworkToken = token
 
-        var info = infoCenter.nowPlayingInfo ?? [:]
+        var info = projectedNowPlayingInfo
         info[LegatoiOSNowPlayingInfoKey.trackIdentifier] = metadata.trackId
         info[LegatoiOSNowPlayingInfoKey.title] = metadata.title
         info[LegatoiOSNowPlayingInfoKey.artist] = metadata.artist
@@ -95,10 +112,12 @@ public final class LegatoiOSMediaPlayerNowPlayingRuntime: LegatoiOSNowPlayingRun
             info.removeValue(forKey: LegatoiOSNowPlayingInfoKey.duration)
         }
 
+        info[LegatoiOSNowPlayingInfoKey.defaultPlaybackRate] = Self.defaultPlaybackRate
+
         // Remove any previous artwork so stale images don't persist across track changes
         info.removeValue(forKey: LegatoiOSNowPlayingInfoKey.artwork)
 
-        infoCenter.nowPlayingInfo = info
+        publish(info)
 
         if let artworkUrlString = metadata.artwork, let artworkUrl = URL(string: artworkUrlString) {
             artworkLoader.loadArtworkData(from: artworkUrl) { [weak self] result in
@@ -110,18 +129,27 @@ public final class LegatoiOSMediaPlayerNowPlayingRuntime: LegatoiOSNowPlayingRun
     }
 
     public func updateProgress(_ progress: LegatoiOSProgressUpdate) {
-        var info = infoCenter.nowPlayingInfo ?? [:]
+        var info = projectedNowPlayingInfo
         info[LegatoiOSNowPlayingInfoKey.elapsedTime] = Self.seconds(fromMs: progress.positionMs)
+        info[LegatoiOSNowPlayingInfoKey.defaultPlaybackRate] = Self.defaultPlaybackRate
 
         if let durationMs = progress.durationMs {
             info[LegatoiOSNowPlayingInfoKey.duration] = Self.seconds(fromMs: durationMs)
         }
 
-        infoCenter.nowPlayingInfo = info
+        publish(info)
+    }
+
+    public func updatePlaybackState(_ state: LegatoiOSPlaybackState) {
+        var info = projectedNowPlayingInfo
+        info[LegatoiOSNowPlayingInfoKey.defaultPlaybackRate] = Self.defaultPlaybackRate
+        info[LegatoiOSNowPlayingInfoKey.playbackRate] = state == .playing ? Self.defaultPlaybackRate : 0.0
+        publish(info)
     }
 
     public func clear() {
         activeArtworkToken = nil
+        projectedNowPlayingInfo.removeAll()
         infoCenter.nowPlayingInfo = nil
     }
 
@@ -135,12 +163,17 @@ public final class LegatoiOSMediaPlayerNowPlayingRuntime: LegatoiOSNowPlayingRun
             guard let artwork = Self.createMediaItemArtwork(from: data) else {
                 return
             }
-            var info = infoCenter.nowPlayingInfo ?? [:]
+            var info = projectedNowPlayingInfo
             info[LegatoiOSNowPlayingInfoKey.artwork] = artwork
-            infoCenter.nowPlayingInfo = info
+            publish(info)
         case .failure:
             break
         }
+    }
+
+    private func publish(_ info: [String: Any]) {
+        projectedNowPlayingInfo = info
+        infoCenter.nowPlayingInfo = info
     }
 
     private static func createMediaItemArtwork(from data: Data) -> Any? {
@@ -168,6 +201,8 @@ public final class LegatoiOSMediaPlayerNowPlayingRuntime: LegatoiOSNowPlayingRun
     private static func seconds(fromMs value: Int64) -> Double {
         Double(max(0, value)) / 1_000.0
     }
+
+    private static let defaultPlaybackRate: Double = 1.0
 }
 
 public final class LegatoiOSNoopNowPlayingRuntime: LegatoiOSNowPlayingRuntime {
@@ -178,6 +213,10 @@ public final class LegatoiOSNoopNowPlayingRuntime: LegatoiOSNowPlayingRuntime {
     }
 
     public func updateProgress(_ progress: LegatoiOSProgressUpdate) {
+        // Intentionally no-op.
+    }
+
+    public func updatePlaybackState(_ state: LegatoiOSPlaybackState) {
         // Intentionally no-op.
     }
 

--- a/native/ios/LegatoCore/Sources/LegatoCoreSessionRuntimeiOS/LegatoiOSAVAudioSessionRuntime.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCoreSessionRuntimeiOS/LegatoiOSAVAudioSessionRuntime.swift
@@ -26,12 +26,19 @@ public final class LegatoiOSAVAudioSessionRuntime: NSObject, LegatoiOSSessionRun
     private var interruptionObserver: NSObjectProtocol?
     private var routeChangeObserver: NSObjectProtocol?
 
+    public override init() {
+        self.audioSession = .sharedInstance()
+        self.notificationCenter = .default
+        super.init()
+    }
+
     public init(
         audioSession: AVAudioSession = .sharedInstance(),
         notificationCenter: NotificationCenter = .default
     ) {
         self.audioSession = audioSession
         self.notificationCenter = notificationCenter
+        super.init()
     }
 
     public func configureSession() {

--- a/native/ios/LegatoCore/Tests/LegatoCoreTests/Core/LegatoiOSPlayerEngineNowPlayingProjectionTests.swift
+++ b/native/ios/LegatoCore/Tests/LegatoCoreTests/Core/LegatoiOSPlayerEngineNowPlayingProjectionTests.swift
@@ -1,0 +1,240 @@
+import XCTest
+@testable import LegatoCore
+
+final class LegatoiOSPlayerEngineNowPlayingProjectionTests: XCTestCase {
+    func testRuntimeTrackEndAutoAdvancesToNextTrackWithoutClearingNowPlaying() throws {
+        let playbackRuntime = FakePlaybackRuntime()
+        let nowPlayingRuntime = SpyNowPlayingRuntime()
+        let engine = makeEngine(playbackRuntime: playbackRuntime, nowPlayingRuntime: nowPlayingRuntime)
+
+        try engine.setup()
+        try engine.load(
+            tracks: [
+                LegatoiOSTrack(id: "track-1", url: "https://example.com/1.mp3", durationMs: 100_000),
+                LegatoiOSTrack(id: "track-2", url: "https://example.com/2.mp3", durationMs: 200_000)
+            ]
+        )
+        try engine.play()
+        let playCallsBeforeEnd = playbackRuntime.playCallCount
+
+        playbackRuntime.emitTrackEnd(positionMs: 100_000, durationMs: 100_000)
+
+        let snapshot = engine.snapshot()
+        XCTAssertEqual(snapshot.currentIndex, 1)
+        XCTAssertEqual(snapshot.currentTrack?.id, "track-2")
+        XCTAssertEqual(snapshot.positionMs, 0)
+        XCTAssertEqual(snapshot.durationMs, 200_000)
+        XCTAssertEqual(nowPlayingRuntime.receivedMetadata.last??.trackId, "track-2")
+        XCTAssertEqual(nowPlayingRuntime.clearCallCount, 0)
+        XCTAssertEqual(playbackRuntime.playCallCount, playCallsBeforeEnd + 1)
+    }
+
+    func testRuntimeTrackEndAutoAdvanceDoesNotProjectEndedProgressIntoNextTrack() throws {
+        let playbackRuntime = FakePlaybackRuntime()
+        let nowPlayingRuntime = SpyNowPlayingRuntime()
+        let engine = makeEngine(playbackRuntime: playbackRuntime, nowPlayingRuntime: nowPlayingRuntime)
+
+        try engine.setup()
+        try engine.load(
+            tracks: [
+                LegatoiOSTrack(id: "track-1", url: "https://example.com/1.mp3", durationMs: 100_000),
+                LegatoiOSTrack(id: "track-2", url: "https://example.com/2.mp3", durationMs: 200_000)
+            ]
+        )
+        try engine.play()
+
+        playbackRuntime.emitTrackEnd(positionMs: 100_000, durationMs: 100_000)
+
+        let snapshot = engine.snapshot()
+        XCTAssertEqual(snapshot.currentIndex, 1)
+        XCTAssertEqual(snapshot.currentTrack?.id, "track-2")
+        XCTAssertEqual(snapshot.positionMs, 0)
+        XCTAssertEqual(snapshot.bufferedPositionMs, 0)
+        XCTAssertEqual(snapshot.state, .playing)
+    }
+
+    func testRuntimeTrackEndOnFinalItemClearsNowPlayingSurface() throws {
+        let playbackRuntime = FakePlaybackRuntime()
+        let nowPlayingRuntime = SpyNowPlayingRuntime()
+        let engine = makeEngine(playbackRuntime: playbackRuntime, nowPlayingRuntime: nowPlayingRuntime)
+
+        try engine.setup()
+        try engine.load(
+            tracks: [LegatoiOSTrack(id: "track-1", url: "https://example.com/1.mp3", durationMs: 100_000)]
+        )
+        try engine.play()
+
+        playbackRuntime.emitTrackEnd(positionMs: 100_000, durationMs: 100_000)
+
+        XCTAssertEqual(engine.snapshot().state, .ended)
+        XCTAssertEqual(nowPlayingRuntime.receivedStates.last, .ended)
+        XCTAssertEqual(nowPlayingRuntime.clearCallCount, 1)
+    }
+
+    func testRuntimePlayingTransitionProjectsPlayingStateToNowPlayingManager() throws {
+        let playbackRuntime = FakePlaybackRuntime()
+        let nowPlayingRuntime = SpyNowPlayingRuntime()
+        let engine = makeEngine(playbackRuntime: playbackRuntime, nowPlayingRuntime: nowPlayingRuntime)
+
+        try engine.setup()
+
+        playbackRuntime.emitStateHint(.loading)
+        playbackRuntime.emitStateHint(.ready)
+        playbackRuntime.emitStateHint(.playing)
+
+        XCTAssertEqual(nowPlayingRuntime.receivedStates.last, .playing)
+    }
+
+    func testRuntimePausedBufferingAndEndedTransitionsProjectStateToNowPlayingManager() throws {
+        let playbackRuntime = FakePlaybackRuntime()
+        let nowPlayingRuntime = SpyNowPlayingRuntime()
+        let engine = makeEngine(playbackRuntime: playbackRuntime, nowPlayingRuntime: nowPlayingRuntime)
+
+        try engine.setup()
+
+        playbackRuntime.emitStateHint(.loading)
+        playbackRuntime.emitStateHint(.ready)
+        playbackRuntime.emitStateHint(.playing)
+        playbackRuntime.emitStateHint(.paused)
+        XCTAssertEqual(nowPlayingRuntime.receivedStates.last, .paused)
+
+        playbackRuntime.emitStateHint(.buffering)
+        XCTAssertEqual(nowPlayingRuntime.receivedStates.last, .buffering)
+
+        playbackRuntime.emitStateHint(.playing)
+        playbackRuntime.emitStateHint(.ended)
+        XCTAssertEqual(nowPlayingRuntime.receivedStates.last, .ended)
+
+    }
+
+    func testRuntimeErrorTransitionProjectsStateToNowPlayingManager() throws {
+        let playbackRuntime = FakePlaybackRuntime()
+        let nowPlayingRuntime = SpyNowPlayingRuntime()
+        let engine = makeEngine(playbackRuntime: playbackRuntime, nowPlayingRuntime: nowPlayingRuntime)
+
+        try engine.setup()
+
+        playbackRuntime.emitStateHint(.loading)
+        playbackRuntime.emitStateHint(.ready)
+        playbackRuntime.emitStateHint(.playing)
+        playbackRuntime.emitStateHint(.error)
+
+        XCTAssertEqual(nowPlayingRuntime.receivedStates.last, .error)
+    }
+
+    private func makeEngine(
+        playbackRuntime: FakePlaybackRuntime,
+        nowPlayingRuntime: SpyNowPlayingRuntime
+    ) -> LegatoiOSPlayerEngine {
+        LegatoiOSPlayerEngine(
+            queueManager: LegatoiOSQueueManager(),
+            eventEmitter: LegatoiOSEventEmitter(),
+            snapshotStore: LegatoiOSSnapshotStore(),
+            trackMapper: LegatoiOSTrackMapper(),
+            errorMapper: LegatoiOSErrorMapper(),
+            stateMachine: LegatoiOSStateMachine(),
+            sessionManager: LegatoiOSSessionManager(runtime: FakeSessionRuntime()),
+            nowPlayingManager: LegatoiOSNowPlayingManager(runtime: nowPlayingRuntime),
+            remoteCommandManager: LegatoiOSRemoteCommandManager(runtime: FakeRemoteCommandRuntime()),
+            playbackRuntime: playbackRuntime
+        )
+    }
+}
+
+private final class SpyNowPlayingRuntime: LegatoiOSNowPlayingRuntime {
+    private(set) var receivedStates: [LegatoiOSPlaybackState] = []
+    private(set) var receivedMetadata: [LegatoiOSNowPlayingMetadata?] = []
+    private(set) var clearCallCount: Int = 0
+
+    func updateMetadata(_ metadata: LegatoiOSNowPlayingMetadata?) {
+        receivedMetadata.append(metadata)
+    }
+
+    func updateProgress(_ progress: LegatoiOSProgressUpdate) {}
+
+    func updatePlaybackState(_ state: LegatoiOSPlaybackState) {
+        receivedStates.append(state)
+    }
+
+    func clear() {
+        clearCallCount += 1
+    }
+}
+
+private final class FakePlaybackRuntime: LegatoiOSPlaybackRuntime {
+    private weak var observer: LegatoiOSPlaybackRuntimeObserver?
+    private var currentSnapshot = LegatoiOSRuntimeSnapshot()
+    private(set) var playCallCount: Int = 0
+
+    func configure() {}
+
+    func setObserver(_ observer: LegatoiOSPlaybackRuntimeObserver?) {
+        self.observer = observer
+    }
+
+    func replaceQueue(items: [LegatoiOSRuntimeTrackSource], startIndex: Int?) throws {
+        currentSnapshot = LegatoiOSRuntimeSnapshot(
+            stateHint: currentSnapshot.stateHint,
+            currentIndex: startIndex ?? 0,
+            progress: currentSnapshot.progress
+        )
+    }
+
+    func selectIndex(_ index: Int) throws {
+        currentSnapshot = LegatoiOSRuntimeSnapshot(
+            stateHint: currentSnapshot.stateHint,
+            currentIndex: index,
+            progress: LegatoiOSRuntimeProgress(positionMs: 0, durationMs: nil, bufferedPositionMs: 0)
+        )
+    }
+
+    func play() throws {
+        playCallCount += 1
+    }
+    func pause() throws {}
+    func stop(resetPosition: Bool) throws {}
+    func seek(to positionMs: Int64) throws {}
+
+    func snapshot() -> LegatoiOSRuntimeSnapshot {
+        currentSnapshot
+    }
+
+    func release() {}
+
+    func emitStateHint(_ state: LegatoiOSPlaybackState) {
+        currentSnapshot = LegatoiOSRuntimeSnapshot(
+            stateHint: state,
+            currentIndex: currentSnapshot.currentIndex,
+            progress: currentSnapshot.progress
+        )
+        observer?.playbackRuntimeDidUpdateProgress(currentSnapshot)
+    }
+
+    func emitTrackEnd(positionMs: Int64, durationMs: Int64?) {
+        currentSnapshot = LegatoiOSRuntimeSnapshot(
+            stateHint: .ended,
+            currentIndex: currentSnapshot.currentIndex,
+            progress: LegatoiOSRuntimeProgress(
+                positionMs: positionMs,
+                durationMs: durationMs,
+                bufferedPositionMs: durationMs
+            )
+        )
+        observer?.playbackRuntimeDidReachTrackEnd(currentSnapshot)
+    }
+}
+
+private final class FakeSessionRuntime: LegatoiOSSessionRuntime {
+    var onSignal: ((LegatoiOSSessionSignal) -> Void)?
+
+    func configureSession() {}
+    func updatePlaybackState(_ state: LegatoiOSPlaybackState) {}
+    func releaseSession() {}
+}
+
+private final class FakeRemoteCommandRuntime: LegatoiOSRemoteCommandRuntime {
+    func bind(dispatch: @escaping (LegatoiOSRemoteCommand) -> Void) {}
+    func updatePlaybackState(_ state: LegatoiOSPlaybackState) {}
+    func updateTransportCapabilities(_ capabilities: LegatoiOSTransportCapabilities) {}
+    func unbind() {}
+}

--- a/native/ios/LegatoCore/Tests/LegatoCoreTests/Session/LegatoiOSNowPlayingManagerTests.swift
+++ b/native/ios/LegatoCore/Tests/LegatoCoreTests/Session/LegatoiOSNowPlayingManagerTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import LegatoCore
+
+final class LegatoiOSNowPlayingManagerTests: XCTestCase {
+    func testUpdatePlaybackStateForwardsStateToRuntime() {
+        let runtime = SpyNowPlayingRuntime()
+        let manager = LegatoiOSNowPlayingManager(runtime: runtime)
+
+        manager.updatePlaybackState(.paused)
+
+        XCTAssertEqual(runtime.receivedStates, [.paused])
+    }
+}
+
+private final class SpyNowPlayingRuntime: LegatoiOSNowPlayingRuntime {
+    private(set) var receivedStates: [LegatoiOSPlaybackState] = []
+
+    func updateMetadata(_ metadata: LegatoiOSNowPlayingMetadata?) {}
+
+    func updateProgress(_ progress: LegatoiOSProgressUpdate) {}
+
+    func updatePlaybackState(_ state: LegatoiOSPlaybackState) {
+        receivedStates.append(state)
+    }
+
+    func clear() {}
+}

--- a/native/ios/LegatoCore/Tests/LegatoCoreTests/Session/LegatoiOSNowPlayingRuntimeTests.swift
+++ b/native/ios/LegatoCore/Tests/LegatoCoreTests/Session/LegatoiOSNowPlayingRuntimeTests.swift
@@ -1,7 +1,72 @@
 import XCTest
 @testable import LegatoCore
 
+#if canImport(MediaPlayer) && os(iOS)
+import MediaPlayer
+#endif
+
 final class LegatoiOSNowPlayingRuntimeTests: XCTestCase {
+    func testUpdatePlaybackStatePlayingWritesPlaybackRateOne() {
+        let center = FakeNowPlayingInfoCenter()
+        let runtime = LegatoiOSMediaPlayerNowPlayingRuntime(infoCenter: center)
+
+        runtime.updatePlaybackState(.playing)
+
+        XCTAssertEqual(center.nowPlayingInfo?[LegatoiOSNowPlayingInfoKey.playbackRate] as? Double, 1.0)
+        XCTAssertEqual(center.nowPlayingInfo?[LegatoiOSNowPlayingInfoKey.defaultPlaybackRate] as? Double, 1.0)
+    }
+
+    func testUpdatePlaybackStateNonPlayingWritesPlaybackRateZero() {
+        let center = FakeNowPlayingInfoCenter()
+        let runtime = LegatoiOSMediaPlayerNowPlayingRuntime(infoCenter: center)
+
+        let nonPlayingStates: [LegatoiOSPlaybackState] = [
+            .idle,
+            .loading,
+            .ready,
+            .paused,
+            .buffering,
+            .ended,
+            .error
+        ]
+
+        for state in nonPlayingStates {
+            runtime.updatePlaybackState(state)
+            XCTAssertEqual(
+                center.nowPlayingInfo?[LegatoiOSNowPlayingInfoKey.playbackRate] as? Double,
+                0.0,
+                "Expected playbackRate = 0.0 for state \(state)"
+            )
+            XCTAssertEqual(
+                center.nowPlayingInfo?[LegatoiOSNowPlayingInfoKey.defaultPlaybackRate] as? Double,
+                1.0,
+                "Expected defaultPlaybackRate = 1.0 for state \(state)"
+            )
+        }
+    }
+
+    func testNowPlayingInfoKeysMapToExpectedMediaPlayerPayloadKeys() {
+        #if canImport(MediaPlayer) && os(iOS)
+        XCTAssertEqual(LegatoiOSNowPlayingInfoKey.title, MPMediaItemPropertyTitle)
+        XCTAssertEqual(LegatoiOSNowPlayingInfoKey.artist, MPMediaItemPropertyArtist)
+        XCTAssertEqual(LegatoiOSNowPlayingInfoKey.album, MPMediaItemPropertyAlbumTitle)
+        XCTAssertEqual(LegatoiOSNowPlayingInfoKey.duration, MPMediaItemPropertyPlaybackDuration)
+        XCTAssertEqual(LegatoiOSNowPlayingInfoKey.elapsedTime, MPNowPlayingInfoPropertyElapsedPlaybackTime)
+        XCTAssertEqual(LegatoiOSNowPlayingInfoKey.playbackRate, MPNowPlayingInfoPropertyPlaybackRate)
+        XCTAssertEqual(LegatoiOSNowPlayingInfoKey.defaultPlaybackRate, MPNowPlayingInfoPropertyDefaultPlaybackRate)
+        XCTAssertEqual(LegatoiOSNowPlayingInfoKey.artwork, MPMediaItemPropertyArtwork)
+        #else
+        XCTAssertEqual(LegatoiOSNowPlayingInfoKey.title, "title")
+        XCTAssertEqual(LegatoiOSNowPlayingInfoKey.artist, "artist")
+        XCTAssertEqual(LegatoiOSNowPlayingInfoKey.album, "albumTitle")
+        XCTAssertEqual(LegatoiOSNowPlayingInfoKey.duration, "playbackDuration")
+        XCTAssertEqual(LegatoiOSNowPlayingInfoKey.elapsedTime, "elapsedPlaybackTime")
+        XCTAssertEqual(LegatoiOSNowPlayingInfoKey.playbackRate, "playbackRate")
+        XCTAssertEqual(LegatoiOSNowPlayingInfoKey.defaultPlaybackRate, "defaultPlaybackRate")
+        XCTAssertEqual(LegatoiOSNowPlayingInfoKey.artwork, "artwork")
+        #endif
+    }
+
     func testUpdateMetadataRotatesActiveArtworkToken() {
         let center = FakeNowPlayingInfoCenter()
         let runtime = LegatoiOSMediaPlayerNowPlayingRuntime(
@@ -87,6 +152,67 @@ final class LegatoiOSNowPlayingRuntimeTests: XCTestCase {
         let info = center.nowPlayingInfo
         XCTAssertEqual(info?[LegatoiOSNowPlayingInfoKey.elapsedTime] as? Double, 15.5)
         XCTAssertEqual(info?[LegatoiOSNowPlayingInfoKey.duration] as? Double, 120)
+    }
+
+    func testPauseResumeKeepsElapsedPositionAndDefaultPlaybackRate() {
+        let center = FakeNowPlayingInfoCenter()
+        let runtime = LegatoiOSMediaPlayerNowPlayingRuntime(infoCenter: center)
+
+        runtime.updateProgress(.init(positionMs: 45_000, durationMs: 120_000, bufferedPositionMs: nil))
+        runtime.updatePlaybackState(.paused)
+
+        XCTAssertEqual(center.nowPlayingInfo?[LegatoiOSNowPlayingInfoKey.elapsedTime] as? Double, 45)
+        XCTAssertEqual(center.nowPlayingInfo?[LegatoiOSNowPlayingInfoKey.playbackRate] as? Double, 0.0)
+        XCTAssertEqual(center.nowPlayingInfo?[LegatoiOSNowPlayingInfoKey.defaultPlaybackRate] as? Double, 1.0)
+
+        runtime.updatePlaybackState(.playing)
+
+        XCTAssertEqual(center.nowPlayingInfo?[LegatoiOSNowPlayingInfoKey.elapsedTime] as? Double, 45)
+        XCTAssertEqual(center.nowPlayingInfo?[LegatoiOSNowPlayingInfoKey.playbackRate] as? Double, 1.0)
+        XCTAssertEqual(center.nowPlayingInfo?[LegatoiOSNowPlayingInfoKey.defaultPlaybackRate] as? Double, 1.0)
+    }
+
+    func testUpdatePlaybackStateRestoresCoherentPayloadWhenInfoCenterIsClearedExternally() {
+        let center = FakeNowPlayingInfoCenter()
+        let runtime = LegatoiOSMediaPlayerNowPlayingRuntime(infoCenter: center)
+
+        runtime.updateMetadata(
+            .init(
+                trackId: "track-1",
+                title: "Song",
+                artist: "Artist",
+                album: "Album",
+                durationMs: 120_000
+            )
+        )
+        runtime.updateProgress(.init(positionMs: 45_000, durationMs: 120_000, bufferedPositionMs: nil))
+
+        center.nowPlayingInfo = nil
+        runtime.updatePlaybackState(.paused)
+
+        let info = center.nowPlayingInfo
+        XCTAssertEqual(info?[LegatoiOSNowPlayingInfoKey.title] as? String, "Song")
+        XCTAssertEqual(info?[LegatoiOSNowPlayingInfoKey.duration] as? Double, 120)
+        XCTAssertEqual(info?[LegatoiOSNowPlayingInfoKey.elapsedTime] as? Double, 45)
+        XCTAssertEqual(info?[LegatoiOSNowPlayingInfoKey.playbackRate] as? Double, 0.0)
+        XCTAssertEqual(info?[LegatoiOSNowPlayingInfoKey.defaultPlaybackRate] as? Double, 1.0)
+    }
+
+    func testUpdatePlaybackStateRestoresElapsedWhenInfoCenterPayloadBecomesPartial() {
+        let center = FakeNowPlayingInfoCenter()
+        let runtime = LegatoiOSMediaPlayerNowPlayingRuntime(infoCenter: center)
+
+        runtime.updateProgress(.init(positionMs: 45_000, durationMs: 120_000, bufferedPositionMs: nil))
+        runtime.updatePlaybackState(.paused)
+
+        center.nowPlayingInfo = [LegatoiOSNowPlayingInfoKey.title: "Song"]
+        runtime.updatePlaybackState(.playing)
+
+        let info = center.nowPlayingInfo
+        XCTAssertEqual(info?[LegatoiOSNowPlayingInfoKey.elapsedTime] as? Double, 45)
+        XCTAssertEqual(info?[LegatoiOSNowPlayingInfoKey.duration] as? Double, 120)
+        XCTAssertEqual(info?[LegatoiOSNowPlayingInfoKey.playbackRate] as? Double, 1.0)
+        XCTAssertEqual(info?[LegatoiOSNowPlayingInfoKey.defaultPlaybackRate] as? Double, 1.0)
     }
 
     func testClearRemovesNowPlayingInfo() {

--- a/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackService.kt
+++ b/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackService.kt
@@ -42,6 +42,7 @@ class LegatoPlaybackService : Service() {
     private var activeArtworkRequestToken: ArtworkRequestToken? = null
     private var activeArtworkJob: Job? = null
     private var mediaSession: MediaSession? = null
+    private var lastMediaSessionProjection: MediaSessionPlaybackProjection? = null
     private val artworkRequestTokenFactory: ArtworkRequestTokenFactory = ArtworkRequestTokenFactory()
     private val artworkLoader: LegatoPlaybackArtworkLoader = DefaultLegatoPlaybackArtworkLoader
     private val artworkDiagnostics: LegatoPlaybackArtworkDiagnostics = AndroidLogcatArtworkDiagnostics
@@ -153,8 +154,12 @@ class LegatoPlaybackService : Service() {
     }
 
     private fun onNowPlayingMetadataChanged(metadata: LegatoAndroidNowPlayingMetadata?) {
+        val previousTrackId = currentNowPlayingMetadata?.trackId
         currentNowPlayingMetadata = metadata
         currentArtworkBitmap = null
+        if (previousTrackId != metadata?.trackId) {
+            syncMediaSessionPlaybackState(currentPlaybackState)
+        }
         publishNowPlayingSurfaces()
         refreshArtworkFor(metadata)
     }
@@ -329,33 +334,23 @@ class LegatoPlaybackService : Service() {
     }
 
     private fun syncMediaSessionPlaybackState(state: LegatoAndroidPlaybackState) {
-        val capabilities = LegatoAndroidTransportCapabilitiesProjector.fromSnapshot(coordinator.core.playerEngine.getSnapshot())
+        val snapshot = coordinator.core.playerEngine.getSnapshot()
+        val capabilities = LegatoAndroidTransportCapabilitiesProjector.fromSnapshot(snapshot)
+        val projectedState = projectMediaSessionPlaybackState(
+            state = state,
+            snapshotPositionMs = snapshot.positionMs,
+            activeTrackId = currentNowPlayingMetadata?.trackId ?: snapshot.currentTrack?.id,
+            previousProjection = lastMediaSessionProjection,
+        )
         val playbackState = PlaybackState.Builder()
             .setActions(LegatoPlaybackNotificationTransport.playbackStateActionsFor(state, capabilities))
             .setState(
-                when (state) {
-                    LegatoAndroidPlaybackState.PLAYING,
-                    LegatoAndroidPlaybackState.BUFFERING,
-                    -> PlaybackState.STATE_PLAYING
-
-                    LegatoAndroidPlaybackState.PAUSED,
-                    LegatoAndroidPlaybackState.READY,
-                    -> PlaybackState.STATE_PAUSED
-
-                    LegatoAndroidPlaybackState.LOADING -> PlaybackState.STATE_BUFFERING
-                    LegatoAndroidPlaybackState.ENDED,
-                    LegatoAndroidPlaybackState.IDLE,
-                    LegatoAndroidPlaybackState.ERROR,
-                    -> PlaybackState.STATE_STOPPED
-                },
-                0L,
-                if (state == LegatoAndroidPlaybackState.PLAYING || state == LegatoAndroidPlaybackState.BUFFERING) {
-                    1f
-                } else {
-                    0f
-                },
+                projectedState.playbackStateCode,
+                projectedState.positionMs,
+                projectedState.playbackSpeed,
             )
             .build()
+        lastMediaSessionProjection = projectedState
         mediaSession?.setPlaybackState(playbackState)
     }
 
@@ -420,6 +415,95 @@ class LegatoPlaybackService : Service() {
 
 internal fun <C, R> resolveOnCreateDependency(contextProvider: () -> C, resolver: (C) -> R): R {
     return resolver(contextProvider())
+}
+
+internal data class MediaSessionPlaybackProjection(
+    val playbackStateCode: Int,
+    val positionMs: Long,
+    val playbackSpeed: Float,
+    val activeTrackId: String?,
+)
+
+internal fun projectMediaSessionPlaybackState(
+    state: LegatoAndroidPlaybackState,
+    snapshotPositionMs: Long,
+    activeTrackId: String?,
+    previousProjection: MediaSessionPlaybackProjection?,
+): MediaSessionPlaybackProjection {
+    val playbackStateCode = when (state) {
+        LegatoAndroidPlaybackState.PLAYING -> PlaybackState.STATE_PLAYING
+
+        LegatoAndroidPlaybackState.BUFFERING,
+        LegatoAndroidPlaybackState.LOADING,
+        -> PlaybackState.STATE_BUFFERING
+
+        LegatoAndroidPlaybackState.PAUSED,
+        LegatoAndroidPlaybackState.READY,
+        -> PlaybackState.STATE_PAUSED
+
+        LegatoAndroidPlaybackState.ENDED,
+        LegatoAndroidPlaybackState.IDLE,
+        LegatoAndroidPlaybackState.ERROR,
+        -> PlaybackState.STATE_STOPPED
+    }
+    val playbackSpeed = if (state == LegatoAndroidPlaybackState.PLAYING) {
+        1f
+    } else {
+        0f
+    }
+    val projectedPositionMs = when {
+        shouldResetProjectionForTrackTransition(state, activeTrackId, previousProjection) -> 0L
+        shouldClampProjectionRewind(state, activeTrackId, snapshotPositionMs, previousProjection) -> {
+            previousProjection?.positionMs ?: snapshotPositionMs
+        }
+
+        else -> snapshotPositionMs
+    }
+
+    return MediaSessionPlaybackProjection(
+        playbackStateCode = playbackStateCode,
+        positionMs = projectedPositionMs,
+        playbackSpeed = playbackSpeed,
+        activeTrackId = activeTrackId,
+    )
+}
+
+private const val MAX_MEDIA_SESSION_REWIND_JITTER_MS: Long = 1_500L
+
+internal fun shouldResetProjectionForTrackTransition(
+    state: LegatoAndroidPlaybackState,
+    activeTrackId: String?,
+    previousProjection: MediaSessionPlaybackProjection?,
+): Boolean {
+    if (state != LegatoAndroidPlaybackState.BUFFERING && state != LegatoAndroidPlaybackState.LOADING) {
+        return false
+    }
+
+    val previousTrackId = previousProjection?.activeTrackId ?: return false
+    return activeTrackId != null && activeTrackId != previousTrackId
+}
+
+internal fun shouldClampProjectionRewind(
+    state: LegatoAndroidPlaybackState,
+    activeTrackId: String?,
+    snapshotPositionMs: Long,
+    previousProjection: MediaSessionPlaybackProjection?,
+): Boolean {
+    if (state != LegatoAndroidPlaybackState.PLAYING && state != LegatoAndroidPlaybackState.BUFFERING) {
+        return false
+    }
+
+    val previous = previousProjection ?: return false
+    if (activeTrackId == null || previous.activeTrackId != activeTrackId) {
+        return false
+    }
+
+    if (snapshotPositionMs >= previous.positionMs) {
+        return false
+    }
+
+    val rewindDelta = previous.positionMs - snapshotPositionMs
+    return rewindDelta <= MAX_MEDIA_SESSION_REWIND_JITTER_MS
 }
 
 internal data class ArtworkRequestToken(

--- a/packages/capacitor/android/src/test/kotlin/io/legato/capacitor/LegatoPlaybackServiceBootstrapTest.kt
+++ b/packages/capacitor/android/src/test/kotlin/io/legato/capacitor/LegatoPlaybackServiceBootstrapTest.kt
@@ -1,6 +1,7 @@
 package io.legato.capacitor
 
 import io.legato.core.core.LegatoAndroidNowPlayingMetadata
+import io.legato.core.core.LegatoAndroidPlaybackState
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -10,6 +11,91 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Test
 
 class LegatoPlaybackServiceBootstrapTest {
+    @Test
+    fun `media-session projection keeps canonical snapshot position when playback resumes`() {
+        val projection = projectMediaSessionPlaybackState(
+            state = LegatoAndroidPlaybackState.PLAYING,
+            snapshotPositionMs = 93_000L,
+            activeTrackId = "track-1",
+            previousProjection = null,
+        )
+
+        assertEquals(93_000L, projection.positionMs)
+        assertNotEquals(0L, projection.positionMs)
+    }
+
+    @Test
+    fun `media-session projection re-bases position after seek without resetting to zero`() {
+        val projection = projectMediaSessionPlaybackState(
+            state = LegatoAndroidPlaybackState.PLAYING,
+            snapshotPositionMs = 205_000L,
+            activeTrackId = "track-1",
+            previousProjection = null,
+        )
+
+        assertEquals(205_000L, projection.positionMs)
+        assertNotEquals(0L, projection.positionMs)
+    }
+
+    @Test
+    fun `media-session projection publishes buffering without synthetic progress speed`() {
+        val projection = projectMediaSessionPlaybackState(
+            state = LegatoAndroidPlaybackState.BUFFERING,
+            snapshotPositionMs = 1_500L,
+            activeTrackId = "track-1",
+            previousProjection = null,
+        )
+
+        assertEquals(android.media.session.PlaybackState.STATE_BUFFERING, projection.playbackStateCode)
+        assertEquals(0f, projection.playbackSpeed)
+    }
+
+    @Test
+    fun `media-session projection clamps small same-track rewinds to avoid early visual jumps`() {
+        val projection = projectMediaSessionPlaybackState(
+            state = LegatoAndroidPlaybackState.PLAYING,
+            snapshotPositionMs = 2_200L,
+            activeTrackId = "track-1",
+            previousProjection = MediaSessionPlaybackProjection(
+                playbackStateCode = android.media.session.PlaybackState.STATE_PLAYING,
+                positionMs = 3_000L,
+                playbackSpeed = 1f,
+                activeTrackId = "track-1",
+            ),
+        )
+
+        assertEquals(3_000L, projection.positionMs)
+    }
+
+    @Test
+    fun `media-session projection allows explicit rewinds and track transitions`() {
+        val sameTrackSeekBackProjection = projectMediaSessionPlaybackState(
+            state = LegatoAndroidPlaybackState.PLAYING,
+            snapshotPositionMs = 1_000L,
+            activeTrackId = "track-1",
+            previousProjection = MediaSessionPlaybackProjection(
+                playbackStateCode = android.media.session.PlaybackState.STATE_PLAYING,
+                positionMs = 15_000L,
+                playbackSpeed = 1f,
+                activeTrackId = "track-1",
+            ),
+        )
+        val nextTrackProjection = projectMediaSessionPlaybackState(
+            state = LegatoAndroidPlaybackState.BUFFERING,
+            snapshotPositionMs = 0L,
+            activeTrackId = "track-2",
+            previousProjection = MediaSessionPlaybackProjection(
+                playbackStateCode = android.media.session.PlaybackState.STATE_PLAYING,
+                positionMs = 15_000L,
+                playbackSpeed = 1f,
+                activeTrackId = "track-1",
+            ),
+        )
+
+        assertEquals(1_000L, sameTrackSeekBackProjection.positionMs)
+        assertEquals(0L, nextTrackProjection.positionMs)
+    }
+
     @Test
     fun `artwork completion applies only when token and active metadata still match`() {
         val activeToken = ArtworkRequestToken(


### PR DESCRIPTION
Closes #32

## Summary
- project Android media-surface progress from canonical snapshot position instead of placeholder/unstable values
- project iOS now-playing playback-rate/progress from a coherent runtime-owned payload and clear terminal state cleanly
- add focused test coverage and harness wording so Android position fidelity and iOS play/pause fidelity can be validated directly

## Changes
| File | Change |
|------|--------|
| `packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackService.kt` | projects media-session playback state from canonical snapshot position and stabilizes transition behavior |
| `native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidPlayerEngine.kt` | normalizes end-of-queue and transition behavior to reduce stale projection noise |
| `native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineInterruptionPolicyTest.kt` | adds regression coverage for Android projection/end-of-queue behavior |
| `packages/capacitor/android/src/test/kotlin/io/legato/capacitor/LegatoPlaybackServiceBootstrapTest.kt` | adds projection-focused Android service tests |
| `native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSNowPlayingRuntime.swift` | uses runtime-owned projected payload and official MediaPlayer keys for pause/resume fidelity |
| `native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSNowPlayingManager.swift` | forwards playback-state updates into now-playing runtime seam |
| `native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSPlayerEngine.swift` | projects canonical state into now-playing and normalizes stale-ended auto-advance path |
| `native/ios/LegatoCore/Sources/LegatoCoreSessionRuntimeiOS/LegatoiOSAVAudioSessionRuntime.swift` | fixes reflective init path for extracted Session runtime |
| `native/ios/LegatoCore/Tests/LegatoCoreTests/Session/LegatoiOSNowPlayingRuntimeTests.swift`, `...NowPlayingManagerTests.swift`, `...NowPlayingProjectionTests.swift` | focused iOS projection regression coverage |
| `apps/capacitor-demo/index.html`, `apps/capacitor-demo/src/main.ts`, `apps/capacitor-demo/android/app/src/test/java/com/getcapacitor/myapp/HarnessValidationContractTest.java` | explicit harness wording/checks for Android position fidelity + iOS playbackRate/progress fidelity |

## Test Plan
- [x] `swift test --filter LegatoiOSNowPlayingRuntimeTests` / targeted iOS tests were green during implementation
- [x] `bash ./apps/capacitor-demo/android/gradlew test` remained green
- [x] Manual Android validation confirmed position fidelity is acceptable after the latest projection fix
- [x] Manual iOS validation confirmed pause/resume now preserves system progress bar fidelity correctly

## Notes
- This milestone is fidelity/polish only; it does not add new transport capabilities or change artwork/metadata scope.
- Android/emulator timing can still introduce minor visual noise, but the major incorrect reset/restart behaviors were addressed.
