### PR TITLE
test(release): validate external consumer

### DIFF
--- a/apps/capacitor-demo/scripts/capture-native-release-evidence.mjs
+++ b/apps/capacitor-demo/scripts/capture-native-release-evidence.mjs
@@ -1,5 +1,5 @@
 import { access, copyFile, mkdir, writeFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
 
 const PASS = 'PASS';
 const FAIL = 'FAIL';
@@ -63,12 +63,18 @@ export const captureNativeReleaseEvidence = async ({
   outputDir = 'artifacts/release-native-artifact-foundation-v1',
 } = {}) => {
   const defaults = resolveDefaultArtifacts();
+  const hasCustomEvidencePaths = [androidResolutionLogPath, iosResolutionLogPath, androidSmokeReportPath, iosSmokeReportPath]
+    .some((value) => typeof value === 'string' && value.trim() !== '');
+  const inferredExternalSummaryPath = hasCustomEvidencePaths && !externalSummaryPath
+    ? resolve(dirname(androidResolutionLogPath ?? iosResolutionLogPath ?? androidSmokeReportPath ?? iosSmokeReportPath), 'external-consumer-validation-v1/summary.json')
+    : undefined;
+
   const sources = {
     androidResolutionLog: androidResolutionLogPath ?? defaults.androidResolutionLog,
     iosResolutionLog: iosResolutionLogPath ?? defaults.iosResolutionLog,
     androidSmokeReport: androidSmokeReportPath ?? defaults.androidSmokeReport,
     iosSmokeReport: iosSmokeReportPath ?? defaults.iosSmokeReport,
-    externalConsumerSummary: externalSummaryPath ?? defaults.externalConsumerSummary,
+    externalConsumerSummary: externalSummaryPath ?? inferredExternalSummaryPath ?? defaults.externalConsumerSummary,
   };
 
   const outputNames = resolveOutputNames();

--- a/apps/capacitor-demo/scripts/external-consumer-template.test.mjs
+++ b/apps/capacitor-demo/scripts/external-consumer-template.test.mjs
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const templateRoot = resolve(currentDir, './external-consumer-template');
+
+test('external consumer template package uses standard Capacitor deps with no workspace or local file protocols', async () => {
+  const packageJsonRaw = await readFile(resolve(templateRoot, 'package.json'), 'utf8');
+  const packageJson = JSON.parse(packageJsonRaw);
+
+  assert.equal(packageJson.name, '@legato/external-consumer-template');
+  assert.equal(typeof packageJson.scripts?.typecheck, 'string');
+  assert.match(packageJson.scripts.typecheck, /tsc\s+--noEmit/i);
+  assert.equal(Object.hasOwn(packageJson.dependencies ?? {}, '@legato/capacitor'), false);
+  assert.equal(Object.hasOwn(packageJson.dependencies ?? {}, '@legato/contract'), false);
+
+  const dependencyValues = Object.values({
+    ...(packageJson.dependencies ?? {}),
+    ...(packageJson.devDependencies ?? {}),
+  });
+  for (const value of dependencyValues) {
+    assert.equal(typeof value, 'string');
+    assert.equal(value.includes('workspace:'), false);
+    assert.equal(value.includes('file:'), false);
+  }
+});
+
+test('external consumer template compile surface imports legato capacitor and contract types', async () => {
+  const source = await readFile(resolve(templateRoot, 'src/main.ts'), 'utf8');
+  assert.match(source, /from\s+'@legato\/capacitor'/i);
+  assert.match(source, /from\s+'@legato\/contract'/i);
+  assert.match(source, /Legato/i);
+});

--- a/apps/capacitor-demo/scripts/external-consumer-template/package.json
+++ b/apps/capacitor-demo/scripts/external-consumer-template/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@legato/external-consumer-template",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@capacitor/android": "^8.0.0",
+    "@capacitor/core": "^8.0.0",
+    "@capacitor/ios": "^8.0.0"
+  },
+  "devDependencies": {
+    "@capacitor/cli": "^8.0.0",
+    "typescript": "^5.6.3"
+  }
+}

