### PR TITLE
docs(api): improve boundary migration ergonomics

### DIFF
--- a/apps/capacitor-demo/README.md
+++ b/apps/capacitor-demo/README.md
@@ -8,13 +8,13 @@ Minimal host app to stage the **first real manual smoke path** for `@legato/capa
 
 Validated in Android Capacitor host execution:
 
-- `Legato.setup()`
-- `Legato.add()`
-- `Legato.play()`
-- `Legato.pause()`
+- `audioPlayer.setup()` (preferred) and `Legato.setup()` (compatibility)
+- `audioPlayer.add()` (preferred) and `Legato.add()` (compatibility)
+- `audioPlayer.play()` (preferred) and `Legato.play()` (compatibility)
+- `audioPlayer.pause()` (preferred) and `Legato.pause()` (compatibility)
 - `Legato.getSnapshot()`
 - Snapshot serialization for `queue`, `currentTrack`, and `currentIndex`
-- `createLegatoSync()` helper behavior for minimal resync path
+- `createAudioPlayerSync()` (preferred) and `createLegatoSync()` (compatibility)
 
 Not validated by this milestone:
 
@@ -23,16 +23,16 @@ Not validated by this milestone:
 - Real transport reliability guarantees across devices/OS versions
 - iOS host parity
 
-## Smoke objective (current)
+## Smoke objective (namespaced-first, compatibility-aware)
 
 Validate native bridge + snapshot/event plumbing for the minimal flow in `src/main.ts`:
 
-- `Legato.setup()`
-- `createLegatoSync()`
-- `Legato.add()`
-- `Legato.play()`
-- `Legato.pause()`
-- `Legato.getSnapshot()`
+- `audioPlayer.setup()` (preferred)
+- `createAudioPlayerSync()` (preferred)
+- `addAudioPlayerListener('playback-*', ...)` (preferred)
+- `addMediaSessionListener('remote-*', ...)` (preferred)
+- `audioPlayer.add()` / `audioPlayer.play()` / `audioPlayer.pause()` / `audioPlayer.getSnapshot()`
+- Compatibility validation: equivalent `Legato.*` flow remains available and unchanged
 
 This is a **native smoke** (Android/iOS host), not a browser-only check.
 
@@ -89,14 +89,14 @@ npm run cap:sync
 
 Manual parity checklist to close milestone validation:
 
-1. Start `Run smoke flow` (or manual setup/sync/add/play), then background the app.
-2. Trigger lock-screen/media-notification **pause**, return to app, tap `getSnapshot()`, and verify paused state + frozen progress.
-3. Trigger lock-screen/media-notification **play**, return to app, tap `getSnapshot()`, and verify playing state + advancing progress.
-4. Verify now-playing surfaces show title/artist/album/artwork/duration from fixture metadata.
-5. Trigger remote/manual `skipToNext`/`skipToPrevious` and verify queue transitions match canonical engine behavior.
-6. Trigger remote/manual seek and verify snapshot position updates consistently.
+1. Run guided button `Case: remote pause parity` (it auto-baselines and waits for remote pause).
+2. Run guided button `Case: remote play resume parity` (it auto-baselines paused state and waits for remote play).
+3. Run guided button `Case: remote next/previous parity` and complete both prompts.
+4. Run guided button `Case: remote seek parity` and seek to a clearly different position when prompted.
+5. Verify now-playing surfaces show title/artist/album/artwork/duration from fixture metadata.
+6. Run `Run API boundary validation` to keep Legato/audioPlayer/mediaSession boundary coverage current.
 7. Validate capability projection summary: mid-queue enables next/previous, first track disables previous, ended disables all (`canSkipNext=false`, `canSkipPrevious=false`, `canSeek=false`).
-8. Verify now-playing surfaces show title/artist/album/artwork/duration from fixture metadata.
+8. Run `Run artwork race` and confirm no stale artwork survives rapid track switches/fallback.
 9. (Android lifecycle carry-over) `stop()` + idle tears down foreground service/notification.
 
 ## Quick smoke checklist (manual, lightweight)

--- a/apps/capacitor-demo/android/app/src/test/java/com/getcapacitor/myapp/HarnessValidationContractTest.java
+++ b/apps/capacitor-demo/android/app/src/test/java/com/getcapacitor/myapp/HarnessValidationContractTest.java
@@ -102,6 +102,121 @@ public class HarnessValidationContractTest {
         assertTrue("README should include cap sync reminder", readme.contains("npm run cap:sync"));
     }
 
+    @Test
+    public void capacitorReadme_documentsNamespacedPreferredMigrationMap() throws Exception {
+        String capacitorReadme = readRepoFile("packages/capacitor/README.md");
+
+        assertTrue(
+                "Capacitor README should include explicit legacy-to-namespaced migration heading",
+                capacitorReadme.contains("Legacy → namespaced migration map (preferred path)")
+        );
+        assertTrue(
+                "Capacitor README should include preferred listener helper",
+                capacitorReadme.contains("addAudioPlayerListener")
+        );
+        assertTrue(
+                "Capacitor README should include preferred media session helper",
+                capacitorReadme.contains("addMediaSessionListener")
+        );
+        assertTrue(
+                "Capacitor README should include preferred playback sync helper",
+                capacitorReadme.contains("createAudioPlayerSync")
+        );
+        assertTrue(
+                "Capacitor README should keep compatibility-only posture for legacy helpers",
+                capacitorReadme.contains("Compatibility-only (legacy Legato facade)")
+        );
+    }
+
+    @Test
+    public void demoHarness_copyAndImports_highlightNamespacedFirstSurfaces() throws Exception {
+        String demoReadme = readRepoFile("apps/capacitor-demo/README.md");
+        String mainTs = readRepoFile("apps/capacitor-demo/src/main.ts");
+        String boundaryHarness = readRepoFile("apps/capacitor-demo/src/boundary-harness.js");
+        String boundaryHarnessTest = readRepoFile("apps/capacitor-demo/src/boundary-harness.test.mjs");
+
+        assertTrue(
+                "Demo README should call out namespaced-first smoke objective",
+                demoReadme.contains("Smoke objective (namespaced-first, compatibility-aware)")
+        );
+        assertTrue(
+                "Demo README should keep native host refresh commands",
+                demoReadme.contains("npm run build") && demoReadme.contains("npm run cap:sync")
+        );
+
+        assertTrue("main.ts should import createAudioPlayerSync", mainTs.contains("createAudioPlayerSync"));
+        assertTrue("main.ts should import addAudioPlayerListener", mainTs.contains("addAudioPlayerListener"));
+        assertTrue("main.ts should import addMediaSessionListener", mainTs.contains("addMediaSessionListener"));
+        assertTrue("main.ts should use createAudioPlayerSync for preferred sync path", mainTs.contains("syncController = createAudioPlayerSync({"));
+        assertTrue("main.ts should use addAudioPlayerListener helper", mainTs.contains("addAudioPlayerListener(eventName, (payload) => {"));
+        assertTrue("main.ts should use addMediaSessionListener helper", mainTs.contains("addMediaSessionListener('remote-play', () => {})"));
+
+        assertTrue(
+                "Boundary summary should flag preferred namespaced surfaces",
+                boundaryHarness.contains("`preferredSurface=${payload.preferredSurface}`")
+        );
+        assertTrue(
+                "Boundary summary should label legacy facade as compatibility-only",
+                boundaryHarness.contains("`compatSurface=${payload.compatSurface}`")
+        );
+        assertTrue(
+                "boundary-harness test should lock preferred copy",
+                boundaryHarnessTest.contains("preferredSurface: 'audioPlayer + mediaSession'")
+        );
+    }
+
+    @Test
+    public void capacitorEvents_exposesNamespacedConstantsAndListenerAliases() throws Exception {
+        String eventsTs = readRepoFile("packages/capacitor/src/events.ts");
+
+        assertTrue("Expected audio player event constant alias", eventsTs.contains("export const AUDIO_PLAYER_EVENTS = PLAYER_EVENT_NAMES;"));
+        assertTrue("Expected media session event constant alias", eventsTs.contains("export const MEDIA_SESSION_EVENTS = MEDIA_SESSION_EVENT_NAMES;"));
+        assertTrue("Expected addAudioPlayerListener helper", eventsTs.contains("export const addAudioPlayerListener = audioPlayer.addListener.bind(audioPlayer);"));
+        assertTrue("Expected addMediaSessionListener helper", eventsTs.contains("export const addMediaSessionListener = mediaSession.addListener.bind(mediaSession);"));
+    }
+
+    @Test
+    public void capacitorEvents_preservesLegacyCombinedConstantAndListenerHelper() throws Exception {
+        String eventsTs = readRepoFile("packages/capacitor/src/events.ts");
+
+        assertTrue("Expected legacy combined event constant to remain", eventsTs.contains("export const LEGATO_EVENTS = LEGATO_EVENT_NAMES;"));
+        assertTrue("Expected addLegatoListener to remain", eventsTs.contains("export function addLegatoListener<E extends LegatoEventName>("));
+    }
+
+    @Test
+    public void capacitorSync_exposesAudioPlayerScopedAliasesAndDelegatesToLegacySync() throws Exception {
+        String syncTs = readRepoFile("packages/capacitor/src/sync.ts");
+
+        assertTrue("Expected AudioPlayerSyncClient alias", syncTs.contains("export type AudioPlayerSyncClient = AudioPlayerApi;"));
+        assertTrue("Expected AudioPlayerSyncOptions interface", syncTs.contains("export interface AudioPlayerSyncOptions extends LegatoSyncOptions"));
+        assertTrue("Expected audio player sync factory", syncTs.contains("export function createAudioPlayerSync("));
+        assertTrue("Expected audio player sync to delegate to legacy sync", syncTs.contains("return createLegatoSync(options);"));
+    }
+
+    @Test
+    public void capacitorSync_preservesLegacyFactoryAndPlaybackOnlySubscriptionSource() throws Exception {
+        String syncTs = readRepoFile("packages/capacitor/src/sync.ts");
+
+        assertTrue("Expected createLegatoSync factory to remain", syncTs.contains("export function createLegatoSync(options: LegatoSyncOptions = {}): LegatoSyncController {"));
+        assertTrue("Expected playback-only subscription source", syncTs.contains("AUDIO_PLAYER_EVENTS.map(async (eventName) => {"));
+    }
+
+    @Test
+    public void capacitorIndex_reexportsPreferredNamespacedHelpersBeforeCompatibilityAliases() throws Exception {
+        String indexTs = readRepoFile("packages/capacitor/src/index.ts");
+
+        int preferredIndex = indexTs.indexOf("AUDIO_PLAYER_EVENTS");
+        int compatibilityIndex = indexTs.indexOf("LEGATO_EVENTS");
+
+        assertTrue("Expected preferred namespaced events export", preferredIndex >= 0);
+        assertTrue("Expected compatibility LEGATO_EVENTS export", compatibilityIndex >= 0);
+        assertTrue("Expected preferred namespaced exports before compatibility export", preferredIndex < compatibilityIndex);
+        assertTrue("Expected addAudioPlayerListener export", indexTs.contains("addAudioPlayerListener"));
+        assertTrue("Expected addMediaSessionListener export", indexTs.contains("addMediaSessionListener"));
+        assertTrue("Expected createAudioPlayerSync export", indexTs.contains("createAudioPlayerSync"));
+        assertTrue("Expected createLegatoSync export", indexTs.contains("createLegatoSync"));
+    }
+
     private static String readRepoFile(String relativePath) throws IOException {
         Path repoRoot = locateRepoRoot();
         Path target = repoRoot.resolve(relativePath);

--- a/apps/capacitor-demo/index.html
+++ b/apps/capacitor-demo/index.html
@@ -260,6 +260,17 @@ No smoke run yet.</pre>
         </section>
 
         <section class="card stack">
+          <h2>Guided manual validation cases</h2>
+          <p>Each flow resets baseline, performs setup automatically, then waits for one remote action and writes a pass/fail trail.</p>
+          <div class="actions">
+            <button id="run-case-remote-pause" class="native-action" type="button">Case: remote pause parity</button>
+            <button id="run-case-remote-play" class="native-action" type="button">Case: remote play resume parity</button>
+            <button id="run-case-remote-skip" class="native-action" type="button">Case: remote next/previous parity</button>
+            <button id="run-case-remote-seek" class="native-action" type="button">Case: remote seek parity</button>
+          </div>
+        </section>
+
+        <section class="card stack">
           <h2>Automation report (SmokeReport v1)</h2>
           <div class="actions">
             <button id="copy-smoke-report" type="button">Copy smoke report JSON</button>
@@ -328,9 +339,9 @@ checks=none yet</pre>
         <section class="card stack">
           <h2>Remote transport v2 validation checklist</h2>
           <ul>
-            <li>Background play/pause parity: with playback running, background app and toggle lock-screen/notification play↔pause; verify state changes match manual play()/pause().</li>
-            <li>Remote next/previous parity: on lock-screen/notification and manual buttons, next/previous must match queue transitions from skipToNext()/skipToPrevious().</li>
-            <li>Remote seek parity: lock-screen/notification seek must match seekTo() and keep snapshot position aligned.</li>
+            <li>Background play/pause parity: run guided buttons <code>Case: remote pause parity</code> and <code>Case: remote play resume parity</code>, then verify pass/fail trail in logs/checks.</li>
+            <li>Remote next/previous parity: run <code>Case: remote next/previous parity</code>; next and previous must round-trip queue index as prompted.</li>
+            <li>Remote seek parity: run <code>Case: remote seek parity</code>; remote seek must produce a visible snapshot position jump.</li>
             <li>Boundary behavior parity: previous at first track restarts to 0, next at last track transitions to ended + playbackEnded event.</li>
             <li>Capability projection parity: canSkipNext/canSkipPrevious/canSeek summary must align with queue index + ended/empty states.</li>
             <li>Android lockscreen/notification position from real snapshot: on resume/seek, projected position should rebase near snapshot target (no transient 0 reset).</li>

--- a/apps/capacitor-demo/src/boundary-harness.js
+++ b/apps/capacitor-demo/src/boundary-harness.js
@@ -10,6 +10,8 @@ export const createBoundarySurfaceSnapshot = (activeSurface) => {
   return {
     activeSurface: normalizedSurface,
     playbackTarget: normalizedSurface === 'audioPlayer' ? 'audioPlayer namespace' : 'Legato facade',
+    preferredSurface: 'audioPlayer + mediaSession',
+    compatSurface: 'Legato facade (compatibility-only)',
     playbackCommands: [...PLAYBACK_COMMANDS],
     mediaSessionCommands: [...MEDIA_SESSION_COMMANDS],
   };
@@ -23,6 +25,8 @@ export const createBoundarySurfaceSnapshot = (activeSurface) => {
  * @param {{
  *   activeSurface: 'legato' | 'audioPlayer';
  *   playbackTarget: string;
+ *   preferredSurface: string;
+ *   compatSurface: string;
  *   playbackCommands: string[];
  *   mediaSessionCommands: string[];
  *   parityChecks: BoundaryCheck[];
@@ -32,6 +36,8 @@ export const summarizeBoundaryValidation = (payload) => {
   const lines = [
     `activeSurface=${payload.activeSurface}`,
     `playbackTarget=${payload.playbackTarget}`,
+    `preferredSurface=${payload.preferredSurface}`,
+    `compatSurface=${payload.compatSurface}`,
     `playbackCommands=${payload.playbackCommands.join(', ')}`,
     `mediaSessionCommands=${payload.mediaSessionCommands.join(', ')}`,
   ];

--- a/apps/capacitor-demo/src/boundary-harness.test.mjs
+++ b/apps/capacitor-demo/src/boundary-harness.test.mjs
@@ -11,6 +11,8 @@ test('createBoundarySurfaceSnapshot reports playback controls for Legato facade'
 
   assert.equal(snapshot.activeSurface, 'legato');
   assert.equal(snapshot.playbackTarget, 'Legato facade');
+  assert.equal(snapshot.preferredSurface, 'audioPlayer + mediaSession');
+  assert.equal(snapshot.compatSurface, 'Legato facade (compatibility-only)');
   assert.deepEqual(snapshot.playbackCommands, ['setup', 'add', 'play', 'pause', 'stop', 'seekTo', 'getSnapshot']);
   assert.deepEqual(snapshot.mediaSessionCommands, ['addListener(remote-*)', 'removeAllListeners']);
 });
@@ -20,12 +22,16 @@ test('createBoundarySurfaceSnapshot reports playback controls for audioPlayer na
 
   assert.equal(snapshot.activeSurface, 'audioPlayer');
   assert.equal(snapshot.playbackTarget, 'audioPlayer namespace');
+  assert.equal(snapshot.preferredSurface, 'audioPlayer + mediaSession');
+  assert.equal(snapshot.compatSurface, 'Legato facade (compatibility-only)');
 });
 
 test('summarizeBoundaryValidation renders copy-friendly multi-line status', () => {
   const summary = summarizeBoundaryValidation({
     activeSurface: 'audioPlayer',
     playbackTarget: 'audioPlayer namespace',
+    preferredSurface: 'audioPlayer + mediaSession',
+    compatSurface: 'Legato facade (compatibility-only)',
     playbackCommands: ['setup', 'add', 'play'],
     mediaSessionCommands: ['addListener(remote-*)'],
     parityChecks: [
@@ -37,6 +43,8 @@ test('summarizeBoundaryValidation renders copy-friendly multi-line status', () =
 
   assert.match(summary, /activeSurface=audioPlayer/);
   assert.match(summary, /playbackTarget=audioPlayer namespace/);
+  assert.match(summary, /preferredSurface=audioPlayer \+ mediaSession/);
+  assert.match(summary, /compatSurface=Legato facade \(compatibility-only\)/);
   assert.match(summary, /playbackCommands=setup, add, play/);
   assert.match(summary, /mediaSessionCommands=addListener\(remote-\*\)/);
   assert.match(summary, /✅ Legato facade smoke path/);
@@ -47,6 +55,8 @@ test('summarizeBoundaryValidation marks failed checks clearly', () => {
   const summary = summarizeBoundaryValidation({
     activeSurface: 'legato',
     playbackTarget: 'Legato facade',
+    preferredSurface: 'audioPlayer + mediaSession',
+    compatSurface: 'Legato facade (compatibility-only)',
     playbackCommands: ['setup'],
     mediaSessionCommands: ['addListener(remote-*)'],
     parityChecks: [

--- a/apps/capacitor-demo/src/main.ts
+++ b/apps/capacitor-demo/src/main.ts
@@ -1,8 +1,10 @@
 import { Capacitor } from '@capacitor/core';
 import {
   Legato,
+  addAudioPlayerListener,
+  addMediaSessionListener,
   audioPlayer,
-  createLegatoSync,
+  createAudioPlayerSync,
   mediaSession,
   type AudioPlayerApi,
   type PlaybackSnapshot,
@@ -26,13 +28,17 @@ import {
   summarizeBoundaryValidation,
 } from './boundary-harness.js';
 
-type LegatoSyncController = ReturnType<typeof createLegatoSync>;
+type LegatoSyncController = ReturnType<typeof createAudioPlayerSync>;
 
 const smokeButton = document.querySelector<HTMLButtonElement>('#run-smoke');
 const endSmokeButton = document.querySelector<HTMLButtonElement>('#run-end-smoke');
 const boundarySmokeButton = document.querySelector<HTMLButtonElement>('#run-boundary-smoke');
 const surfaceValidationButton = document.querySelector<HTMLButtonElement>('#run-surface-validation');
 const artworkRaceButton = document.querySelector<HTMLButtonElement>('#run-artwork-race');
+const remotePauseCaseButton = document.querySelector<HTMLButtonElement>('#run-case-remote-pause');
+const remotePlayCaseButton = document.querySelector<HTMLButtonElement>('#run-case-remote-play');
+const remoteSkipCaseButton = document.querySelector<HTMLButtonElement>('#run-case-remote-skip');
+const remoteSeekCaseButton = document.querySelector<HTMLButtonElement>('#run-case-remote-seek');
 const copyLogButton = document.querySelector<HTMLButtonElement>('#copy-log');
 const copyEventsButton = document.querySelector<HTMLButtonElement>('#copy-events');
 const copySmokeReportButton = document.querySelector<HTMLButtonElement>('#copy-smoke-report');
@@ -71,6 +77,10 @@ if (
   || !boundarySmokeButton
   || !surfaceValidationButton
   || !artworkRaceButton
+  || !remotePauseCaseButton
+  || !remotePlayCaseButton
+  || !remoteSkipCaseButton
+  || !remoteSeekCaseButton
   || !copyLogButton
   || !copyEventsButton
   || !copySmokeReportButton
@@ -111,6 +121,9 @@ const playbackSmokeDelayMs = 1500;
 const endSmokeDelayMs = 6500;
 const boundarySettleDelayMs = 300;
 const artworkRaceSettleDelayMs = 180;
+const guidedCaseTimeoutMs = 15000;
+const guidedCasePollMs = 220;
+const guidedCaseSettleMs = 600;
 const recentEventsLimit = 24;
 const progressSamplesLimit = 8;
 
@@ -119,6 +132,7 @@ const isNative = Capacitor.isNativePlatform();
 
 type PlaybackSurface = 'legato' | 'audioPlayer';
 type BoundaryCheck = { label: string; ok: boolean; detail: string };
+type SyncEventRecord = { name: string; summary: string; timestamp: number };
 
 let syncController: LegatoSyncController | null = null;
 let latestSnapshot: PlaybackSnapshot | null = null;
@@ -130,6 +144,7 @@ let activeSmokeFlow: SmokeFlow | null = null;
 const observedSyncEvents = new Set<string>();
 let activePlaybackSurface: PlaybackSurface = 'legato';
 let boundaryChecks: BoundaryCheck[] = [];
+let syncEventHistory: SyncEventRecord[] = [];
 
 const resolvePlaybackApi = (surface: PlaybackSurface): AudioPlayerApi => (
   surface === 'audioPlayer' ? audioPlayer : Legato
@@ -583,7 +598,7 @@ const startSync = async (): Promise<void> => {
     return;
   }
 
-  syncController = createLegatoSync({
+  syncController = createAudioPlayerSync({
     onSnapshot: (snapshot) => {
       updateSnapshotViews(snapshot);
       log('sync snapshot', snapshot);
@@ -591,6 +606,14 @@ const startSync = async (): Promise<void> => {
     onEvent: (eventName, payload) => {
       observedSyncEvents.add(eventName);
       const details = summarizePayload(payload);
+      syncEventHistory = [
+        ...syncEventHistory.slice(-95),
+        {
+          name: eventName,
+          summary: details,
+          timestamp: Date.now(),
+        },
+      ];
       log(`event:${eventName}`, payload);
       addRecentEvent(`event:${eventName}${details ? ` | ${details}` : ''}`);
 
@@ -603,6 +626,14 @@ const startSync = async (): Promise<void> => {
   const initial = await syncController.start();
   updateSnapshotViews(initial);
   log('sync.start() initial snapshot', initial);
+};
+
+const verifyNamespacedAudioPlayerListenerHelper = async (): Promise<void> => {
+  const eventName = 'playback-progress';
+  const helperHandle = await addAudioPlayerListener(eventName, (payload) => {
+    void payload;
+  });
+  await helperHandle.remove();
 };
 
 const stopSync = async (): Promise<void> => {
@@ -685,6 +716,7 @@ const snapshotAction = async (surface: PlaybackSurface = activePlaybackSurface):
 const clearFlows = (): void => {
   logNode.value = '';
   recentEvents = [];
+  syncEventHistory = [];
   latestSmokeReport = null;
   observedSyncEvents.clear();
   renderRecentEvents();
@@ -707,6 +739,72 @@ const resetSmokeBaseline = async (): Promise<void> => {
   recentProgressSamples = [];
 };
 
+const sleep = async (durationMs: number): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, durationMs));
+};
+
+const waitForCondition = async (predicate: () => boolean, timeoutMs: number): Promise<boolean> => {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) {
+      return true;
+    }
+    await sleep(guidedCasePollMs);
+  }
+
+  return predicate();
+};
+
+const caseCheck = (label: string, ok: boolean, detail: string): void => {
+  addBoundaryCheck({ label, ok, detail });
+  log(`[guided-case] ${ok ? 'PASS' : 'FAIL'} | ${label} | ${detail}`);
+};
+
+const remoteEventSeenSince = (eventName: string | RegExp, startedAt: number): boolean => (
+  syncEventHistory.some((entry) => {
+    if (entry.timestamp < startedAt) {
+      return false;
+    }
+    return typeof eventName === 'string'
+      ? entry.name === eventName
+      : eventName.test(entry.name);
+  })
+);
+
+const setupGuidedRemoteCaseBaseline = async (
+  caseName: string,
+  prePause = false,
+): Promise<PlaybackSnapshot> => {
+  clearFlows();
+  boundaryChecks = [];
+  renderBoundarySummary();
+
+  log(`[guided-case] start | ${caseName}`);
+  log('[guided-case] baseline reset: stop previous playback, start sync, add fixture queue, begin playback.');
+
+  await setupAction('legato');
+  await resetSmokeBaseline();
+  await startSync();
+  await addAction('legato');
+  await playAction('legato');
+  await sleep(guidedCaseSettleMs);
+
+  if (prePause) {
+    await pauseAction('legato');
+    await sleep(Math.round(guidedCaseSettleMs / 2));
+  }
+
+  await snapshotAction('legato');
+
+  if (!latestSnapshot) {
+    throw new Error(`Unable to capture baseline snapshot for ${caseName}`);
+  }
+
+  log(`[guided-case] baseline ready | ${summarizeSnapshot(latestSnapshot)}`);
+  return latestSnapshot;
+};
+
 const runSmokeFlow = async (): Promise<void> => {
   startSmokeVerdict('smoke');
   clearFlows();
@@ -718,6 +816,7 @@ const runSmokeFlow = async (): Promise<void> => {
   await setupAction('legato');
   await resetSmokeBaseline();
   await startSync();
+  await verifyNamespacedAudioPlayerListenerHelper();
   await addAction('legato');
   await playAction('legato');
 
@@ -852,8 +951,8 @@ const runSurfaceValidationFlow = async (): Promise<void> => {
       : `Mismatch detected: legato={state:${legatoSnapshot.state}, track:${legatoSnapshot.currentTrack?.id ?? 'none'}, queue:${queueLengthFromSnapshot(legatoSnapshot)}} audioPlayer={state:${audioPlayerSnapshot.state}, track:${audioPlayerSnapshot.currentTrack?.id ?? 'none'}, queue:${queueLengthFromSnapshot(audioPlayerSnapshot)}}`,
   });
 
-  const remotePlayHandle = await mediaSession.addListener('remote-play', () => {});
-  const remotePauseHandle = await mediaSession.addListener('remote-pause', () => {});
+  const remotePlayHandle = await addMediaSessionListener('remote-play', () => {});
+  const remotePauseHandle = await addMediaSessionListener('remote-pause', () => {});
   await remotePlayHandle.remove();
   await remotePauseHandle.remove();
   await mediaSession.removeAllListeners();
@@ -863,6 +962,230 @@ const runSurfaceValidationFlow = async (): Promise<void> => {
     ok: true,
     detail: 'remote listener registration/removal verified via mediaSession namespace.',
   });
+};
+
+const runRemotePauseCaseFlow = async (): Promise<void> => {
+  const baseline = await setupGuidedRemoteCaseBaseline('remote pause parity');
+  const baselinePosition = typeof baseline.position === 'number' ? baseline.position : null;
+  const startedAt = Date.now();
+
+  log('[guided-case] action required: background app and press PAUSE from lock-screen/notification/remote control within 15s.');
+  const observed = await waitForCondition(
+    () => latestSnapshot?.state === 'paused' || remoteEventSeenSince(/remote-?pause/i, startedAt),
+    guidedCaseTimeoutMs,
+  );
+
+  if (observed) {
+    await sleep(guidedCaseSettleMs);
+  }
+  await snapshotAction('legato');
+
+  const paused = latestSnapshot?.state === 'paused';
+  const remotePauseEventSeen = remoteEventSeenSince(/remote-?pause/i, startedAt);
+  const afterPosition = typeof latestSnapshot?.position === 'number' ? latestSnapshot.position : null;
+  const delta = baselinePosition !== null && afterPosition !== null
+    ? afterPosition - baselinePosition
+    : null;
+
+  caseCheck(
+    'Remote pause command observed',
+    remotePauseEventSeen || paused,
+    remotePauseEventSeen
+      ? 'remote-pause event observed in sync stream.'
+      : paused
+        ? 'Snapshot reached paused state even without explicit remote-pause event name.'
+        : 'No remote-pause signal observed before timeout.',
+  );
+  caseCheck('Playback state is paused', paused, `snapshot.state=${latestSnapshot?.state ?? 'unknown'}`);
+  caseCheck(
+    'Progress froze after pause',
+    paused && delta !== null ? Math.abs(delta) <= 320 : false,
+    delta === null
+      ? 'Unable to compare baseline/after positions.'
+      : `position delta=${delta >= 0 ? '+' : ''}${delta}ms (expect near 0 when paused).`,
+  );
+
+  log('[guided-case] end | remote pause parity');
+};
+
+const runRemotePlayCaseFlow = async (): Promise<void> => {
+  const baseline = await setupGuidedRemoteCaseBaseline('remote play resume parity', true);
+  const baselinePosition = typeof baseline.position === 'number' ? baseline.position : null;
+  const startedAt = Date.now();
+
+  log('[guided-case] action required: keep app backgrounded and press PLAY from lock-screen/notification/remote control within 15s.');
+  const observed = await waitForCondition(
+    () => latestSnapshot?.state === 'playing' || remoteEventSeenSince(/remote-?play/i, startedAt),
+    guidedCaseTimeoutMs,
+  );
+
+  if (observed) {
+    await sleep(guidedCaseSettleMs);
+  }
+  await snapshotAction('legato');
+
+  const remotePlayEventSeen = remoteEventSeenSince(/remote-?play/i, startedAt);
+  const playing = latestSnapshot?.state === 'playing';
+  const firstAfterPosition = typeof latestSnapshot?.position === 'number' ? latestSnapshot.position : null;
+
+  await sleep(1000);
+  await snapshotAction('legato');
+  const secondAfterPosition = typeof latestSnapshot?.position === 'number' ? latestSnapshot.position : null;
+  const resumedDelta = firstAfterPosition !== null && secondAfterPosition !== null
+    ? secondAfterPosition - firstAfterPosition
+    : null;
+  const baselineToNowDelta = baselinePosition !== null && secondAfterPosition !== null
+    ? secondAfterPosition - baselinePosition
+    : null;
+
+  caseCheck(
+    'Remote play command observed',
+    remotePlayEventSeen || playing,
+    remotePlayEventSeen
+      ? 'remote-play event observed in sync stream.'
+      : playing
+        ? 'Snapshot moved to playing state even without explicit remote-play event name.'
+        : 'No remote-play signal observed before timeout.',
+  );
+  caseCheck('Playback state returned to playing', playing, `snapshot.state=${latestSnapshot?.state ?? 'unknown'}`);
+  caseCheck(
+    'Progress advanced after remote play',
+    playing && resumedDelta !== null ? resumedDelta >= 320 : false,
+    resumedDelta === null
+      ? 'Unable to compare progress samples after remote play.'
+      : `latest delta=${resumedDelta >= 0 ? '+' : ''}${resumedDelta}ms over ~1s, baseline delta=${baselineToNowDelta ?? 'n/a'}ms.`,
+  );
+
+  log('[guided-case] end | remote play resume parity');
+};
+
+const runRemoteSkipCaseFlow = async (): Promise<void> => {
+  const baseline = await setupGuidedRemoteCaseBaseline('remote next/previous parity');
+  const baselineIndex = typeof baseline.currentIndex === 'number' ? baseline.currentIndex : null;
+
+  if (baselineIndex === null) {
+    caseCheck('Baseline index available', false, 'currentIndex missing in baseline snapshot.');
+    return;
+  }
+
+  const nextStartedAt = Date.now();
+  log('[guided-case] action required: press NEXT from lock-screen/notification/remote control within 15s.');
+  const nextObserved = await waitForCondition(
+    () => (
+      (typeof latestSnapshot?.currentIndex === 'number' && latestSnapshot.currentIndex > baselineIndex)
+      || remoteEventSeenSince(/remote-?(next|skip.*next)/i, nextStartedAt)
+    ),
+    guidedCaseTimeoutMs,
+  );
+
+  if (nextObserved) {
+    await sleep(guidedCaseSettleMs);
+  }
+  await snapshotAction('legato');
+
+  const indexAfterNext = typeof latestSnapshot?.currentIndex === 'number' ? latestSnapshot.currentIndex : null;
+  const remoteNextSeen = remoteEventSeenSince(/remote-?(next|skip.*next)/i, nextStartedAt);
+  const nextAdvanced = indexAfterNext !== null && indexAfterNext > baselineIndex;
+
+  caseCheck(
+    'Remote next command observed',
+    remoteNextSeen || nextAdvanced,
+    remoteNextSeen
+      ? 'remote-next/skip-to-next event observed.'
+      : nextAdvanced
+        ? `track index moved ${baselineIndex} -> ${indexAfterNext}.`
+        : 'No next transition observed before timeout.',
+  );
+  caseCheck(
+    'Queue index advanced on next',
+    nextAdvanced,
+    `baseline=${baselineIndex}, afterNext=${indexAfterNext ?? 'null'}`,
+  );
+
+  const previousStartedAt = Date.now();
+  log('[guided-case] action required: now press PREVIOUS from lock-screen/notification/remote control within 15s.');
+  const previousObserved = await waitForCondition(
+    () => (
+      (typeof latestSnapshot?.currentIndex === 'number' && latestSnapshot.currentIndex === baselineIndex)
+      || remoteEventSeenSince(/remote-?(previous|skip.*previous)/i, previousStartedAt)
+    ),
+    guidedCaseTimeoutMs,
+  );
+
+  if (previousObserved) {
+    await sleep(guidedCaseSettleMs);
+  }
+  await snapshotAction('legato');
+
+  const indexAfterPrevious = typeof latestSnapshot?.currentIndex === 'number' ? latestSnapshot.currentIndex : null;
+  const remotePreviousSeen = remoteEventSeenSince(/remote-?(previous|skip.*previous)/i, previousStartedAt);
+  const previousAligned = indexAfterPrevious === baselineIndex;
+
+  caseCheck(
+    'Remote previous command observed',
+    remotePreviousSeen || previousAligned,
+    remotePreviousSeen
+      ? 'remote-previous/skip-to-previous event observed.'
+      : previousAligned
+        ? `track index returned to baseline (${baselineIndex}).`
+        : 'No previous transition observed before timeout.',
+  );
+  caseCheck(
+    'Queue index returned to baseline after previous',
+    previousAligned,
+    `baseline=${baselineIndex}, afterPrevious=${indexAfterPrevious ?? 'null'}`,
+  );
+
+  log('[guided-case] end | remote next/previous parity');
+};
+
+const runRemoteSeekCaseFlow = async (): Promise<void> => {
+  const baseline = await setupGuidedRemoteCaseBaseline('remote seek parity');
+  const baselinePosition = typeof baseline.position === 'number' ? baseline.position : null;
+
+  if (baselinePosition === null) {
+    caseCheck('Baseline position available', false, 'position missing in baseline snapshot.');
+    return;
+  }
+
+  const startedAt = Date.now();
+  log('[guided-case] action required: seek from lock-screen/notification/remote control to a visibly different position (e.g. 4s) within 15s.');
+  const observed = await waitForCondition(
+    () => (
+      (typeof latestSnapshot?.position === 'number' && Math.abs(latestSnapshot.position - baselinePosition) >= 1200)
+      || remoteEventSeenSince(/remote-?seek/i, startedAt)
+    ),
+    guidedCaseTimeoutMs,
+  );
+
+  if (observed) {
+    await sleep(guidedCaseSettleMs);
+  }
+  await snapshotAction('legato');
+
+  const remoteSeekSeen = remoteEventSeenSince(/remote-?seek/i, startedAt);
+  const finalPosition = typeof latestSnapshot?.position === 'number' ? latestSnapshot.position : null;
+  const jumpDelta = finalPosition === null ? null : finalPosition - baselinePosition;
+  const seekJumped = jumpDelta !== null && Math.abs(jumpDelta) >= 1200;
+
+  caseCheck(
+    'Remote seek command observed',
+    remoteSeekSeen || seekJumped,
+    remoteSeekSeen
+      ? 'remote-seek event observed in sync stream.'
+      : seekJumped
+        ? `snapshot position jumped by ${jumpDelta >= 0 ? '+' : ''}${jumpDelta}ms.`
+        : 'No seek movement observed before timeout.',
+  );
+  caseCheck(
+    'Snapshot position moved after remote seek',
+    seekJumped,
+    jumpDelta === null
+      ? 'Unable to compare baseline/final positions.'
+      : `baseline=${baselinePosition}ms, final=${finalPosition}ms, delta=${jumpDelta >= 0 ? '+' : ''}${jumpDelta}ms.`,
+  );
+
+  log('[guided-case] end | remote seek parity');
 };
 
 const setPlaybackSurface = (surface: PlaybackSurface): void => {
@@ -875,7 +1198,7 @@ envStatusNode.textContent = `platform=${platform} | native=${isNative}`;
 log('Legato parity harness ready.');
 log('platform:', platform);
 log('isNativePlatform:', isNative);
-log('Use smoke buttons for quick pass/fail and manual controls for lifecycle/focus deep checks.');
+log('Use smoke buttons for quick pass/fail, guided cases for scripted remote checks, and manual controls for deep debugging.');
 renderBoundarySummary();
 
 smokeButton.addEventListener('click', () => {
@@ -896,6 +1219,22 @@ surfaceValidationButton.addEventListener('click', () => {
 
 artworkRaceButton.addEventListener('click', () => {
   void runNativeAction('run artwork race flow', runArtworkRaceFlow);
+});
+
+remotePauseCaseButton.addEventListener('click', () => {
+  void runNativeAction('run guided case: remote pause parity', runRemotePauseCaseFlow);
+});
+
+remotePlayCaseButton.addEventListener('click', () => {
+  void runNativeAction('run guided case: remote play resume parity', runRemotePlayCaseFlow);
+});
+
+remoteSkipCaseButton.addEventListener('click', () => {
+  void runNativeAction('run guided case: remote next/previous parity', runRemoteSkipCaseFlow);
+});
+
+remoteSeekCaseButton.addEventListener('click', () => {
+  void runNativeAction('run guided case: remote seek parity', runRemoteSeekCaseFlow);
 });
 
 setupButton.addEventListener('click', () => {

--- a/packages/capacitor/README.md
+++ b/packages/capacitor/README.md
@@ -33,6 +33,47 @@ It also exports typed event helpers aligned with `@legato/contract`, and `create
 - New integrations: prefer `audioPlayer` for playback operations and `mediaSession` for remote/session listeners.
 - Mixed migration is supported: both namespaced exports and `Legato` route to the same underlying plugin/state.
 
