### PR TITLE
chore(api): harden boundary typecheck

### DIFF
--- a/apps/capacitor-demo/capacitor.config.ts
+++ b/apps/capacitor-demo/capacitor.config.ts
@@ -4,7 +4,6 @@ const config: CapacitorConfig = {
   appId: 'io.legato.demo',
   appName: 'Legato Demo',
   webDir: 'dist',
-  bundledWebRuntime: false,
 };
 
 export default config;

--- a/apps/capacitor-demo/src/main.ts
+++ b/apps/capacitor-demo/src/main.ts
@@ -216,7 +216,7 @@ const summarizeSnapshot = (snapshot: PlaybackSnapshot): string => {
     `duration=${formatMs(snapshot.duration)}`,
     `buffered=${formatMs(snapshot.bufferedPosition ?? null)}`,
     `queue=${queueLength}`,
-    `error=${snapshot.error ? JSON.stringify(snapshot.error) : 'none'}`,
+    `error=${snapshot.state === 'error' ? 'state=error (details in logs)' : 'none'}`,
   ].join(' | ');
 };
 

--- a/packages/capacitor/src/definitions.ts
+++ b/packages/capacitor/src/definitions.ts
@@ -29,6 +29,18 @@ export type AudioPlayerEventPayloadMap = ContractPlayerEventPayloadMap;
 export type MediaSessionEventPayloadMap = ContractMediaSessionEventPayloadMap;
 export type LegatoEventPayloadMap = ContractLegatoEventPayloadMap;
 
