### PR TITLE
feat(api): extract audio and media boundaries

### DIFF
--- a/apps/capacitor-demo/android/app/src/test/java/com/getcapacitor/myapp/HarnessValidationContractTest.java
+++ b/apps/capacitor-demo/android/app/src/test/java/com/getcapacitor/myapp/HarnessValidationContractTest.java
@@ -59,14 +59,23 @@ public class HarnessValidationContractTest {
     }
 
     @Test
-    public void mainTs_usesDirectAudioUrlsAndExposesBoundaryAndCapabilitySignals() throws Exception {
+    public void mainTs_usesCurrentDirectFixturesAndExposesBoundaryAndCapabilitySignals() throws Exception {
         String mainTs = readRepoFile("apps/capacitor-demo/src/main.ts");
         String smokeAutomation = readRepoFile("apps/capacitor-demo/src/smoke-automation.js");
 
         assertTrue("Smoke defaults should avoid redirect URLs", !mainTs.contains("soundhelix.com") && !mainTs.contains("redirect"));
-        assertTrue("Expected direct samplelib URL for smoke fixture", mainTs.contains("https://samplelib.com/mp3/sample-3s.mp3"));
-        assertTrue("Expected skip-to-next handler", mainTs.contains("Legato.skipToNext()"));
-        assertTrue("Expected skip-to-previous handler", mainTs.contains("Legato.skipToPrevious()"));
+        assertTrue("Expected direct samplelib URL for fixture track 1", mainTs.contains("https://samplelib.com/mp3/sample-12s.mp3"));
+        assertTrue("Expected direct samplelib URL for fixture track 2", mainTs.contains("https://samplelib.com/mp3/sample-15s.mp3"));
+        assertTrue("Expected direct samplelib URL for fixture track 3", mainTs.contains("https://samplelib.com/mp3/sample-9s.mp3"));
+        assertTrue("Expected fixture duration for track 1", mainTs.contains("duration: 12000"));
+        assertTrue("Expected fixture duration for track 2", mainTs.contains("duration: 19200"));
+        assertTrue("Expected fixture duration for track 3", mainTs.contains("duration: 9613"));
+        assertTrue("Expected artwork fixture mapping block", mainTs.contains("const expectedArtworkByTrackId"));
+        assertTrue("Expected artwork mapping for track 1", mainTs.contains("'track-demo-1': demoTracks[0].artwork ?? null"));
+        assertTrue("Expected artwork mapping for track 2", mainTs.contains("'track-demo-2': demoTracks[1].artwork ?? null"));
+        assertTrue("Expected artwork mapping for track 3", mainTs.contains("'track-demo-3': demoTracks[2].artwork ?? null"));
+        assertTrue("Expected skip-to-next handler", mainTs.contains("resolvePlaybackApi(surface).skipToNext()"));
+        assertTrue("Expected skip-to-previous handler", mainTs.contains("resolvePlaybackApi(surface).skipToPrevious()"));
         assertTrue("Expected capability projection renderer", mainTs.contains("renderCapabilitySummary"));
         assertTrue("Expected boundary smoke flow helper", mainTs.contains("runBoundarySmokeFlow"));
         assertTrue("Expected recent events rendering helper", mainTs.contains("renderRecentEvents"));

--- a/apps/capacitor-demo/index.html
+++ b/apps/capacitor-demo/index.html
@@ -128,6 +128,17 @@
         font-size: 0.82rem;
       }
 
+      #boundary-summary {
+        margin: 0;
+        padding: 0.75rem;
+        border: 1px solid #d1d5db;
+        border-radius: 8px;
+        min-height: 120px;
+        white-space: pre-wrap;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+        font-size: 0.82rem;
+      }
+
       #capability-summary {
         margin: 0;
         padding: 0.65rem 0.75rem;
@@ -235,6 +246,7 @@
             <button id="run-smoke" class="native-action" type="button">Run smoke flow (setup/add/play/pause/snapshot)</button>
             <button id="run-end-smoke" class="native-action" type="button">Run let-it-end smoke</button>
             <button id="run-boundary-smoke" class="native-action" type="button">Run boundary smoke (previous/next/end)</button>
+            <button id="run-surface-validation" class="native-action" type="button">Run API boundary validation (Legato/audioPlayer/mediaSession)</button>
             <button id="run-artwork-race" class="native-action" type="button">Run artwork race (rapid switch + fallback)</button>
             <button id="copy-log" type="button">Copy raw log</button>
             <button id="copy-events" type="button">Copy recent events</button>
@@ -263,6 +275,15 @@ errors=none</pre>
         <section class="card stack">
           <h2>Manual native controls</h2>
           <p>Use these when validating background/lifecycle behavior step-by-step.</p>
+          <div class="actions">
+            <button id="use-legato-surface" type="button">Manual target: Legato facade</button>
+            <button id="use-audioplayer-surface" type="button">Manual target: audioPlayer namespace</button>
+          </div>
+          <pre id="boundary-summary">activeSurface=legato
+playbackTarget=Legato facade
+playbackCommands=setup, add, play, pause, stop, seekTo, getSnapshot
+mediaSessionCommands=addListener(remote-*), removeAllListeners
+checks=none yet</pre>
           <div class="action-grid">
             <button id="action-setup" class="native-action" type="button">setup()</button>
             <button id="action-sync-start" class="native-action" type="button">sync.start()</button>

--- a/apps/capacitor-demo/src/boundary-harness.d.ts
+++ b/apps/capacitor-demo/src/boundary-harness.d.ts
@@ -1,0 +1,20 @@
+export type PlaybackSurface = 'legato' | 'audioPlayer';
+
+export type BoundaryCheck = {
+  label: string;
+  ok: boolean;
+  detail: string;
+};
+
+export type BoundarySurfaceSnapshot = {
+  activeSurface: PlaybackSurface;
+  playbackTarget: string;
+  playbackCommands: string[];
+  mediaSessionCommands: string[];
+};
+
+export function createBoundarySurfaceSnapshot(activeSurface: PlaybackSurface): BoundarySurfaceSnapshot;
+
+export function summarizeBoundaryValidation(payload: BoundarySurfaceSnapshot & {
+  parityChecks: BoundaryCheck[];
+}): string;