+### Legacy → namespaced migration map (preferred path)
+
+| Legacy helper/API | Preferred namespaced API | Posture |
+|---|---|---|
+| `Legato.addListener('playback-*', ...)` | `addAudioPlayerListener('playback-*', ...)` | Preferred for new code |
+| `Legato.addListener('remote-*', ...)` | `addMediaSessionListener('remote-*', ...)` | Preferred for new code |
+| `createLegatoSync(...)` | `createAudioPlayerSync(...)` | Preferred for new code |
+| `LEGATO_EVENTS` | `AUDIO_PLAYER_EVENTS` + `MEDIA_SESSION_EVENTS` | Preferred for explicit boundaries |
+| `Legato` facade calls (`Legato.play()`, etc.) | `audioPlayer` / `mediaSession` namespaces | Compatibility-only for existing flows |
+
+Compatibility-only (legacy Legato facade): `Legato`, `createLegatoSync`, `LEGATO_EVENTS`, and `addLegatoListener` remain supported and unchanged.
+
+```ts
+import {
+  addAudioPlayerListener,
+  addMediaSessionListener,
+  createAudioPlayerSync,
+} from '@legato/capacitor';
+
+const sync = createAudioPlayerSync({
+  onSnapshot(snapshot) {
+    console.log('snapshot', snapshot.state);
+  },
+});
+
+await sync.start();
+
+const playbackHandle = await addAudioPlayerListener('playback-state-changed', (payload) => {
+  console.log('playback state', payload.state);
+});
+
+const remoteHandle = await addMediaSessionListener('remote-play', () => {
+  console.log('remote play');
+});
+
+// ...later
+await playbackHandle.remove();
+await remoteHandle.remove();
+await sync.stop();
+```
+
 ## MVP limitations
 
 - Native runtime playback wiring (ExoPlayer/AVPlayer) is still pending in core.