--- a/apps/capacitor-demo/scripts/external-consumer-template/src/main.ts
+++ b/apps/capacitor-demo/scripts/external-consumer-template/src/main.ts
@@ -1,0 +1,18 @@
+import { Legato, type PlaybackSnapshot } from '@legato/capacitor';
+import type { Track } from '@legato/contract';
+
+const fixtureTrack: Track = {
+  id: 'external-track-1',
+  url: 'https://samplelib.com/mp3/sample-12s.mp3',
+  title: 'External Fixture Track',
+  artist: 'Legato',
+  album: 'External Consumer Validation',
+  artwork: 'https://i.pravatar.cc/300',
+  duration: 12000,
+  type: 'progressive',
+};
+
+export const compileSurfaceProof = async (): Promise<PlaybackSnapshot> => {
+  await Legato.setup();
+  return Legato.add({ tracks: [fixtureTrack] });
+};

--- a/apps/capacitor-demo/scripts/external-consumer-template/tsconfig.json
+++ b/apps/capacitor-demo/scripts/external-consumer-template/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/capacitor-demo/scripts/external-consumer-validation-v1-docs.test.mjs
+++ b/apps/capacitor-demo/scripts/external-consumer-validation-v1-docs.test.mjs
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const docsPath = resolve(currentDir, '../../../docs/releases/external-consumer-validation-v1.md');
+
+test('external consumer runbook states v1 boundaries and non-goals', async () => {
+  const runbook = await readFile(docsPath, 'utf8');
+
+  assert.match(runbook, /NOT publication proof/i);
+  assert.match(runbook, /outside the monorepo/i);
+  assert.match(runbook, /npm pack/i);
+});
+
+test('external consumer runbook includes deterministic command sequence and artifact outputs', async () => {
+  const runbook = await readFile(docsPath, 'utf8');
+
+  assert.match(runbook, /npm run build/i);
+  assert.match(runbook, /npm run validate:external:consumer/i);
+  assert.match(runbook, /npm run capture:release:native-artifacts/i);
+  assert.match(runbook, /artifacts\/external-consumer-validation-v1\/summary\.json/i);
+  assert.match(runbook, /artifacts\/release-native-artifact-foundation-v1\/manifest\.json/i);
+});