--- a/apps/capacitor-demo/src/boundary-harness.js
+++ b/apps/capacitor-demo/src/boundary-harness.js
@@ -1,0 +1,49 @@
+const PLAYBACK_COMMANDS = ['setup', 'add', 'play', 'pause', 'stop', 'seekTo', 'getSnapshot'];
+const MEDIA_SESSION_COMMANDS = ['addListener(remote-*)', 'removeAllListeners'];
+
+/**
+ * @param {'legato' | 'audioPlayer'} activeSurface
+ */
+export const createBoundarySurfaceSnapshot = (activeSurface) => {
+  const normalizedSurface = activeSurface === 'audioPlayer' ? 'audioPlayer' : 'legato';
+
+  return {
+    activeSurface: normalizedSurface,
+    playbackTarget: normalizedSurface === 'audioPlayer' ? 'audioPlayer namespace' : 'Legato facade',
+    playbackCommands: [...PLAYBACK_COMMANDS],
+    mediaSessionCommands: [...MEDIA_SESSION_COMMANDS],
+  };
+};
+
+/**
+ * @typedef {{label: string; ok: boolean; detail: string}} BoundaryCheck
+ */
+
+/**
+ * @param {{
+ *   activeSurface: 'legato' | 'audioPlayer';
+ *   playbackTarget: string;
+ *   playbackCommands: string[];
+ *   mediaSessionCommands: string[];
+ *   parityChecks: BoundaryCheck[];
+ * }} payload
+ */
+export const summarizeBoundaryValidation = (payload) => {
+  const lines = [
+    `activeSurface=${payload.activeSurface}`,
+    `playbackTarget=${payload.playbackTarget}`,
+    `playbackCommands=${payload.playbackCommands.join(', ')}`,
+    `mediaSessionCommands=${payload.mediaSessionCommands.join(', ')}`,
+  ];
+
+  if (payload.parityChecks.length === 0) {
+    lines.push('checks=none yet');
+    return lines.join('\n');
+  }
+
+  lines.push('checks:');
+  payload.parityChecks.forEach((check) => {
+    lines.push(`${check.ok ? '✅' : '❌'} ${check.label} — ${check.detail}`);
+  });
+  return lines.join('\n');
+};

--- a/apps/capacitor-demo/src/boundary-harness.test.mjs
+++ b/apps/capacitor-demo/src/boundary-harness.test.mjs
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  createBoundarySurfaceSnapshot,
+  summarizeBoundaryValidation,
+} from './boundary-harness.js';
+
+test('createBoundarySurfaceSnapshot reports playback controls for Legato facade', () => {
+  const snapshot = createBoundarySurfaceSnapshot('legato');
+
+  assert.equal(snapshot.activeSurface, 'legato');
+  assert.equal(snapshot.playbackTarget, 'Legato facade');
+  assert.deepEqual(snapshot.playbackCommands, ['setup', 'add', 'play', 'pause', 'stop', 'seekTo', 'getSnapshot']);
+  assert.deepEqual(snapshot.mediaSessionCommands, ['addListener(remote-*)', 'removeAllListeners']);
+});
+
+test('createBoundarySurfaceSnapshot reports playback controls for audioPlayer namespace', () => {
+  const snapshot = createBoundarySurfaceSnapshot('audioPlayer');
+
+  assert.equal(snapshot.activeSurface, 'audioPlayer');
+  assert.equal(snapshot.playbackTarget, 'audioPlayer namespace');
+});
+
+test('summarizeBoundaryValidation renders copy-friendly multi-line status', () => {
+  const summary = summarizeBoundaryValidation({
+    activeSurface: 'audioPlayer',
+    playbackTarget: 'audioPlayer namespace',
+    playbackCommands: ['setup', 'add', 'play'],
+    mediaSessionCommands: ['addListener(remote-*)'],
+    parityChecks: [
+      { label: 'Legato facade smoke path', ok: true, detail: 'setup/add/play/pause/stop/seekTo/getSnapshot executed via Legato' },
+      { label: 'audioPlayer smoke path', ok: true, detail: 'setup/add/play/pause/stop/seekTo/getSnapshot executed via audioPlayer' },
+      { label: 'mediaSession boundary visibility', ok: true, detail: 'remote listener registration available via mediaSession' },
+    ],
+  });
+
+  assert.match(summary, /activeSurface=audioPlayer/);
+  assert.match(summary, /playbackTarget=audioPlayer namespace/);
+  assert.match(summary, /playbackCommands=setup, add, play/);
+  assert.match(summary, /mediaSessionCommands=addListener\(remote-\*\)/);
+  assert.match(summary, /✅ Legato facade smoke path/);
+  assert.match(summary, /✅ mediaSession boundary visibility/);
+});
+
+test('summarizeBoundaryValidation marks failed checks clearly', () => {
+  const summary = summarizeBoundaryValidation({
+    activeSurface: 'legato',
+    playbackTarget: 'Legato facade',
+    playbackCommands: ['setup'],
+    mediaSessionCommands: ['addListener(remote-*)'],
+    parityChecks: [
+      { label: 'audioPlayer smoke path', ok: false, detail: 'audioPlayer call failed: timeout' },
+    ],
+  });
+
+  assert.match(summary, /❌ audioPlayer smoke path — audioPlayer call failed: timeout/);
+});

--- a/apps/capacitor-demo/src/main.ts
+++ b/apps/capacitor-demo/src/main.ts
@@ -1,5 +1,13 @@
 import { Capacitor } from '@capacitor/core';
