### PR TITLE
fix(native): improve notification fidelity

### DIFF
--- a/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackService.kt
+++ b/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackService.kt
@@ -475,10 +475,6 @@ internal fun shouldResetProjectionForTrackTransition(
     activeTrackId: String?,
     previousProjection: MediaSessionPlaybackProjection?,
 ): Boolean {
-    if (state != LegatoAndroidPlaybackState.BUFFERING && state != LegatoAndroidPlaybackState.LOADING) {
-        return false
-    }
-
     val previousTrackId = previousProjection?.activeTrackId ?: return false
     return activeTrackId != null && activeTrackId != previousTrackId
 }


### PR DESCRIPTION
Closes #36

## Summary
- polish Android media-surface playback-state projection so notification/lockscreen fidelity stays closer to the canonical playback snapshot
- carry the final small fix that remained after separating this milestone from the API boundary extraction PR

## Changes
| File | Change |
|------|--------|
| `packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackService.kt` | final Android playback-state projection cleanup for system media-surface fidelity |

## Test Plan
- [x] Manual Android validation confirmed progress fidelity is acceptable after the latest changes
- [x] `sdd-verify` for `notification-lockscreen-polish-v4` passed after blocker fixes
- [ ] Optional rerun of Android device validation after merge for extra confidence

## Notes
- This PR is intentionally tiny because the larger v4 work was already completed and verified; this is the remaining isolated change from that milestone.