--- a/apps/capacitor-demo/scripts/run-external-consumer-validation.mjs
+++ b/apps/capacitor-demo/scripts/run-external-consumer-validation.mjs
@@ -1,0 +1,414 @@
+import { cp, lstat, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+
+const PASS = 'PASS';
+const FAIL = 'FAIL';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const defaultRepoRoot = resolve(scriptDir, '../../..');
+const defaultTemplateRoot = resolve(scriptDir, 'external-consumer-template');
+const defaultArtifactsDir = resolve(scriptDir, '../artifacts/external-consumer-validation-v1');
+
+const normalizePath = (value) => resolve(value).replaceAll('\\', '/');
+
+const isInside = (target, root) => {
+  const normalizedTarget = normalizePath(target);
+  const normalizedRoot = normalizePath(root).replace(/\/+$/, '');
+  return normalizedTarget === normalizedRoot || normalizedTarget.startsWith(`${normalizedRoot}/`);
+};
+
+export const ensureFixtureOutsideRepo = ({ repoRoot, fixtureRoot }) => {
+  if (isInside(fixtureRoot, repoRoot)) {
+    throw new Error(`External fixture must be outside repo root. repoRoot=${repoRoot} fixtureRoot=${fixtureRoot}`);
+  }
+};
+
+const collectStringValues = (value, into = []) => {
+  if (typeof value === 'string') {
+    into.push(value);
+    return into;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectStringValues(item, into);
+    }
+    return into;
+  }
+  if (value && typeof value === 'object') {
+    for (const item of Object.values(value)) {
+      collectStringValues(item, into);
+    }
+  }
+  return into;
+};
+
+export const inspectIsolationLeaks = ({ packageLockRaw = '', installManifestRaw = '' }) => {
+  const failures = [];
+  const haystacks = [packageLockRaw, installManifestRaw];
+  for (const haystack of haystacks) {
+    if (/workspace:/i.test(haystack)) {
+      failures.push('Isolation breach: workspace: reference detected in dependency metadata.');
+      break;
+    }
+  }
+
+  const scanDirectoryFileRefs = (text) => {
+    const refs = text.match(/file:[^"\s,}]+/gi) ?? [];
+    for (const ref of refs) {
+      if (!/\.tgz$/i.test(ref)) {
+        failures.push(`Isolation breach: directory file: dependency detected (${ref}). Only .tgz file: refs are allowed.`);
+      }
+    }
+  };
+  scanDirectoryFileRefs(packageLockRaw);
+  scanDirectoryFileRefs(installManifestRaw);
+
+  try {
+    if (packageLockRaw.trim().length > 0) {
+      const parsed = JSON.parse(packageLockRaw);
+      const strings = collectStringValues(parsed);
+      for (const value of strings) {
+        if (/^workspace:/i.test(value)) {
+          failures.push(`Isolation breach: workspace protocol detected (${value}).`);
+        }
+        if (/^file:/i.test(value) && !/\.tgz$/i.test(value)) {
+          failures.push(`Isolation breach: directory file: protocol detected (${value}).`);
+        }
+      }
+    }
+  } catch {
+    failures.push('Isolation breach: failed to parse package-lock.json for dependency source checks.');
+  }
+
+  const status = failures.length === 0 ? PASS : FAIL;
+  return {
+    status,
+    exitCode: status === PASS ? 0 : 1,
+    failures,
+  };
+};
+
+const runCommand = async ({ command, args, cwd }) => new Promise((resolveResult, rejectResult) => {
+  const child = spawn(command, args, {
+    cwd,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: process.env,
+  });
+
+  let stdout = '';
+  let stderr = '';
+
+  child.stdout.on('data', (chunk) => {
+    stdout += chunk.toString();
+  });
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk.toString();
+  });
+
+  child.on('close', (code) => {
+    if (code === 0) {
+      resolveResult({ stdout, stderr, exitCode: code });
+      return;
+    }
+    const error = new Error(`Command failed (${command} ${args.join(' ')})`);
+    error.exitCode = code;
+    error.stdout = stdout;
+    error.stderr = stderr;
+    rejectResult(error);
+  });
+});
+
+const pathExists = async (path) => {
+  try {
+    await lstat(path);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const ensureCapacitorPlatform = async ({ fixtureRoot, platform, commandRunner }) => {
+  const platformRoot = join(fixtureRoot, platform);
+  const exists = await pathExists(platformRoot);
+  if (exists) {
+    return;
+  }
+
+  await commandRunner({
+    command: 'npx',
+    args: ['cap', 'add', platform],
+    cwd: fixtureRoot,
+  });
+};
+
+const ensureFixtureScaffold = async (fixtureRoot) => {
+  const capacitorConfigPath = join(fixtureRoot, 'capacitor.config.ts');
+  const webDir = join(fixtureRoot, 'dist');
+  const indexHtmlPath = join(webDir, 'index.html');
+  const nodeModulesPath = join(fixtureRoot, 'node_modules');
+
+  await mkdir(webDir, { recursive: true });
+  await writeFile(capacitorConfigPath, `import { CapacitorConfig } from '@capacitor/cli';\n\nconst config: CapacitorConfig = {\n  appId: 'dev.legato.external',\n  appName: 'legato-external-consumer',\n  webDir: 'dist'\n};\n\nexport default config;\n`, 'utf8');
+  await writeFile(indexHtmlPath, '<!doctype html><html><body><div id="app">external fixture</div></body></html>\n', 'utf8');
+  await mkdir(nodeModulesPath, { recursive: true });
+};
+
+const parsePackTarballName = (stdout) => {
+  const lines = stdout.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  return lines[lines.length - 1] ?? null;
+};
+
+const readJsonIfPresent = async (path) => {
+  try {
+    return JSON.parse(await readFile(path, 'utf8'));
+  } catch {
+    return null;
+  }
+};
+
+const stringify = (value) => `${JSON.stringify(value, null, 2)}\n`;
+
+const validateTarballSource = ({ installedPackage, expectedTarballPath }) => {
+  if (!installedPackage || typeof installedPackage.resolved !== 'string') {
+    return false;
+  }
+  return installedPackage.resolved.endsWith(basename(expectedTarballPath));
+};
+
+const parseArgs = (argv) => {
+  const options = {
+    repoRoot: defaultRepoRoot,
+    artifactsDir: defaultArtifactsDir,
+    keepFixture: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--repo-root' && argv[i + 1]) {
+      options.repoRoot = resolve(argv[i + 1]);
+      i += 1;
+      continue;
+    }
+    if (arg === '--artifacts-dir' && argv[i + 1]) {
+      options.artifactsDir = resolve(argv[i + 1]);
+      i += 1;
+      continue;
+    }
+    if (arg === '--keep-fixture') {
+      options.keepFixture = true;
+    }
+  }
+
+  return options;
+};
+
+export const runExternalConsumerValidation = async ({
+  repoRoot = defaultRepoRoot,
+  templateRoot = defaultTemplateRoot,
+  artifactsDir = defaultArtifactsDir,
+  fixtureRoot,
+  keepFixture = false,
+  commandRunner = runCommand,
+  skipPack = false,
+  tarballs: providedTarballs,
+} = {}) => {
+  const failures = [];
+  const areas = {
+    isolation: FAIL,
+    installability: FAIL,
+    typecheckAndSync: FAIL,
+    validatorReuse: FAIL,
+  };
+
+  await mkdir(artifactsDir, { recursive: true });
+
+  const resolvedFixtureRoot = fixtureRoot ?? await mkdtemp(join(tmpdir(), 'legato-external-consumer-'));
+  const tarballs = {
+    capacitor: providedTarballs?.capacitor,
+    contract: providedTarballs?.contract,
+  };
+
+  const runManifest = {
+    repoRoot,
+    fixtureRoot: resolvedFixtureRoot,
+    artifactsDir,
+    tarballs,
+    startedAt: new Date().toISOString(),
+  };
+
+  const capSyncLogPath = join(artifactsDir, 'cap-sync.log');
+  const typecheckLogPath = join(artifactsDir, 'typecheck.log');
+  const validatorSummaryPath = join(artifactsDir, 'validator-summary.txt');
+  const runManifestPath = join(artifactsDir, 'run-manifest.json');
+  const installMetadataPath = join(artifactsDir, 'install-metadata.json');
+  const dependencyScanPath = join(artifactsDir, 'dependency-scan.json');
+  const summaryPath = join(artifactsDir, 'summary.json');
+
+  try {
+    ensureFixtureOutsideRepo({ repoRoot, fixtureRoot: resolvedFixtureRoot });
+    await cp(templateRoot, resolvedFixtureRoot, { recursive: true, force: true });
+    await ensureFixtureScaffold(resolvedFixtureRoot);
+
+    if (!skipPack) {
+      const contractPack = await commandRunner({
+        command: 'npm',
+        args: ['pack', '--pack-destination', artifactsDir],
+        cwd: resolve(repoRoot, 'packages/contract'),
+      });
+      const capacitorPack = await commandRunner({
+        command: 'npm',
+        args: ['pack', '--pack-destination', artifactsDir],
+        cwd: resolve(repoRoot, 'packages/capacitor'),
+      });
+      const contractTarball = parsePackTarballName(contractPack.stdout);
+      const capacitorTarball = parsePackTarballName(capacitorPack.stdout);
+      tarballs.contract = resolve(artifactsDir, contractTarball ?? '');
+      tarballs.capacitor = resolve(artifactsDir, capacitorTarball ?? '');
+    }
+
+    if (!tarballs.contract || !tarballs.capacitor) {
+      throw new Error('Tarball generation/injection failed: missing capacitor or contract tarball path.');
+    }
+
+    await commandRunner({
+      command: 'npm',
+      args: ['install', '--no-audit', '--no-fund', tarballs.contract, tarballs.capacitor],
+      cwd: resolvedFixtureRoot,
+    });
+
+    const packageLockPath = join(resolvedFixtureRoot, 'package-lock.json');
+    const packageLockRaw = await readFile(packageLockPath, 'utf8');
+    const packageLock = JSON.parse(packageLockRaw);
+    const capacitorInstall = packageLock?.packages?.['node_modules/@legato/capacitor'] ?? null;
+    const contractInstall = packageLock?.packages?.['node_modules/@legato/contract'] ?? null;
+    const installManifest = {
+      capacitor: capacitorInstall,
+      contract: contractInstall,
+    };
+    await writeFile(installMetadataPath, stringify(installManifest), 'utf8');
+
+    const installabilityOk = validateTarballSource({ installedPackage: capacitorInstall, expectedTarballPath: tarballs.capacitor })
+      && validateTarballSource({ installedPackage: contractInstall, expectedTarballPath: tarballs.contract });
+    if (!installabilityOk) {
+      failures.push('Installability contract breach: @legato packages were not resolved from provided tarballs.');
+    } else {
+      areas.installability = PASS;
+    }
+
+    const leakScan = inspectIsolationLeaks({
+      packageLockRaw,
+      installManifestRaw: JSON.stringify(installManifest),
+    });
+
+    const installedCapacitorPath = join(resolvedFixtureRoot, 'node_modules/@legato/capacitor');
+    const installedContractPath = join(resolvedFixtureRoot, 'node_modules/@legato/contract');
+    const capacitorStat = await lstat(installedCapacitorPath);
+    const contractStat = await lstat(installedContractPath);
+    if (capacitorStat.isSymbolicLink() || contractStat.isSymbolicLink()) {
+      leakScan.failures.push('Isolation breach: monorepo symlink detected in node_modules/@legato/* install.');
+      leakScan.status = FAIL;
+    }
+
+    await writeFile(dependencyScanPath, stringify(leakScan), 'utf8');
+    if (leakScan.status === PASS) {
+      areas.isolation = PASS;
+    } else {
+      failures.push(...leakScan.failures);
+    }
+
+    const typecheckResult = await commandRunner({ command: 'npm', args: ['run', 'typecheck'], cwd: resolvedFixtureRoot });
+    await writeFile(typecheckLogPath, `${typecheckResult.stdout}${typecheckResult.stderr}`, 'utf8');
+
+    await ensureCapacitorPlatform({
+      fixtureRoot: resolvedFixtureRoot,
+      platform: 'ios',
+      commandRunner,
+    });
+    await ensureCapacitorPlatform({
+      fixtureRoot: resolvedFixtureRoot,
+      platform: 'android',
+      commandRunner,
+    });
+
+    const capSyncResult = await commandRunner({
+      command: 'npx',
+      args: ['cap', 'sync', 'ios', 'android'],
+      cwd: resolvedFixtureRoot,
+    });
+    await writeFile(capSyncLogPath, `${capSyncResult.stdout}${capSyncResult.stderr}`, 'utf8');
+    areas.typecheckAndSync = PASS;
+
+    const validatorCli = await commandRunner({
+      command: 'node',
+      args: [
+        resolve(scriptDir, 'validate-native-artifacts.mjs'),
+        '--plugin-gradle', join(resolvedFixtureRoot, 'node_modules/@legato/capacitor/android/build.gradle'),
+        '--android-settings', join(resolvedFixtureRoot, 'android/settings.gradle'),
+        '--capapp-spm-package', join(resolvedFixtureRoot, 'ios/App/CapApp-SPM/Package.swift'),
+        '--plugin-swift-package', join(resolvedFixtureRoot, 'node_modules/@legato/capacitor/Package.swift'),
+        '--plugin-swift-source', join(resolvedFixtureRoot, 'node_modules/@legato/capacitor/ios/Sources/LegatoPlugin/LegatoPlugin.swift'),
+        '--capacitor-config', join(resolvedFixtureRoot, 'ios/App/App/capacitor.config.json'),
+        '--fixture-root', resolvedFixtureRoot,
+        '--repo-root', repoRoot,
+      ],
+      cwd: repoRoot,
+    });
+    await writeFile(validatorSummaryPath, `${validatorCli.stdout}${validatorCli.stderr}`, 'utf8');
+    if (/Overall:\s*PASS/i.test(validatorCli.stdout)) {
+      areas.validatorReuse = PASS;
+    } else {
+      failures.push('Validator reuse failed: validate-native-artifacts did not report PASS against fixture hosts.');
+    }
+  } catch (error) {
+    const stdout = typeof error?.stdout === 'string' ? error.stdout : '';
+    const stderr = typeof error?.stderr === 'string' ? error.stderr : '';
+    const text = [stdout, stderr].filter(Boolean).join('\n').trim();
+    if (text.length > 0) {
+      failures.push(text);
+      await writeFile(capSyncLogPath, `${stdout}\n${stderr}`.trimEnd() + '\n', 'utf8');
+    }
+    if (error instanceof Error && error.message) {
+      failures.push(error.message);
+    }
+  } finally {
+    runManifest.tarballs = tarballs;
+    await writeFile(runManifestPath, stringify(runManifest), 'utf8');
+  }
+
+  const status = failures.length === 0 ? PASS : FAIL;
+  const summary = {
+    status,
+    exitCode: status === PASS ? 0 : 1,
+    areas,
+    failures,
+    artifacts: {
+      runManifestPath,
+      installMetadataPath,
+      dependencyScanPath,
+      typecheckLogPath,
+      capSyncLogPath,
+      validatorSummaryPath,
+    },
+    fixtureRoot: resolvedFixtureRoot,
+  };
+
+  await writeFile(summaryPath, stringify(summary), 'utf8');
+
+  if (!keepFixture) {
+    await rm(resolvedFixtureRoot, { recursive: true, force: true });
+  }
+
+  return summary;
+};
+
+const isEntrypoint = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+
+if (isEntrypoint) {
+  const options = parseArgs(process.argv.slice(2));
+  const result = await runExternalConsumerValidation(options);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  process.exit(result.exitCode);
+}

--- a/apps/capacitor-demo/scripts/run-external-consumer-validation.test.mjs
+++ b/apps/capacitor-demo/scripts/run-external-consumer-validation.test.mjs
@@ -1,0 +1,162 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+
+import {
+  ensureFixtureOutsideRepo,
+  inspectIsolationLeaks,
+  runExternalConsumerValidation,
+} from './run-external-consumer-validation.mjs';
+
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+test('fixture isolation guard fails when fixture root is inside repo root', () => {
+  assert.throws(
+    () => ensureFixtureOutsideRepo({
+      repoRoot: '/repo/legato',
+      fixtureRoot: '/repo/legato/tmp/external-fixture',
+    }),
+    /outside repo root/i,
+  );
+});
+
+test('isolation scanner reports workspace and non-tarball file leaks', () => {
+  const result = inspectIsolationLeaks({
+    packageLockRaw: JSON.stringify({
+      dependencies: {
+        '@legato/capacitor': { version: 'workspace:*' },
+        localDep: { version: 'file:../local-package' },
+      },
+    }),
+    installManifestRaw: '{"resolved":"file:../../outside-repo"}',
+  });
+
+  assert.equal(result.status, 'FAIL');
+  assert.match(result.failures.join('\n'), /workspace:/i);
+  assert.match(result.failures.join('\n'), /directory file:/i);
+});
+
+test('orchestrator preserves sync resolver output in evidence on failure', async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), 'legato-external-orchestrator-'));
+  const artifactsDir = join(tempDir, 'artifacts');
+  const fixtureRoot = join(tempDir, 'fixture');
+  const repoRoot = join(tempDir, 'repo-root');
+  await mkdir(repoRoot, { recursive: true });
+  await mkdir(fixtureRoot, { recursive: true });
+
+  const providedTarballs = {
+    capacitor: '/tmp/legato-capacitor-current.tgz',
+    contract: '/tmp/legato-contract-current.tgz',
+  };
+  const commandCalls = [];
+  const commandRunner = async ({ command, args }) => {
+    commandCalls.push([command, ...args].join(' '));
+    if (command === 'npm' && args[0] === 'install') {
+      await writeFile(join(fixtureRoot, 'package-lock.json'), JSON.stringify({
+        packages: {
+          'node_modules/@legato/capacitor': { resolved: `file:${basename(providedTarballs.capacitor)}` },
+          'node_modules/@legato/contract': { resolved: `file:${basename(providedTarballs.contract)}` },
+        },
+      }), 'utf8');
+      await mkdir(join(fixtureRoot, 'node_modules/@legato/capacitor'), { recursive: true });
+      await mkdir(join(fixtureRoot, 'node_modules/@legato/contract'), { recursive: true });
+    }
+    if (command === 'npx' && args[0] === 'cap' && args[1] === 'sync') {
+      const error = new Error('sync failed');
+      error.stdout = 'xcodebuild: error: Could not resolve package dependencies';
+      error.stderr = 'Missing package product CapApp-SPM';
+      throw error;
+    }
+    return { stdout: 'ok', stderr: '' };
+  };
+
+  try {
+    const result = await runExternalConsumerValidation({
+      repoRoot,
+      fixtureRoot,
+      artifactsDir,
+      keepFixture: true,
+      commandRunner,
+      skipPack: true,
+      tarballs: providedTarballs,
+    });
+
+    assert.equal(result.status, 'FAIL');
+    assert.equal(result.areas.typecheckAndSync, 'FAIL');
+    assert.match(result.failures.join('\n'), /Could not resolve package dependencies/i);
+    const npmInstallCommands = commandCalls.filter((call) => call.startsWith('npm install'));
+    assert.equal(npmInstallCommands.length, 1);
+    assert.match(npmInstallCommands[0], new RegExp(escapeRegExp(basename(providedTarballs.contract)), 'i'));
+    assert.match(npmInstallCommands[0], new RegExp(escapeRegExp(basename(providedTarballs.capacitor)), 'i'));
+    assert.match(commandCalls.join('\n'), /npx cap sync ios android/i);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('orchestrator provisions ios/android platforms before cap sync in disposable fixture', async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), 'legato-external-orchestrator-platforms-'));
+  const artifactsDir = join(tempDir, 'artifacts');
+  const fixtureRoot = join(tempDir, 'fixture');
+  const repoRoot = join(tempDir, 'repo-root');
+  await mkdir(repoRoot, { recursive: true });
+  await mkdir(fixtureRoot, { recursive: true });
+
+  const providedTarballs = {
+    capacitor: '/tmp/legato-capacitor-current.tgz',
+    contract: '/tmp/legato-contract-current.tgz',
+  };
+  const commandCalls = [];
+  const commandRunner = async ({ command, args }) => {
+    commandCalls.push([command, ...args].join(' '));
+    if (command === 'npm' && args[0] === 'install') {
+      await writeFile(join(fixtureRoot, 'package-lock.json'), JSON.stringify({
+        packages: {
+          'node_modules/@legato/capacitor': { resolved: `file:${basename(providedTarballs.capacitor)}` },
+          'node_modules/@legato/contract': { resolved: `file:${basename(providedTarballs.contract)}` },
+        },
+      }), 'utf8');
+      await mkdir(join(fixtureRoot, 'node_modules/@legato/capacitor'), { recursive: true });
+      await mkdir(join(fixtureRoot, 'node_modules/@legato/contract'), { recursive: true });
+      return { stdout: 'install ok', stderr: '' };
+    }
+    if (command === 'npx' && args[0] === 'cap' && args[1] === 'add' && (args[2] === 'ios' || args[2] === 'android')) {
+      await mkdir(join(fixtureRoot, args[2]), { recursive: true });
+      return { stdout: `added ${args[2]}`, stderr: '' };
+    }
+    if (command === 'npx' && args[0] === 'cap' && args[1] === 'sync') {
+      const error = new Error('sync failed');
+      error.stdout = 'xcodebuild: error: Could not resolve package dependencies';
+      error.stderr = 'Missing package product CapApp-SPM';
+      throw error;
+    }
+    return { stdout: 'ok', stderr: '' };
+  };
+
+  try {
+    await runExternalConsumerValidation({
+      repoRoot,
+      fixtureRoot,
+      artifactsDir,
+      keepFixture: true,
+      commandRunner,
+      skipPack: true,
+      tarballs: providedTarballs,
+    });
+
+    const joinedCalls = commandCalls.join('\n');
+    assert.match(joinedCalls, /npx cap add ios/i);
+    assert.match(joinedCalls, /npx cap add android/i);
+    const syncIndex = commandCalls.findIndex((call) => /npx cap sync ios android/i.test(call));
+    const addIosIndex = commandCalls.findIndex((call) => /npx cap add ios/i.test(call));
+    const addAndroidIndex = commandCalls.findIndex((call) => /npx cap add android/i.test(call));
+    assert.equal(addIosIndex > -1, true);
+    assert.equal(addAndroidIndex > -1, true);
+    assert.equal(syncIndex > addIosIndex, true);
+    assert.equal(syncIndex > addAndroidIndex, true);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/apps/capacitor-demo/scripts/validate-native-artifacts.test.mjs
+++ b/apps/capacitor-demo/scripts/validate-native-artifacts.test.mjs
@@ -198,7 +198,7 @@ test('validator fails when Gradle output reports unresolved Android artifact coo
   assert.equal(result.status, 'FAIL');
   assert.equal(result.exitCode, 1);
   assert.equal(result.failures.length > 0, true);
-  assert.match(result.failures[0], /Could not find dev\.dgutierrez:legato-android-core:0\.1\.0/i);
+  assert.match(result.failures[0], /Could not find dev\.dgutierrez:legato-android-core:0\.1\.1/i);
 });
 
 test('formatter prints stable summary structure', () => {
@@ -217,7 +217,7 @@ test('formatter prints stable summary structure', () => {
   assert.match(summary, /Overall: FAIL/i);
   assert.match(summary, /android-artifacts: FAIL/i);
   assert.match(summary, /ios-artifacts: FAIL/i);
-  assert.match(summary, /Could not find dev\.dgutierrez:legato-android-core:0\.1\.0/i);
+  assert.match(summary, /Could not find dev\.dgutierrez:legato-android-core:0\.1\.1/i);
 });
 
 test('CLI exits non-zero with actionable output when local-project regression is detected', async () => {

--- a/docs/releases/external-consumer-validation-v1.md
+++ b/docs/releases/external-consumer-validation-v1.md
@@ -1,0 +1,39 @@
+# External Consumer Validation V1 — Release Checklist
+
+This runbook validates packaging/wiring behavior for a disposable external consumer. It is **NOT publication proof**.
+
+## Scope Boundaries (v1)
+
+- Validate installability from local `npm pack` tarballs.
+- Run in a fixture app outside the monorepo root.
+- Reuse existing native validators against fixture-generated hosts.
+- Do **not** treat this as npm publication, provenance, or registry proof.
+
+## Local Command Sequence
+
+Run from `apps/capacitor-demo`:
+
+1. `npm run build`
+2. `npm run validate:external:consumer`
+3. `npm run capture:release:native-artifacts`
+4. `npm run validate:release:native-artifacts`
+
+## Expected Artifacts
+
+- `apps/capacitor-demo/artifacts/external-consumer-validation-v1/summary.json`
+- `apps/capacitor-demo/artifacts/external-consumer-validation-v1/run-manifest.json`
+- `apps/capacitor-demo/artifacts/external-consumer-validation-v1/install-metadata.json`
+- `apps/capacitor-demo/artifacts/external-consumer-validation-v1/cap-sync.log`
+- `apps/capacitor-demo/artifacts/external-consumer-validation-v1/validator-summary.txt`
+- `apps/capacitor-demo/artifacts/release-native-artifact-foundation-v1/manifest.json`
+
+## Evidence Interpretation
+
+`summary.json` must report PASS for:
+
+- `isolation`
+- `installability`
+- `typecheckAndSync`
+- `validatorReuse`
+
+Any FAIL blocks release readiness.


### PR DESCRIPTION
Closes #48

## Summary
- add a disposable external consumer fixture outside the monorepo to validate installability without workspace/path leakage
- install `@legato/contract` and `@legato/capacitor` from packed tarballs into the fixture and run `typecheck` + `npx cap sync ios android`
- reuse the native validators against the fixture via explicit path injection and capture machine-readable evidence for release gates

## Changes
| File | Change |
|------|--------|
| `apps/capacitor-demo/scripts/external-consumer-template/*` | committed template for a disposable external Capacitor fixture |
| `apps/capacitor-demo/scripts/run-external-consumer-validation.mjs` | orchestrates tarball packing, isolated fixture materialization, installability checks, `typecheck`, `cap sync`, validator reuse, and evidence capture |
| `apps/capacitor-demo/scripts/run-external-consumer-validation.test.mjs` | tests tarball-first install flow and fixture provisioning behavior |
| `apps/capacitor-demo/scripts/external-consumer-template.test.mjs` | ensures template stays free of monorepo/workspace coupling |
| `apps/capacitor-demo/scripts/validate-native-artifacts.test.mjs` | aligns artifact validation with current published coordinates (`0.1.1`) |
| `apps/capacitor-demo/scripts/capture-native-release-evidence.mjs` | now captures external-consumer evidence coherently |
| `docs/releases/external-consumer-validation-v1.md` | runbook and expectations for disposable external-consumer validation |
| `apps/capacitor-demo/scripts/external-consumer-validation-v1-docs.test.mjs` | docs/contract coverage for the new validation lane |

## Test Plan
- [x] `node --test apps/capacitor-demo/scripts/run-external-consumer-validation.test.mjs apps/capacitor-demo/scripts/external-consumer-template.test.mjs apps/capacitor-demo/scripts/external-consumer-validation-v1-docs.test.mjs`
- [x] `node --test apps/capacitor-demo/scripts/validate-native-artifacts.test.mjs apps/capacitor-demo/scripts/capture-native-release-evidence.test.mjs`
- [x] `bash ./apps/capacitor-demo/android/gradlew test`
- [x] verify rerun confirmed external consumer validation passes end-to-end (`isolation`, `installability`, `typecheckAndSync`, `validatorReuse`)

## Notes
- This validates external consumption through packed artifacts/tarballs and a disposable fixture; it is not yet a proof of full public npm/Maven/Swift package publication workflows on every host combination.
- The fixture is intentionally disposable and remains outside the monorepo during execution even though its template is committed here for reviewability.