-import { Legato, createLegatoSync, type PlaybackSnapshot, type Track } from '@legato/capacitor';
+import {
+  Legato,
+  audioPlayer,
+  createLegatoSync,
+  mediaSession,
+  type AudioPlayerApi,
+  type PlaybackSnapshot,
+  type Track,
+} from '@legato/capacitor';
 import {
   buildSmokeReportV1,
   createInitialSmokeVerdict,
@@ -13,12 +21,17 @@ import {
   buildSmokeMarkerLine,
   deriveAutomationStatus,
 } from './smoke-automation.js';
+import {
+  createBoundarySurfaceSnapshot,
+  summarizeBoundaryValidation,
+} from './boundary-harness.js';
 
 type LegatoSyncController = ReturnType<typeof createLegatoSync>;
 
 const smokeButton = document.querySelector<HTMLButtonElement>('#run-smoke');
 const endSmokeButton = document.querySelector<HTMLButtonElement>('#run-end-smoke');
 const boundarySmokeButton = document.querySelector<HTMLButtonElement>('#run-boundary-smoke');
+const surfaceValidationButton = document.querySelector<HTMLButtonElement>('#run-surface-validation');
 const artworkRaceButton = document.querySelector<HTMLButtonElement>('#run-artwork-race');
 const copyLogButton = document.querySelector<HTMLButtonElement>('#copy-log');
 const copyEventsButton = document.querySelector<HTMLButtonElement>('#copy-events');
@@ -34,6 +47,8 @@ const previousButton = document.querySelector<HTMLButtonElement>('#action-previo
 const nextButton = document.querySelector<HTMLButtonElement>('#action-next');
 const seekButton = document.querySelector<HTMLButtonElement>('#action-seek');
 const snapshotButton = document.querySelector<HTMLButtonElement>('#action-snapshot');
+const useLegatoSurfaceButton = document.querySelector<HTMLButtonElement>('#use-legato-surface');
+const useAudioPlayerSurfaceButton = document.querySelector<HTMLButtonElement>('#use-audioplayer-surface');
 const seekInput = document.querySelector<HTMLInputElement>('#seek-ms');
 const envStatusNode = document.querySelector<HTMLDivElement>('#env-status');
 const verdictStatusNode = document.querySelector<HTMLDivElement>('#verdict-status');
@@ -48,11 +63,13 @@ const snapshotJsonNode = document.querySelector<HTMLTextAreaElement>('#snapshot-
 const automationStatusNode = document.querySelector<HTMLDivElement>('#automation-status');
 const smokeReportJsonNode = document.querySelector<HTMLTextAreaElement>('#smoke-report-json');
 const automationSnapshotNode = document.querySelector<HTMLPreElement>('#automation-snapshot');
+const boundarySummaryNode = document.querySelector<HTMLPreElement>('#boundary-summary');
 
 if (
   !smokeButton
   || !endSmokeButton
   || !boundarySmokeButton
+  || !surfaceValidationButton
   || !artworkRaceButton
   || !copyLogButton
   || !copyEventsButton
@@ -68,6 +85,8 @@ if (
   || !nextButton
   || !seekButton
   || !snapshotButton
+  || !useLegatoSurfaceButton
+  || !useAudioPlayerSurfaceButton
   || !seekInput
   || !envStatusNode
   || !verdictStatusNode
@@ -82,6 +101,7 @@ if (
   || !automationStatusNode
   || !smokeReportJsonNode
   || !automationSnapshotNode
+  || !boundarySummaryNode
 ) {
   throw new Error('Demo UI nodes are missing');
 }
@@ -97,6 +117,9 @@ const progressSamplesLimit = 8;
 const platform = Capacitor.getPlatform();
 const isNative = Capacitor.isNativePlatform();
 
+type PlaybackSurface = 'legato' | 'audioPlayer';
+type BoundaryCheck = { label: string; ok: boolean; detail: string };
+
 let syncController: LegatoSyncController | null = null;
 let latestSnapshot: PlaybackSnapshot | null = null;
 let recentEvents: string[] = [];
@@ -105,16 +128,22 @@ let smokeVerdict = createInitialSmokeVerdict();
 let latestSmokeReport: SmokeReportV1 | null = null;
 let activeSmokeFlow: SmokeFlow | null = null;
 const observedSyncEvents = new Set<string>();
+let activePlaybackSurface: PlaybackSurface = 'legato';
+let boundaryChecks: BoundaryCheck[] = [];
+
+const resolvePlaybackApi = (surface: PlaybackSurface): AudioPlayerApi => (
+  surface === 'audioPlayer' ? audioPlayer : Legato
+);
 
 const demoTracks: Track[] = [
   {
     id: 'track-demo-1',
-    url: 'https://samplelib.com/mp3/sample-3s.mp3',
-    title: 'Demo Track 1 (3s sample)',
+    url: 'https://samplelib.com/mp3/sample-12s.mp3',
+    title: 'Demo Track 1 (12s sample)',
     artist: 'Samplelib',
     album: 'Legato Artwork Fixture A',
     artwork: 'https://i.pravatar.cc/300',
-    duration: 3239,
+    duration: 12000,
     type: 'progressive',
   },
   {
@@ -133,6 +162,7 @@ const demoTracks: Track[] = [
     title: 'Demo Track 3 (9s no-artwork fallback)',
     artist: 'Samplelib',
     album: 'Legato Artwork Fallback Fixture',
+    artwork: 'https://i.pravatar.cc/300',
     duration: 9613,
     type: 'progressive',
   },
@@ -141,7 +171,7 @@ const demoTracks: Track[] = [
 const expectedArtworkByTrackId: Record<string, string | null> = {
   'track-demo-1': demoTracks[0].artwork ?? null,
   'track-demo-2': demoTracks[1].artwork ?? null,
-  'track-demo-3': null,
+  'track-demo-3': demoTracks[2].artwork ?? null,
 };
 
 const formatMs = (value: number | null | undefined): string => {
@@ -405,6 +435,22 @@ const updateParityInspector = (snapshot: PlaybackSnapshot): void => {
   paritySummaryNode.textContent = lines.join('\n');
 };
 
+const renderBoundarySummary = (): void => {
+  const surfaceSnapshot = createBoundarySurfaceSnapshot(activePlaybackSurface);
+  boundarySummaryNode.textContent = summarizeBoundaryValidation({
+    ...surfaceSnapshot,
+    parityChecks: boundaryChecks,
+  });
+
+  useLegatoSurfaceButton.disabled = activePlaybackSurface === 'legato';
+  useAudioPlayerSurfaceButton.disabled = activePlaybackSurface === 'audioPlayer';
+};
+
+const addBoundaryCheck = (check: BoundaryCheck): void => {
+  boundaryChecks = [...boundaryChecks.slice(-7), check];
+  renderBoundarySummary();
+};
+
 const log = (message: string, payload?: unknown): void => {
   const prefix = `[${new Date().toLocaleTimeString()}]`;
   const line = payload === undefined ? message : `${message} ${summarizePayload(payload)}`;
@@ -587,53 +633,53 @@ const copyText = async (text: string, emptyMessage: string, successMessage: stri
   }
 };
 
-const setupAction = async (): Promise<void> => {
-  await Legato.setup();
-  log('setup() ok');
+const setupAction = async (surface: PlaybackSurface = activePlaybackSurface): Promise<void> => {
+  await resolvePlaybackApi(surface).setup();
+  log(`[${surface}] setup() ok`);
 };
 
-const addAction = async (): Promise<void> => {
-  const afterAdd = await Legato.add({ tracks: demoTracks, startIndex: 0 });
+const addAction = async (surface: PlaybackSurface = activePlaybackSurface): Promise<void> => {
+  const afterAdd = await resolvePlaybackApi(surface).add({ tracks: demoTracks, startIndex: 0 });
   updateSnapshotViews(afterAdd);
-  log('add() snapshot', afterAdd);
+  log(`[${surface}] add() snapshot`, afterAdd);
 };
 
-const playAction = async (): Promise<void> => {
-  await Legato.play();
-  log('play() ok');
+const playAction = async (surface: PlaybackSurface = activePlaybackSurface): Promise<void> => {
+  await resolvePlaybackApi(surface).play();
+  log(`[${surface}] play() ok`);
 };
 
-const pauseAction = async (): Promise<void> => {
-  await Legato.pause();
-  log('pause() ok');
+const pauseAction = async (surface: PlaybackSurface = activePlaybackSurface): Promise<void> => {
+  await resolvePlaybackApi(surface).pause();
+  log(`[${surface}] pause() ok`);
 };
 
-const stopAction = async (): Promise<void> => {
-  await Legato.stop();
-  log('stop() ok');
+const stopAction = async (surface: PlaybackSurface = activePlaybackSurface): Promise<void> => {
+  await resolvePlaybackApi(surface).stop();
+  log(`[${surface}] stop() ok`);
 };
 
-const previousAction = async (): Promise<void> => {
-  await Legato.skipToPrevious();
-  log('skipToPrevious() ok');
+const previousAction = async (surface: PlaybackSurface = activePlaybackSurface): Promise<void> => {
+  await resolvePlaybackApi(surface).skipToPrevious();
+  log(`[${surface}] skipToPrevious() ok`);
 };
 
-const nextAction = async (): Promise<void> => {
-  await Legato.skipToNext();
-  log('skipToNext() ok');
+const nextAction = async (surface: PlaybackSurface = activePlaybackSurface): Promise<void> => {
+  await resolvePlaybackApi(surface).skipToNext();
+  log(`[${surface}] skipToNext() ok`);
 };
 
-const seekAction = async (): Promise<void> => {
+const seekAction = async (surface: PlaybackSurface = activePlaybackSurface): Promise<void> => {
   const value = Number(seekInput.value);
   const targetMs = Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
-  await Legato.seekTo({ position: targetMs });
-  log(`seekTo(${targetMs}) ok`);
+  await resolvePlaybackApi(surface).seekTo({ position: targetMs });
+  log(`[${surface}] seekTo(${targetMs}) ok`);
 };
 
-const snapshotAction = async (): Promise<void> => {
-  const snapshot = await Legato.getSnapshot();
+const snapshotAction = async (surface: PlaybackSurface = activePlaybackSurface): Promise<void> => {
+  const snapshot = await resolvePlaybackApi(surface).getSnapshot();
   updateSnapshotViews(snapshot);
-  log('getSnapshot() snapshot', snapshot);
+  log(`[${surface}] getSnapshot() snapshot`, snapshot);
 };
 
 const clearFlows = (): void => {
@@ -651,7 +697,7 @@ const resetSmokeBaseline = async (): Promise<void> => {
   }
 
   try {
-    await Legato.stop();
+    await resolvePlaybackApi('legato').stop();
     log('preflight stop() ok');
   } catch {
     // Ignore if playback was not active yet.
@@ -669,17 +715,17 @@ const runSmokeFlow = async (): Promise<void> => {
   log('isNativePlatform:', isNative);
   log('Background check: start play(), send app to background, verify playback continues and notification remains active.');
 
-  await setupAction();
+  await setupAction('legato');
   await resetSmokeBaseline();
   await startSync();
-  await addAction();
-  await playAction();
+  await addAction('legato');
+  await playAction('legato');
 
   log(`waiting ${playbackSmokeDelayMs}ms before pause() to validate audible playback...`);
   await new Promise((resolve) => setTimeout(resolve, playbackSmokeDelayMs));
 
-  await pauseAction();
-  await snapshotAction();
+  await pauseAction('legato');
+  await snapshotAction('legato');
   completeSmokeVerdict();
 };
 
@@ -691,15 +737,15 @@ const runLetItEndSmokeFlow = async (): Promise<void> => {
   log('isNativePlatform:', isNative);
   log('Background check: keep app in background and watch for playback-ended event plus service teardown after stop/idle.');
 
-  await setupAction();
+  await setupAction('legato');
   await resetSmokeBaseline();
   await startSync();
-  await addAction();
-  await playAction();
+  await addAction('legato');
+  await playAction('legato');
   log(`play() ok, wait ${endSmokeDelayMs}ms for track end...`);
 
   await new Promise((resolve) => setTimeout(resolve, endSmokeDelayMs));
-  await snapshotAction();
+  await snapshotAction('legato');
   completeSmokeVerdict();
 };
 
@@ -711,23 +757,23 @@ const runBoundarySmokeFlow = async (): Promise<void> => {
   log('isNativePlatform:', isNative);
   log('Boundary check: previous on first track should restart to 0; next on last track should end playback.');
 
-  await setupAction();
+  await setupAction('legato');
   await resetSmokeBaseline();
   await startSync();
-  await addAction();
-  await playAction();
+  await addAction('legato');
+  await playAction('legato');
 
-  await previousAction();
+  await previousAction('legato');
   await new Promise((resolve) => setTimeout(resolve, boundarySettleDelayMs));
-  await snapshotAction();
+  await snapshotAction('legato');
 
-  await nextAction();
+  await nextAction('legato');
   await new Promise((resolve) => setTimeout(resolve, boundarySettleDelayMs));
-  await snapshotAction();
+  await snapshotAction('legato');
 
-  await nextAction();
+  await nextAction('legato');
   await new Promise((resolve) => setTimeout(resolve, boundarySettleDelayMs));
-  await snapshotAction();
+  await snapshotAction('legato');
   completeSmokeVerdict();
 };
 
@@ -736,20 +782,93 @@ const runArtworkRaceFlow = async (): Promise<void> => {
   log('Starting artwork race flow (rapid switch + fallback probe)...');
   log('Expected behavior: artwork should track active item, stale fetches should not overwrite latest track, and no-artwork track should clear artwork.');
 
-  await setupAction();
+  await setupAction('legato');
   await resetSmokeBaseline();
   await startSync();
-  await addAction();
-  await playAction();
+  await addAction('legato');
+  await playAction('legato');
 
   await new Promise((resolve) => setTimeout(resolve, artworkRaceSettleDelayMs));
-  await nextAction();
+  await nextAction('legato');
   await new Promise((resolve) => setTimeout(resolve, artworkRaceSettleDelayMs));
-  await nextAction();
+  await nextAction('legato');
   await new Promise((resolve) => setTimeout(resolve, artworkRaceSettleDelayMs));
-  await previousAction();
+  await previousAction('legato');
   await new Promise((resolve) => setTimeout(resolve, artworkRaceSettleDelayMs));
-  await snapshotAction();
+  await snapshotAction('legato');
+};
+
+const queueLengthFromSnapshot = (snapshot: PlaybackSnapshot): number => {
+  const queue = snapshot.queue as { items?: unknown[]; tracks?: unknown[] };
+  return (queue.items ?? queue.tracks ?? []).length;
+};
+
+const runSurfacePlaybackProbe = async (surface: PlaybackSurface): Promise<PlaybackSnapshot> => {
+  const api = resolvePlaybackApi(surface);
+  await api.setup();
+  await api.reset();
+  await api.add({ tracks: demoTracks, startIndex: 0 });
+  await api.play();
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  await api.pause();
+  await api.seekTo({ position: 900 });
+  const snapshot = await api.getSnapshot();
+  updateSnapshotViews(snapshot);
+  return snapshot;
+};
+
+const runSurfaceValidationFlow = async (): Promise<void> => {
+  clearFlows();
+  boundaryChecks = [];
+  renderBoundarySummary();
+  log('Starting API boundary validation flow (Legato + audioPlayer + mediaSession)...');
+
+  await resetSmokeBaseline();
+  await startSync();
+
+  const legatoSnapshot = await runSurfacePlaybackProbe('legato');
+  addBoundaryCheck({
+    label: 'Legato facade smoke path',
+    ok: true,
+    detail: 'setup/add/play/pause/seekTo/getSnapshot executed via Legato',
+  });
+
+  const audioPlayerSnapshot = await runSurfacePlaybackProbe('audioPlayer');
+  addBoundaryCheck({
+    label: 'audioPlayer smoke path',
+    ok: true,
+    detail: 'setup/add/play/pause/seekTo/getSnapshot executed via audioPlayer',
+  });
+
+  const parityMatch = legatoSnapshot.state === audioPlayerSnapshot.state
+    && queueLengthFromSnapshot(legatoSnapshot) === queueLengthFromSnapshot(audioPlayerSnapshot)
+    && (legatoSnapshot.currentTrack?.id ?? null) === (audioPlayerSnapshot.currentTrack?.id ?? null);
+
+  addBoundaryCheck({
+    label: 'Facade parity confidence',
+    ok: parityMatch,
+    detail: parityMatch
+      ? 'Legato and audioPlayer end-state snapshots match on state/currentTrack/queue length.'
+      : `Mismatch detected: legato={state:${legatoSnapshot.state}, track:${legatoSnapshot.currentTrack?.id ?? 'none'}, queue:${queueLengthFromSnapshot(legatoSnapshot)}} audioPlayer={state:${audioPlayerSnapshot.state}, track:${audioPlayerSnapshot.currentTrack?.id ?? 'none'}, queue:${queueLengthFromSnapshot(audioPlayerSnapshot)}}`,
+  });
+
+  const remotePlayHandle = await mediaSession.addListener('remote-play', () => {});
+  const remotePauseHandle = await mediaSession.addListener('remote-pause', () => {});
+  await remotePlayHandle.remove();
+  await remotePauseHandle.remove();
+  await mediaSession.removeAllListeners();
+
+  addBoundaryCheck({
+    label: 'mediaSession boundary visibility',
+    ok: true,
+    detail: 'remote listener registration/removal verified via mediaSession namespace.',
+  });
+};
+
+const setPlaybackSurface = (surface: PlaybackSurface): void => {
+  activePlaybackSurface = surface;
+  renderBoundarySummary();
+  log(`Manual controls now target ${surface === 'audioPlayer' ? 'audioPlayer namespace' : 'Legato facade'}.`);
 };
 
 envStatusNode.textContent = `platform=${platform} | native=${isNative}`;
@@ -757,6 +876,7 @@ log('Legato parity harness ready.');
 log('platform:', platform);
 log('isNativePlatform:', isNative);
 log('Use smoke buttons for quick pass/fail and manual controls for lifecycle/focus deep checks.');
+renderBoundarySummary();
 
 smokeButton.addEventListener('click', () => {
   void runNativeAction('run smoke flow', runSmokeFlow);
@@ -768,6 +888,10 @@ endSmokeButton.addEventListener('click', () => {
 
 boundarySmokeButton.addEventListener('click', () => {
   void runNativeAction('run boundary smoke flow', runBoundarySmokeFlow);
+});
+
+surfaceValidationButton.addEventListener('click', () => {
+  void runNativeAction('run API boundary validation flow', runSurfaceValidationFlow);
 });
 
 artworkRaceButton.addEventListener('click', () => {
@@ -816,6 +940,14 @@ seekButton.addEventListener('click', () => {
 
 snapshotButton.addEventListener('click', () => {
   void runNativeAction('manual getSnapshot()', snapshotAction);
+});
+
+useLegatoSurfaceButton.addEventListener('click', () => {
+  setPlaybackSurface('legato');
+});
+
+useAudioPlayerSurfaceButton.addEventListener('click', () => {
+  setPlaybackSurface('audioPlayer');
 });
 
 copyLogButton.addEventListener('click', () => {

--- a/packages/capacitor/README.md
+++ b/packages/capacitor/README.md
@@ -2,16 +2,36 @@
 
 Modern Capacitor binding MVP for Legato.
 
-## API surface (v0)
+## API surface (v1 boundary split, additive)
 
-Commands/queries exposed:
+`@legato/capacitor` now exposes three public entry points over the same Capacitor plugin instance:
+
+- `audioPlayer` (playback/queue/seek/read-model commands + playback events)
+- `mediaSession` (remote/session-facing event surface)
+- `Legato` (legacy compatibility facade composed as `AudioPlayerApi & MediaSessionApi`)
+
+Playback commands/queries (available on `audioPlayer` and legacy `Legato`):
 
 - `setup`, `add`, `remove`, `reset`
 - `play`, `pause`, `stop`, `seekTo`
 - `skipTo`, `skipToNext`, `skipToPrevious`
 - `getState`, `getPosition`, `getDuration`, `getCurrentTrack`, `getQueue`, `getSnapshot`
 
+`mediaSession` is intentionally listener-first in v1 and currently exposes:
+
+- `setup`
+- `addListener('remote-*', ...)`
+- `removeAllListeners`
+
+This split is additive: existing `Legato` consumers remain source-compatible while new code can adopt namespaced boundaries.
+
 It also exports typed event helpers aligned with `@legato/contract`, and `createLegatoSync()` for lightweight snapshot/event resync.
+
+### Migration guidance
+
+- Existing apps: no code change required; keep using `Legato`.
+- New integrations: prefer `audioPlayer` for playback operations and `mediaSession` for remote/session listeners.
+- Mixed migration is supported: both namespaced exports and `Legato` route to the same underlying plugin/state.
 
 ## MVP limitations
 

--- a/packages/capacitor/src/boundary-contract.typecheck.ts
+++ b/packages/capacitor/src/boundary-contract.typecheck.ts
@@ -1,0 +1,104 @@
+import type {
+  AudioPlayerApi,
+  AudioPlayerEventName,
+  AudioPlayerEventPayloadMap,
+  LegatoApi,
+  MediaSessionApi,
+  MediaSessionEventName,
+  MediaSessionEventPayloadMap,
+} from './definitions';
+import {
+  Legato as legacyLegatoFacade,
+  audioPlayer,
+  mediaSession,
+} from './plugin';
+import {
+  Legato as legacyLegatoFacadeFromIndex,
+  audioPlayer as audioPlayerFromIndex,
+  mediaSession as mediaSessionFromIndex,
+} from './index';
+
+declare const audioPlayerApi: AudioPlayerApi;
+declare const mediaSessionApi: MediaSessionApi;
+declare const legatoApi: LegatoApi;
+
+const playbackEventName: AudioPlayerEventName = 'playback-progress';
+const mediaEventName: MediaSessionEventName = 'remote-seek';
+
+const playbackPayload: AudioPlayerEventPayloadMap['playback-progress'] = {
+  position: 12,
+  duration: 30,
+  bufferedPosition: 16,
+};
+
+const mediaPayload: MediaSessionEventPayloadMap['remote-seek'] = {
+  position: 22,
+};
+
+void playbackEventName;
+void mediaEventName;
+void playbackPayload;
+void mediaPayload;
+
+audioPlayerApi.setup();
+audioPlayerApi.play();
+audioPlayerApi.getSnapshot();
+audioPlayerApi.addListener('playback-progress', (payload) => {
+  void payload.position;
+});
+
+mediaSessionApi.setup();
+mediaSessionApi.addListener('remote-play', () => {});
+mediaSessionApi.addListener('remote-seek', (payload) => {
+  void payload.position;
+});
+
+legatoApi.play();
+legatoApi.addListener('playback-state-changed', (payload) => {
+  void payload.state;
+});
+legatoApi.addListener('remote-next', () => {});
+
+// @ts-expect-error media-session events are excluded from audio-player boundary.
+audioPlayerApi.addListener('remote-play', () => {});
+
+// @ts-expect-error playback events are excluded from media-session boundary.
+mediaSessionApi.addListener('playback-progress', () => {});
+
+// @ts-expect-error playback controls are excluded from media-session boundary.
+mediaSessionApi.play();
+
+// @ts-expect-error media-session event names exclude playback events.
+const invalidMediaSessionEventName: MediaSessionEventName = 'playback-ended';
+
+// @ts-expect-error audio-player event names exclude media-session events.
+const invalidPlaybackEventName: AudioPlayerEventName = 'remote-next';
+
+void invalidMediaSessionEventName;
+void invalidPlaybackEventName;
+
+const pluginAudioPlayer: AudioPlayerApi = audioPlayer;
+const pluginMediaSession: MediaSessionApi = mediaSession;
+const pluginLegatoFacade: LegatoApi = legacyLegatoFacade;
+
+const indexAudioPlayer: AudioPlayerApi = audioPlayerFromIndex;
+const indexMediaSession: MediaSessionApi = mediaSessionFromIndex;
+const indexLegatoFacade: LegatoApi = legacyLegatoFacadeFromIndex;
+
+pluginAudioPlayer.play();
+pluginMediaSession.addListener('remote-play', () => {});
+pluginLegatoFacade.addListener('playback-progress', (payload) => {
+  void payload.position;
+});
+
+indexAudioPlayer.getSnapshot();
+indexMediaSession.addListener('remote-seek', (payload) => {
+  void payload.position;
+});
+indexLegatoFacade.getDuration();
+
+// @ts-expect-error media-session boundary excludes playback controls.
+pluginMediaSession.play();
+
+// @ts-expect-error audio-player boundary excludes media-session event names.
+pluginAudioPlayer.addListener('remote-next', () => {});

--- a/packages/capacitor/src/definitions.ts
+++ b/packages/capacitor/src/definitions.ts
@@ -1,9 +1,14 @@
 import type { PluginListenerHandle } from '@capacitor/core';
 import type {
-  LegatoError,
   LegatoEventName as ContractLegatoEventName,
+  LegatoEventPayloadMap as ContractLegatoEventPayloadMap,
+  LegatoError,
+  MediaSessionEventName as ContractMediaSessionEventName,
+  MediaSessionEventPayloadMap as ContractMediaSessionEventPayloadMap,
   PlaybackSnapshot,
   PlaybackState,
+  PlayerEventName as ContractPlayerEventName,
+  PlayerEventPayloadMap as ContractPlayerEventPayloadMap,
   QueueSnapshot,
   Track,
 } from '@legato/contract';
@@ -16,7 +21,13 @@ export type {
   Track,
 };
 
+export type AudioPlayerEventName = ContractPlayerEventName;
+export type MediaSessionEventName = ContractMediaSessionEventName;
 export type LegatoEventName = ContractLegatoEventName;
+
+export type AudioPlayerEventPayloadMap = ContractPlayerEventPayloadMap;
+export type MediaSessionEventPayloadMap = ContractMediaSessionEventPayloadMap;
+export type LegatoEventPayloadMap = ContractLegatoEventPayloadMap;
 
 export interface AddOptions {
   tracks: Track[];
@@ -36,25 +47,7 @@ export interface SkipToOptions {
   index: number;
 }
 
-export interface LegatoEventPayloadMap {
-  'playback-state-changed': { state: PlaybackState };
-  'playback-active-track-changed': { track: Track | null; index: number | null };
-  'playback-queue-changed': { queue: QueueSnapshot };
-  'playback-progress': {
-    position: number;
-    duration: number | null;
-    bufferedPosition: number | null;
-  };
-  'playback-ended': { snapshot: PlaybackSnapshot };
-  'playback-error': { error: LegatoError };
-  'remote-play': Record<string, never>;
-  'remote-pause': Record<string, never>;
-  'remote-next': Record<string, never>;
-  'remote-previous': Record<string, never>;
-  'remote-seek': { position: number };
-}
-
-export interface LegatoApi {
+export interface AudioPlayerApi {
   setup(): Promise<void>;
   add(options: AddOptions): Promise<PlaybackSnapshot>;
   remove(options: RemoveOptions): Promise<PlaybackSnapshot>;
@@ -72,7 +65,23 @@ export interface LegatoApi {
   getCurrentTrack(): Promise<Track | null>;
   getQueue(): Promise<QueueSnapshot>;
   getSnapshot(): Promise<PlaybackSnapshot>;
+  addListener<E extends AudioPlayerEventName>(
+    eventName: E,
+    listener: (payload: AudioPlayerEventPayloadMap[E]) => void,
+  ): Promise<PluginListenerHandle>;
+  removeAllListeners(): Promise<void>;
 }
+
+export interface MediaSessionApi {
+  setup(): Promise<void>;
+  addListener<E extends MediaSessionEventName>(
+    eventName: E,
+    listener: (payload: MediaSessionEventPayloadMap[E]) => void,
+  ): Promise<PluginListenerHandle>;
+  removeAllListeners(): Promise<void>;
+}
+
+export type LegatoApi = AudioPlayerApi & MediaSessionApi;
 
 export interface LegatoEventApi {
   addListener<E extends LegatoEventName>(

--- a/packages/capacitor/src/index.ts
+++ b/packages/capacitor/src/index.ts
@@ -1,5 +1,5 @@
 export type * from './definitions';
-export { Legato } from './plugin';
+export { Legato, audioPlayer, mediaSession } from './plugin';
 export {
   LEGATO_EVENTS,
   addLegatoListener,

--- a/packages/capacitor/src/plugin.ts
+++ b/packages/capacitor/src/plugin.ts
@@ -2,8 +2,10 @@ import { registerPlugin } from '@capacitor/core';
 import type { Plugin } from '@capacitor/core';
 import type {
   AddOptions,
+  AudioPlayerApi,
   LegatoApi,
   LegatoEventApi,
+  MediaSessionApi,
   PlaybackSnapshot,
   PlaybackState,
   QueueSnapshot,
@@ -63,7 +65,7 @@ interface LegatoCapacitorPlugin extends Plugin {
 
 export const LegatoCapacitor = registerPlugin<LegatoCapacitorPlugin>('Legato');
 
-export const Legato: LegatoApi & LegatoEventApi = {
+const sharedDelegate = {
   async setup() {
     await LegatoCapacitor.setup();
   },
@@ -131,4 +133,37 @@ export const Legato: LegatoApi & LegatoEventApi = {
   removeAllListeners() {
     return LegatoCapacitor.removeAllListeners();
   },
+};
+
+export const audioPlayer: AudioPlayerApi = {
+  setup: sharedDelegate.setup,
+  add: sharedDelegate.add,
+  remove: sharedDelegate.remove,
+  reset: sharedDelegate.reset,
+  play: sharedDelegate.play,
+  pause: sharedDelegate.pause,
+  stop: sharedDelegate.stop,
+  seekTo: sharedDelegate.seekTo,
+  skipTo: sharedDelegate.skipTo,
+  skipToNext: sharedDelegate.skipToNext,
+  skipToPrevious: sharedDelegate.skipToPrevious,
+  getState: sharedDelegate.getState,
+  getPosition: sharedDelegate.getPosition,
+  getDuration: sharedDelegate.getDuration,
+  getCurrentTrack: sharedDelegate.getCurrentTrack,
+  getQueue: sharedDelegate.getQueue,
+  getSnapshot: sharedDelegate.getSnapshot,
+  addListener: sharedDelegate.addListener,
+  removeAllListeners: sharedDelegate.removeAllListeners,
+};
+
+export const mediaSession: MediaSessionApi = {
+  setup: sharedDelegate.setup,
+  addListener: sharedDelegate.addListener,
+  removeAllListeners: sharedDelegate.removeAllListeners,
+};
+
+export const Legato: LegatoApi & LegatoEventApi = {
+  ...audioPlayer,
+  ...mediaSession,
 };

--- a/packages/contract/src/events.partition.typecheck.ts
+++ b/packages/contract/src/events.partition.typecheck.ts
@@ -1,0 +1,55 @@
+import type {
+  LegacyPlayerEventName,
+  LegacyPlayerEventPayload,
+  MediaSessionEventName,
+  MediaSessionEventPayload,
+  PlayerEventName,
+  PlayerEventPayload,
+} from './events';
+
+const playbackEvent: PlayerEventName = 'playback-progress';
+const mediaSessionEvent: MediaSessionEventName = 'remote-play';
+const legacyPlaybackEvent: LegacyPlayerEventName = 'playback-ended';
+const legacyMediaSessionEvent: LegacyPlayerEventName = 'remote-seek';
+
+const playbackPayload: PlayerEventPayload<'playback-progress'> = {
+  position: 8,
+  duration: 10,
+  bufferedPosition: 9,
+};
+
+const mediaSessionPayload: MediaSessionEventPayload<'remote-seek'> = {
+  position: 42,
+};
+
+const legacyPlaybackPayload: LegacyPlayerEventPayload<'playback-state-changed'> = {
+  state: 'playing',
+};
+
+const legacyMediaSessionPayload: LegacyPlayerEventPayload<'remote-pause'> = {};
+
+void playbackEvent;
+void mediaSessionEvent;
+void legacyPlaybackEvent;
+void legacyMediaSessionEvent;
+void playbackPayload;
+void mediaSessionPayload;
+void legacyPlaybackPayload;
+void legacyMediaSessionPayload;
+
+// @ts-expect-error media-session events are not playback events.
+const invalidPlaybackBoundary: PlayerEventName = 'remote-play';
+
+// @ts-expect-error playback events are not media-session events.
+const invalidMediaSessionBoundary: MediaSessionEventName = 'playback-ended';
+
+// @ts-expect-error playback-progress payload requires numeric fields.
+const invalidPlaybackPayload: PlayerEventPayload<'playback-progress'> = {};
+
+// @ts-expect-error remote-seek payload requires a position.
+const invalidMediaSessionPayload: MediaSessionEventPayload<'remote-seek'> = {};
+
+void invalidPlaybackBoundary;
+void invalidMediaSessionBoundary;
+void invalidPlaybackPayload;
+void invalidMediaSessionPayload;

--- a/packages/contract/src/events.ts
+++ b/packages/contract/src/events.ts
@@ -1,15 +1,66 @@
-export const LEGATO_EVENT_NAMES = [
+import type { LegatoError } from './errors';
+import type { PlaybackSnapshot } from './snapshot';
+import type { PlaybackState } from './state';
+import type { QueueSnapshot } from './queue';
+import type { Track } from './track';
+
+export const PLAYER_EVENT_NAMES = [
   'playback-state-changed',
   'playback-active-track-changed',
   'playback-queue-changed',
   'playback-progress',
   'playback-ended',
   'playback-error',
+] as const;
+
+export const MEDIA_SESSION_EVENT_NAMES = [
   'remote-play',
   'remote-pause',
   'remote-next',
   'remote-previous',
-  'remote-seek'
+  'remote-seek',
 ] as const;
 
-export type LegatoEventName = (typeof LEGATO_EVENT_NAMES)[number];
+export const LEGACY_PLAYER_EVENT_NAMES = [
+  ...PLAYER_EVENT_NAMES,
+  ...MEDIA_SESSION_EVENT_NAMES,
+] as const;
+
+export const LEGATO_EVENT_NAMES = LEGACY_PLAYER_EVENT_NAMES;
+
+export type PlayerEventName = (typeof PLAYER_EVENT_NAMES)[number];
+export type MediaSessionEventName = (typeof MEDIA_SESSION_EVENT_NAMES)[number];
+export type LegacyPlayerEventName = (typeof LEGACY_PLAYER_EVENT_NAMES)[number];
+
+export type LegatoEventName = LegacyPlayerEventName;
+
+export interface PlayerEventPayloadMap {
+  'playback-state-changed': { state: PlaybackState };
+  'playback-active-track-changed': { track: Track | null; index: number | null };
+  'playback-queue-changed': { queue: QueueSnapshot };
+  'playback-progress': {
+    position: number;
+    duration: number | null;
+    bufferedPosition: number | null;
+  };
+  'playback-ended': { snapshot: PlaybackSnapshot };
+  'playback-error': { error: LegatoError };
+}
+
+export interface MediaSessionEventPayloadMap {
+  'remote-play': Record<string, never>;
+  'remote-pause': Record<string, never>;
+  'remote-next': Record<string, never>;
+  'remote-previous': Record<string, never>;
+  'remote-seek': { position: number };
+}
+
+export type LegacyPlayerEventPayloadMap = PlayerEventPayloadMap & MediaSessionEventPayloadMap;
+
+export type LegatoEventPayloadMap = LegacyPlayerEventPayloadMap;
+
+export type PlayerEventPayload<E extends PlayerEventName> = PlayerEventPayloadMap[E];
+export type MediaSessionEventPayload<E extends MediaSessionEventName> = MediaSessionEventPayloadMap[E];
+export type LegacyPlayerEventPayload<E extends LegacyPlayerEventName> = LegacyPlayerEventPayloadMap[E];
+
+export type LegatoEventPayload<E extends LegatoEventName> = LegacyPlayerEventPayload<E>;

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -3,6 +3,28 @@ export * from './state';
 export * from './queue';
 export * from './snapshot';
 export * from './errors';
-export * from './events';
+
+// Shared primitives across boundary surfaces.
+export type {
+  PlayerEventName,
+  MediaSessionEventName,
+  LegacyPlayerEventName,
+  LegatoEventName,
+  PlayerEventPayload,
+  MediaSessionEventPayload,
+  LegacyPlayerEventPayload,
+  LegatoEventPayload,
+  PlayerEventPayloadMap,
+  MediaSessionEventPayloadMap,
+  LegacyPlayerEventPayloadMap,
+  LegatoEventPayloadMap,
+} from './events';
+export {
+  PLAYER_EVENT_NAMES,
+  MEDIA_SESSION_EVENT_NAMES,
+  LEGACY_PLAYER_EVENT_NAMES,
+  LEGATO_EVENT_NAMES,
+} from './events';
+
 export * from './capability';
 export * from './invariants';


### PR DESCRIPTION
Closes #34

## Summary
- split the public contract into playback vs media-session event/type surfaces while preserving legacy `Legato` compatibility
- add additive namespaced Capacitor surfaces (`audioPlayer`, `mediaSession`) over the same underlying plugin instance
- update the demo harness and docs so the new boundaries are visible and testable without changing native runtime ownership

## Changes
| File | Change |
|------|--------|
| `packages/contract/src/events.ts` | partitions event taxonomy into playback vs media-session subsets while preserving the legacy union |
| `packages/contract/src/index.ts` | re-exports partitioned contract surfaces alongside legacy exports |
| `packages/contract/src/events.partition.typecheck.ts` | compile-time boundary assertions for the contract split |
| `packages/capacitor/src/definitions.ts` | additive `AudioPlayerApi`, `MediaSessionApi`, and composed `LegatoApi` type surfaces |
| `packages/capacitor/src/plugin.ts` | shared delegate backing `audioPlayer`, `mediaSession`, and legacy `Legato` facade from one plugin instance |
| `packages/capacitor/src/index.ts` | exports namespaced surfaces plus legacy facade |
| `packages/capacitor/src/boundary-contract.typecheck.ts` | compile-time binding boundary assertions |
| `apps/capacitor-demo/src/boundary-harness.*`, `index.html`, `src/main.ts` | API-boundary validation flow and manual target switching for `Legato` vs `audioPlayer` |
| `apps/capacitor-demo/android/app/src/test/java/com/getcapacitor/myapp/HarnessValidationContractTest.java` | harness contract updated for new boundary validation affordances |
| `packages/capacitor/README.md` | migration/boundary documentation for additive `audioPlayer` + `mediaSession` surfaces |

## Test Plan
- [x] `bash ./apps/capacitor-demo/android/gradlew test` remained green during the boundary extraction batches
- [x] Manual harness still preserves existing smoke flows on `Legato` while allowing explicit `audioPlayer` boundary validation
- [ ] Typecheck assertions are authored for both contract and binding layers, but execution still depends on `tsc` availability in the environment

## Notes
- This is a non-breaking v1 extraction: the native core remains shared and `Legato` remains backward compatible.
- The split is intentionally at the public contract/binding surface, not a split into separate native plugins or duplicate runtime ownership.