+export type AudioPlayerListener<E extends AudioPlayerEventName> = (
+  payload: AudioPlayerEventPayloadMap[E],
+) => void;
+
+export type MediaSessionListener<E extends MediaSessionEventName> = (
+  payload: MediaSessionEventPayloadMap[E],
+) => void;
+
+export type LegatoListener<E extends LegatoEventName> = (
+  payload: LegatoEventPayloadMap[E],
+) => void;
+
 export interface AddOptions {
   tracks: Track[];
   startIndex?: number;
@@ -67,7 +79,7 @@ export interface AudioPlayerApi {
   getSnapshot(): Promise<PlaybackSnapshot>;
   addListener<E extends AudioPlayerEventName>(
     eventName: E,
-    listener: (payload: AudioPlayerEventPayloadMap[E]) => void,
+    listener: AudioPlayerListener<E>,
   ): Promise<PluginListenerHandle>;
   removeAllListeners(): Promise<void>;
 }
@@ -76,7 +88,7 @@ export interface MediaSessionApi {
   setup(): Promise<void>;
   addListener<E extends MediaSessionEventName>(
     eventName: E,
-    listener: (payload: MediaSessionEventPayloadMap[E]) => void,
+    listener: MediaSessionListener<E>,
   ): Promise<PluginListenerHandle>;
   removeAllListeners(): Promise<void>;
 }
@@ -86,7 +98,7 @@ export type LegatoApi = AudioPlayerApi & MediaSessionApi;
 export interface LegatoEventApi {
   addListener<E extends LegatoEventName>(
     eventName: E,
-    listener: (payload: LegatoEventPayloadMap[E]) => void,
+    listener: LegatoListener<E>,
   ): Promise<PluginListenerHandle>;
   removeAllListeners(): Promise<void>;
 }

--- a/packages/capacitor/src/plugin.ts
+++ b/packages/capacitor/src/plugin.ts
@@ -3,9 +3,15 @@ import type { Plugin } from '@capacitor/core';
 import type {
   AddOptions,
   AudioPlayerApi,
+  AudioPlayerEventName,
+  AudioPlayerListener,
   LegatoApi,
   LegatoEventApi,
+  LegatoEventName,
+  LegatoListener,
   MediaSessionApi,
+  MediaSessionEventName,
+  MediaSessionListener,
   PlaybackSnapshot,
   PlaybackState,
   QueueSnapshot,
@@ -69,11 +75,11 @@ const sharedDelegate = {
   async setup() {
     await LegatoCapacitor.setup();
   },
-  async add(options) {
+  async add(options: AddOptions) {
     const result = await LegatoCapacitor.add(options);
     return result.snapshot;
   },
-  async remove(options) {
+  async remove(options: RemoveOptions) {
     const result = await LegatoCapacitor.remove(options);
     return result.snapshot;
   },
@@ -90,10 +96,10 @@ const sharedDelegate = {
   async stop() {
     await LegatoCapacitor.stop();
   },
-  async seekTo(options) {
+  async seekTo(options: SeekToOptions) {
     await LegatoCapacitor.seekTo(options);
   },
-  async skipTo(options) {
+  async skipTo(options: SkipToOptions) {
     const result = await LegatoCapacitor.skipTo(options);
     return result.snapshot;
   },
@@ -127,13 +133,25 @@ const sharedDelegate = {
     const result = await LegatoCapacitor.getSnapshot();
     return result.snapshot;
   },
-  addListener(eventName, listener) {
-    return LegatoCapacitor.addListener(eventName, listener);
-  },
   removeAllListeners() {
     return LegatoCapacitor.removeAllListeners();
   },
 };
+
+const addAudioPlayerListener: AudioPlayerApi['addListener'] = <E extends AudioPlayerEventName>(
+  eventName: E,
+  listener: AudioPlayerListener<E>,
+) => LegatoCapacitor.addListener(eventName, listener);
+
+const addMediaSessionListener: MediaSessionApi['addListener'] = <E extends MediaSessionEventName>(
+  eventName: E,
+  listener: MediaSessionListener<E>,
+) => LegatoCapacitor.addListener(eventName, listener);
+
+const addLegatoListener: LegatoEventApi['addListener'] = <E extends LegatoEventName>(
+  eventName: E,
+  listener: LegatoListener<E>,
+) => LegatoCapacitor.addListener(eventName, listener);
 
 export const audioPlayer: AudioPlayerApi = {
   setup: sharedDelegate.setup,
@@ -153,17 +171,19 @@ export const audioPlayer: AudioPlayerApi = {
   getCurrentTrack: sharedDelegate.getCurrentTrack,
   getQueue: sharedDelegate.getQueue,
   getSnapshot: sharedDelegate.getSnapshot,
-  addListener: sharedDelegate.addListener,
+  addListener: addAudioPlayerListener,
   removeAllListeners: sharedDelegate.removeAllListeners,
 };
 
 export const mediaSession: MediaSessionApi = {
   setup: sharedDelegate.setup,
-  addListener: sharedDelegate.addListener,
+  addListener: addMediaSessionListener,
   removeAllListeners: sharedDelegate.removeAllListeners,
 };
 
 export const Legato: LegatoApi & LegatoEventApi = {
   ...audioPlayer,
   ...mediaSession,
+  addListener: addLegatoListener,
+  removeAllListeners: sharedDelegate.removeAllListeners,
 };

--- a/packages/capacitor/src/sync.ts
+++ b/packages/capacitor/src/sync.ts
@@ -1,10 +1,5 @@
 import type { PluginListenerHandle } from '@capacitor/core';
-import type {
-  AudioPlayerApi,
-  LegatoEventName,
-  LegatoEventPayloadMap,
-  PlaybackSnapshot,
-} from './definitions';
+import type { AudioPlayerApi, LegatoEventName, LegatoEventPayloadMap, PlaybackSnapshot } from './definitions';
 import { AUDIO_PLAYER_EVENTS } from './events';
 import { Legato } from './plugin';
 
@@ -40,43 +35,61 @@ export function createLegatoSync(options: LegatoSyncOptions = {}): LegatoSyncCon
     return snapshot;
   };
 
-  const applyEventToSnapshot = (
-    eventName: LegatoEventName,
-    payload: LegatoEventPayloadMap[LegatoEventName],
-  ) => {
+  const applyEventToSnapshot = (eventName: LegatoEventName, payload: LegatoEventPayloadMap[LegatoEventName]) => {
     if (!current) {
       return;
     }
 
     switch (eventName) {
-      case 'playback-state-changed':
-        publishSnapshot({ ...current, state: payload.state });
+      case 'playback-state-changed': {
+        const eventPayload = payload as LegatoEventPayloadMap['playback-state-changed'];
+        publishSnapshot({ ...current, state: eventPayload.state });
         break;
-      case 'playback-active-track-changed':
+      }
+      case 'playback-active-track-changed': {
+        const eventPayload = payload as LegatoEventPayloadMap['playback-active-track-changed'];
         publishSnapshot({
           ...current,
-          currentTrack: payload.track,
-          currentIndex: payload.index,
-          duration: payload.track?.duration ?? current.duration,
+          currentTrack: eventPayload.track,
+          currentIndex: eventPayload.index,
+          duration: eventPayload.track?.duration ?? current.duration,
           queue: {
             ...current.queue,
-            currentIndex: payload.index,
+            currentIndex: eventPayload.index,
           },
         });
         break;
-      case 'playback-queue-changed':
-        publishSnapshot({ ...current, queue: payload.queue, currentIndex: payload.queue.currentIndex });
-        break;
-      case 'playback-progress':
+      }
+      case 'playback-queue-changed': {
+        const eventPayload = payload as LegatoEventPayloadMap['playback-queue-changed'];
         publishSnapshot({
           ...current,
-          position: payload.position,
-          duration: payload.duration,
-          bufferedPosition: payload.bufferedPosition,
+          queue: eventPayload.queue,
+          currentIndex: eventPayload.queue.currentIndex,
         });
         break;
-      case 'playback-ended':
-        publishSnapshot(payload.snapshot);
+      }
+      case 'playback-progress': {
+        const eventPayload = payload as LegatoEventPayloadMap['playback-progress'];
+        publishSnapshot({
+          ...current,
+          position: eventPayload.position,
+          duration: eventPayload.duration,
+          bufferedPosition: eventPayload.bufferedPosition,
+        });
+        break;
+      }
+      case 'playback-ended': {
+        const eventPayload = payload as LegatoEventPayloadMap['playback-ended'];
+        publishSnapshot(eventPayload.snapshot);
+        break;
+      }
+      case 'playback-error':
+      case 'remote-play':
+      case 'remote-pause':
+      case 'remote-next':
+      case 'remote-previous':
+      case 'remote-seek':
         break;
       default:
         break;
@@ -87,8 +100,9 @@ export function createLegatoSync(options: LegatoSyncOptions = {}): LegatoSyncCon
     await Promise.all(
       AUDIO_PLAYER_EVENTS.map(async (eventName) => {
         const handle = await client.addListener(eventName, (payload) => {
-          options.onEvent?.(eventName, payload as LegatoEventPayloadMap[LegatoEventName]);
-          applyEventToSnapshot(eventName, payload as LegatoEventPayloadMap[LegatoEventName]);
+          const legatoPayload = payload as LegatoEventPayloadMap[typeof eventName];
+          options.onEvent?.(eventName, legatoPayload);
+          applyEventToSnapshot(eventName, legatoPayload);
         });
         handles.push(handle);
       }),


### PR DESCRIPTION
Closes #40

## Summary
- restore clean typecheck confidence for the new `audioPlayer` / `mediaSession` boundary surfaces
- harden `packages/capacitor` type signatures without changing runtime/native behavior
- fix demo-side type drift so the adoption example stays compile-time trustworthy

## Changes
| File | Change |
|------|--------|
| `packages/capacitor/src/definitions.ts` | introduces reusable listener aliases and tightens API listener signatures |
| `packages/capacitor/src/plugin.ts` | makes shared delegate typing explicit and preserves legacy `Legato.addListener` typing intentionally |
| `packages/capacitor/src/sync.ts` | narrows event payload handling in a typed way and keeps `createAudioPlayerSync` aligned to `createLegatoSync` |
| `apps/capacitor-demo/capacitor.config.ts` | removes stale `bundledWebRuntime` key invalid for current Capacitor config typing |
| `apps/capacitor-demo/src/main.ts` | removes stale `snapshot.error` typing assumptions and aligns demo output with current contract |

## Test Plan
- [x] `cd packages/capacitor && npm run typecheck`
- [x] `cd apps/capacitor-demo && npm run typecheck`
- [x] `cd apps/capacitor-demo/android && sh ./gradlew test`

## Notes
- This is compile-time/API hardening only; no native runtime behavior changed.
- `./gradlew` still lacks execute permission in this workspace, so the verified command remains `sh ./gradlew test`.