--- a/packages/capacitor/src/events.ts
+++ b/packages/capacitor/src/events.ts
@@ -1,11 +1,21 @@
-import { LEGATO_EVENT_NAMES } from '@legato/contract';
+import {
+  LEGATO_EVENT_NAMES,
+  MEDIA_SESSION_EVENT_NAMES,
+  PLAYER_EVENT_NAMES,
+} from '@legato/contract';
 import type {
   LegatoEventName,
   LegatoEventPayloadMap,
 } from './definitions';
-import { Legato } from './plugin';
+import { Legato, audioPlayer, mediaSession } from './plugin';
+
+export const AUDIO_PLAYER_EVENTS = PLAYER_EVENT_NAMES;
+export const MEDIA_SESSION_EVENTS = MEDIA_SESSION_EVENT_NAMES;
 
 export const LEGATO_EVENTS = LEGATO_EVENT_NAMES;
+
+export const addAudioPlayerListener = audioPlayer.addListener.bind(audioPlayer);
+export const addMediaSessionListener = mediaSession.addListener.bind(mediaSession);
 
 export function addLegatoListener<E extends LegatoEventName>(
   eventName: E,

--- a/packages/capacitor/src/index.ts
+++ b/packages/capacitor/src/index.ts
@@ -1,6 +1,10 @@
 export type * from './definitions';
 export { Legato, audioPlayer, mediaSession } from './plugin';
 export {
+  AUDIO_PLAYER_EVENTS,
+  MEDIA_SESSION_EVENTS,
+  addAudioPlayerListener,
+  addMediaSessionListener,
   LEGATO_EVENTS,
   addLegatoListener,
   onPlaybackActiveTrackChanged,
@@ -15,4 +19,4 @@ export {
   onRemotePrevious,
   onRemoteSeek,
 } from './events';
-export { createLegatoSync } from './sync';
+export { createAudioPlayerSync, createLegatoSync } from './sync';

--- a/packages/capacitor/src/sync.ts
+++ b/packages/capacitor/src/sync.ts
@@ -1,15 +1,14 @@
 import type { PluginListenerHandle } from '@capacitor/core';
 import type {
-  LegatoApi,
-  LegatoEventApi,
+  AudioPlayerApi,
   LegatoEventName,
   LegatoEventPayloadMap,
   PlaybackSnapshot,
 } from './definitions';
-import { LEGATO_EVENTS } from './events';
+import { AUDIO_PLAYER_EVENTS } from './events';
 import { Legato } from './plugin';
 
-type SyncClient = LegatoApi & LegatoEventApi;
+type SyncClient = AudioPlayerApi;
 
 export interface LegatoSyncOptions {
   client?: SyncClient;
@@ -22,6 +21,12 @@ export interface LegatoSyncController {
   resync(): Promise<PlaybackSnapshot>;
   getCurrent(): PlaybackSnapshot | null;
   stop(): Promise<void>;
+}
+
+export type AudioPlayerSyncClient = AudioPlayerApi;
+
+export interface AudioPlayerSyncOptions extends LegatoSyncOptions {
+  client?: AudioPlayerSyncClient;
 }
 
 export function createLegatoSync(options: LegatoSyncOptions = {}): LegatoSyncController {
@@ -80,7 +85,7 @@ export function createLegatoSync(options: LegatoSyncOptions = {}): LegatoSyncCon
 
   const subscribe = async () => {
     await Promise.all(
-      LEGATO_EVENTS.map(async (eventName) => {
+      AUDIO_PLAYER_EVENTS.map(async (eventName) => {
         const handle = await client.addListener(eventName, (payload) => {
           options.onEvent?.(eventName, payload as LegatoEventPayloadMap[LegatoEventName]);
           applyEventToSnapshot(eventName, payload as LegatoEventPayloadMap[LegatoEventName]);
@@ -107,4 +112,8 @@ export function createLegatoSync(options: LegatoSyncOptions = {}): LegatoSyncCon
       await Promise.all(handles.splice(0).map((handle) => handle.remove()));
     },
   };
+}
+
+export function createAudioPlayerSync(options: AudioPlayerSyncOptions = {}): LegatoSyncController {
+  return createLegatoSync(options);
 }


### PR DESCRIPTION
Closes #38

## Summary
- add namespaced-first helper ergonomics around `audioPlayer` / `mediaSession` without changing native/runtime behavior
- add playback-scoped sync ergonomics (`createAudioPlayerSync`) backed by the shared existing sync implementation
- update docs and the Capacitor demo harness so the preferred path is explicit while preserving `Legato` compatibility

## Changes
| File | Change |
|------|--------|
| `packages/capacitor/src/events.ts` | adds namespaced listener helpers (`AUDIO_PLAYER_EVENTS`, `MEDIA_SESSION_EVENTS`, `addAudioPlayerListener`, `addMediaSessionListener`) while preserving legacy helpers |
| `packages/capacitor/src/sync.ts` | adds `AudioPlayerSyncClient`, `AudioPlayerSyncOptions`, and `createAudioPlayerSync` over the existing sync implementation |
| `packages/capacitor/src/index.ts` | exports namespaced-first helpers while keeping legacy compatibility exports |
| `packages/capacitor/README.md` | adds migration-oriented docs mapping `Legato` usage to `audioPlayer` / `mediaSession` |
| `apps/capacitor-demo/src/main.ts` | uses namespaced-first helper imports/usages in boundary validation flows |
| `apps/capacitor-demo/src/boundary-harness.js` / `.test.mjs` | improves visible summary of preferred vs compatibility paths |
| `apps/capacitor-demo/index.html` / `README.md` | clarifies migration-oriented boundary validation in the demo |
| `apps/capacitor-demo/android/app/src/test/java/com/getcapacitor/myapp/HarnessValidationContractTest.java` | aligns contract assertions with the new boundary ergonomics surface |

## Test Plan
- [x] `bash ./apps/capacitor-demo/android/gradlew test` remains green
- [x] Boundary harness guided validation shows `Legato`, `audioPlayer`, and `mediaSession` surfaces are all visible and usable
- [ ] `packages/capacitor` `npm run typecheck` remains blocked by pre-existing TypeScript/tooling debt (not introduced by this milestone)

## Notes
- This is additive API ergonomics only: no native/runtime behavior changes are included.
- The remaining `remote play resume parity` guided-case flake is treated as non-blocking harness timing noise, not a runtime regression.
