### PR TITLE
ci(release): automate Android publish flow

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -1,0 +1,313 @@
+name: Release Android (v1)
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Release target (v1 supports android only)'
+        required: true
+        type: choice
+        options:
+          - android
+      mode:
+        description: 'Execution mode'
+        required: true
+        type: choice
+        options:
+          - preflight-only
+          - publish
+      release_id:
+        description: 'Unique release identifier for evidence/audit tracking'
+        required: true
+        type: string
+
+concurrency:
+  group: release-android-${{ inputs.release_id }}
+  cancel-in-progress: false
+
+jobs:
+  validate-dispatch:
+    name: Validate dispatch contract
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate target/mode and persist dispatch payload
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/release-ci
+
+          if [[ "${{ inputs.target }}" != "android" ]]; then
+            echo "v1 is Android-only; unsupported target: ${{ inputs.target }}" >&2
+            exit 1
+          fi
+
+          if [[ "${{ inputs.mode }}" != "preflight-only" && "${{ inputs.mode }}" != "publish" ]]; then
+            echo "Unsupported mode: ${{ inputs.mode }}" >&2
+            exit 1
+          fi
+
+          cat > artifacts/release-ci/dispatch.json <<'JSON'
+          {
+            "target": "${{ inputs.target }}",
+            "mode": "${{ inputs.mode }}",
+            "release_id": "${{ inputs.release_id }}",
+            "run_id": "${{ github.run_id }}",
+            "run_attempt": "${{ github.run_attempt }}",
+            "actor": "${{ github.actor }}"
+          }
+          JSON
+
+      - name: Upload dispatch payload
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dispatch
+          path: artifacts/release-ci/dispatch.json
+
+  android-preflight:
+    name: Android preflight
+    runs-on: ubuntu-latest
+    needs: validate-dispatch
+    defaults:
+      run:
+        working-directory: apps/capacitor-demo
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: apps/capacitor-demo/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run scope check
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p ./artifacts
+          npm run release:scope:check 2>&1 | tee ./artifacts/release-ci-scope.log
+
+      - name: Run Android preflight
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p ./artifacts/release-ci
+          npm run release:android:preflight 2>&1 | tee ./artifacts/release-ci/preflight.log
+
+      - name: Upload preflight log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-preflight
+          path: |
+            apps/capacitor-demo/artifacts/release-ci/preflight.log
+            apps/capacitor-demo/artifacts/release-ci-scope.log
+
+  android-publish:
+    name: Android publish (protected)
+    runs-on: ubuntu-latest
+    needs: android-preflight
+    if: ${{ inputs.mode == 'publish' }}
+    environment: release
+    defaults:
+      run:
+        working-directory: apps/capacitor-demo
+    env:
+      ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.ORG_GRADLE_PROJECT_mavenCentralUsername || secrets.MAVEN_CENTRAL_USERNAME }}
+      ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.ORG_GRADLE_PROJECT_mavenCentralPassword || secrets.MAVEN_CENTRAL_PASSWORD }}
+      ORG_GRADLE_PROJECT_signingGnupgKeyName: ${{ secrets.ORG_GRADLE_PROJECT_signingGnupgKeyName || secrets.SIGNING_GNUPG_KEY_NAME || secrets.SIGNING_GNUPG_KEYNAME }}
+      ORG_GRADLE_PROJECT_signingGnupgPassphrase: ${{ secrets.ORG_GRADLE_PROJECT_signingGnupgPassphrase || secrets.SIGNING_GNUPG_PASSPHRASE }}
+      ORG_GRADLE_PROJECT_signingGnupgExecutable: ${{ secrets.ORG_GRADLE_PROJECT_signingGnupgExecutable || secrets.SIGNING_GNUPG_EXECUTABLE }}
+      ORG_GRADLE_PROJECT_signingGnupgHomeDir: ${{ secrets.ORG_GRADLE_PROJECT_signingGnupgHomeDir || secrets.SIGNING_GNUPG_HOME_DIR }}
+      ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKey || secrets.SIGNING_KEY }}
+      ORG_GRADLE_PROJECT_signingInMemoryKeyFile: ${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKeyFile || secrets.SIGNING_KEY_FILE }}
+      ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKeyPassword || secrets.SIGNING_PASSWORD }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: apps/capacitor-demo/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish Android artifact
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p ./artifacts/release-ci
+          npm run release:android:publish 2>&1 | tee ./artifacts/release-ci/publish.log
+
+      - name: Upload publish log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-publish
+          path: apps/capacitor-demo/artifacts/release-ci/publish.log
+
+  android-verify:
+    name: Android verify
+    runs-on: ubuntu-latest
+    needs:
+      - android-preflight
+      - android-publish
+    if: ${{ always() && needs.android-preflight.result == 'success' && (inputs.mode == 'preflight-only' || needs.android-publish.result == 'success') }}
+    defaults:
+      run:
+        working-directory: apps/capacitor-demo
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: apps/capacitor-demo/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify Android release (with bounded retries)
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p ./artifacts/release-ci
+          npm run release:android:verify:ci -- --attempts 6 --backoff-ms 120000 --summary-file ./artifacts/release-ci/verify-summary.json 2>&1 | tee ./artifacts/release-ci/verify.log
+
+      - name: Upload verify log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-verify
+          path: |
+            apps/capacitor-demo/artifacts/release-ci/verify.log
+            apps/capacitor-demo/artifacts/release-ci/verify-summary.json
+
+  evidence:
+    name: Evidence and summary
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - validate-dispatch
+      - android-preflight
+      - android-publish
+      - android-verify
+    steps:
+      - name: Download dispatch artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dispatch
+          path: artifacts/release-ci
+
+      - name: Download preflight artifact
+        if: ${{ needs.android-preflight.result != 'skipped' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: release-preflight
+          path: artifacts/release-ci
+
+      - name: Download publish artifact
+        if: ${{ needs.android-publish.result != 'skipped' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: release-publish
+          path: artifacts/release-ci
+
+      - name: Download verify artifact
+        if: ${{ needs.android-verify.result != 'skipped' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: release-verify
+          path: artifacts/release-ci
+
+      - name: Ensure expected evidence files exist
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/release-ci
+
+          [[ -f artifacts/release-ci/preflight.log ]] || printf 'preflight stage did not produce a log.\n' > artifacts/release-ci/preflight.log
+          [[ -f artifacts/release-ci/publish.log ]] || printf 'publish stage was skipped (mode=%s).\n' "${{ inputs.mode }}" > artifacts/release-ci/publish.log
+          [[ -f artifacts/release-ci/verify.log ]] || printf 'verify stage was skipped due to upstream failure/skip.\n' > artifacts/release-ci/verify.log
+
+      - name: Build release summary payloads
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > artifacts/release-ci/summary.json <<'JSON'
+          {
+            "release_id": "${{ inputs.release_id }}",
+            "target": "${{ inputs.target }}",
+            "mode": "${{ inputs.mode }}",
+            "run_id": "${{ github.run_id }}",
+            "run_attempt": "${{ github.run_attempt }}",
+            "actor": "${{ github.actor }}",
+            "environment": {
+              "name": "release",
+              "required_for_mode": "publish",
+              "publish_job_result": "${{ needs.android-publish.result }}"
+            },
+            "stages": {
+              "validate_dispatch": "${{ needs.validate-dispatch.result }}",
+              "android_preflight": "${{ needs.android-preflight.result }}",
+              "android_publish": "${{ needs.android-publish.result }}",
+              "android_verify": "${{ needs.android-verify.result }}"
+            },
+            "artifacts": [
+              "dispatch.json",
+              "preflight.log",
+              "publish.log",
+              "verify.log",
+              "summary.json",
+              "summary.md"
+            ]
+          }
+          JSON
+
+          cat > artifacts/release-ci/summary.md <<'MARKDOWN'
+          # Android Release v1 Summary
+
+          - Release ID: `${{ inputs.release_id }}`
+          - Target: `${{ inputs.target }}`
+          - Mode: `${{ inputs.mode }}`
+          - Run: `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`
+          - Actor: `${{ github.actor }}`
+          - Protected Environment: `release` (required for `publish`)
+          - Android preflight: `${{ needs.android-preflight.result }}`
+          - Android publish: `${{ needs.android-publish.result }}`
+          - Android verify: `${{ needs.android-verify.result }}`
+          - iOS status: `manual/preflight-only in v1 (not auto-published by CI)`
+          MARKDOWN
+
+          {
+            echo '## Android Release v1'
+            echo "- Release ID: \`${{ inputs.release_id }}\`"
+            echo "- Mode: \`${{ inputs.mode }}\`"
+            echo "- Preflight: \`${{ needs.android-preflight.result }}\`"
+            echo "- Publish: \`${{ needs.android-publish.result }}\`"
+            echo "- Verify: \`${{ needs.android-verify.result }}\`"
+            echo "- Evidence artifact: \`release-evidence-${{ inputs.release_id }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload evidence bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-evidence-${{ inputs.release_id }}
+          path: |
+            artifacts/release-ci/dispatch.json
+            artifacts/release-ci/preflight.log
+            artifacts/release-ci/publish.log
+            artifacts/release-ci/verify.log
+            artifacts/release-ci/summary.json
+            artifacts/release-ci/summary.md

--- a/apps/capacitor-demo/package.json
+++ b/apps/capacitor-demo/package.json
@@ -23,6 +23,7 @@
     "release:android:preflight": "node ../../native/android/core/scripts/release-android.mjs preflight --contract ../../packages/capacitor/native-artifacts.json --build-gradle ../../native/android/core/build.gradle --project-dir ../../native/android/core",
     "release:android:publish": "node ../../native/android/core/scripts/release-android.mjs publish --contract ../../packages/capacitor/native-artifacts.json --build-gradle ../../native/android/core/build.gradle --project-dir ../../native/android/core",
     "release:android:verify": "node ../../native/android/core/scripts/release-android.mjs verify --contract ../../packages/capacitor/native-artifacts.json",
+    "release:android:verify:ci": "node ./scripts/retry-android-release-verify.mjs",
     "release:scope:check": "node ./scripts/check-publication-scope.mjs --repo-root ../..",
     "release:ios:preflight": "node ../../packages/capacitor/scripts/release-ios-preflight.mjs --contract ../../packages/capacitor/native-artifacts.json --native-package ../../native/ios/LegatoCore/Package.swift --plugin-package ../../packages/capacitor/Package.swift --release-tag ${IOS_RELEASE_TAG:-v0.1.1}",
     "cap:add:android": "npx cap add android",

--- a/apps/capacitor-demo/scripts/publication-pipeline-v1-docs.test.mjs
+++ b/apps/capacitor-demo/scripts/publication-pipeline-v1-docs.test.mjs
@@ -7,29 +7,30 @@ import { fileURLToPath } from 'node:url';
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const docsPath = resolve(currentDir, '../../../docs/releases/publication-pipeline-v1.md');
 
-test('publication pipeline runbook separates automated preflight from manual iOS release responsibilities', async () => {
+test('publication pipeline runbook enforces Android-only CI with explicit iOS manual boundary', async () => {
   const runbook = await readFile(docsPath, 'utf8');
 
-  assert.match(runbook, /iOS Preflight \(automatable\)/i);
-  assert.match(runbook, /Manual Handoff \(non-automated in v1\)/i);
+  assert.match(runbook, /CI-driven through GitHub Actions in v1/i);
+  assert.match(runbook, /target`\s*\|\s*`android`/i);
+  assert.match(runbook, /manual-handoff only in v1/i);
   assert.match(runbook, /release:ios:preflight/i);
-  assert.match(runbook, /legato-ios-core/i);
   assert.match(runbook, /do not implement automated iOS publication in this v1 milestone/i);
 });
 
-test('publication pipeline runbook includes required evidence checklist before manual handoff', async () => {
+test('publication pipeline runbook documents protected publish gate and retained evidence files', async () => {
   const runbook = await readFile(docsPath, 'utf8');
 
-  assert.match(runbook, /Runbook Checklist Artifact/i);
-  assert.match(runbook, /Release tag submitted to preflight/i);
-  assert.match(runbook, /Preflight summary output/i);
-  assert.match(runbook, /Link\/path to the output attached in PR/i);
-  assert.match(runbook, /Manual handoff confirmation/i);
+  assert.match(runbook, /environment `release` approval/i);
+  assert.match(runbook, /release-evidence-<release_id>/i);
+  assert.match(runbook, /dispatch\.json/i);
+  assert.match(runbook, /preflight\.log/i);
+  assert.match(runbook, /summary\.json/i);
+  assert.match(runbook, /summary\.md/i);
 });
 
 test('publication pipeline runbook links local validation evidence closeout artifact', async () => {
   const runbook = await readFile(docsPath, 'utf8');
 
   assert.match(runbook, /publication-pipeline-v1-validation\.md/i);
-  assert.match(runbook, /release:scope:check/i);
+  assert.match(runbook, /workflow_dispatch/i);
 });

--- a/apps/capacitor-demo/scripts/publication-pipeline-v1-validation-docs.test.mjs
+++ b/apps/capacitor-demo/scripts/publication-pipeline-v1-validation-docs.test.mjs
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const validationDocsPath = resolve(currentDir, '../../../docs/releases/publication-pipeline-v1-validation.md');
+
+test('validation checklist includes required audit fields for release dispatch and approvals', async () => {
+  const docs = await readFile(validationDocsPath, 'utf8');
+
+  assert.match(docs, /release_id/i);
+  assert.match(docs, /mode/i);
+  assert.match(docs, /Approver \(publish mode\)/i);
+  assert.match(docs, /Stage outcomes/i);
+  assert.match(docs, /android-preflight/i);
+  assert.match(docs, /android-publish/i);
+  assert.match(docs, /android-verify/i);
+});
+
+test('validation checklist enforces evidence bundle filenames and Android-only scope', async () => {
+  const docs = await readFile(validationDocsPath, 'utf8');
+
+  assert.match(docs, /Android-only in v1/i);
+  assert.match(docs, /release-evidence-<release_id>/i);
+  assert.match(docs, /dispatch\.json/i);
+  assert.match(docs, /preflight\.log/i);
+  assert.match(docs, /publish\.log/i);
+  assert.match(docs, /verify\.log/i);
+  assert.match(docs, /summary\.json/i);
+  assert.match(docs, /summary\.md/i);
+});

--- a/apps/capacitor-demo/scripts/release-android-scripts.test.mjs
+++ b/apps/capacitor-demo/scripts/release-android-scripts.test.mjs
@@ -14,12 +14,14 @@ test('package scripts expose android preflight/publish/verify release gates', as
   assert.equal(typeof packageJson.scripts?.['release:android:preflight'], 'string');
   assert.equal(typeof packageJson.scripts?.['release:android:publish'], 'string');
   assert.equal(typeof packageJson.scripts?.['release:android:verify'], 'string');
+  assert.equal(typeof packageJson.scripts?.['release:android:verify:ci'], 'string');
   assert.equal(typeof packageJson.scripts?.['release:scope:check'], 'string');
   assert.equal(typeof packageJson.scripts?.['validate:external:consumer'], 'string');
 
   assert.match(packageJson.scripts['release:android:preflight'], /release-android\.mjs\s+preflight/i);
   assert.match(packageJson.scripts['release:android:publish'], /release-android\.mjs\s+publish/i);
   assert.match(packageJson.scripts['release:android:verify'], /release-android\.mjs\s+verify/i);
+  assert.match(packageJson.scripts['release:android:verify:ci'], /retry-android-release-verify\.mjs/i);
   assert.match(packageJson.scripts['release:android:preflight'], /native-artifacts\.json/i);
   assert.match(packageJson.scripts['release:scope:check'], /check-publication-scope\.mjs/i);
   assert.match(packageJson.scripts['validate:external:consumer'], /run-external-consumer-validation\.mjs/i);

--- a/apps/capacitor-demo/scripts/release-ci-workflow.test.mjs
+++ b/apps/capacitor-demo/scripts/release-ci-workflow.test.mjs
@@ -1,0 +1,162 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const workflowPath = resolve(currentDir, '../../../.github/workflows/release-android.yml');
+
+function getJobSection(workflow, jobName) {
+  const jobPattern = new RegExp(`\\n  ${jobName}:\\n([\\s\\S]*?)(?=\\n  [a-z0-9-]+:\\n|$)`, 'i');
+  const match = workflow.match(jobPattern);
+  assert.ok(match, `expected to find job section for ${jobName}`);
+  return match[1];
+}
+
+function getJobIfExpression(workflow, jobName) {
+  const section = getJobSection(workflow, jobName);
+  const match = section.match(/\n {4}if:\s*\$\{\{\s*([^}]+?)\s*\}\}/i);
+  assert.ok(match, `expected if condition for ${jobName}`);
+  return match[1].trim();
+}
+
+function evaluateGithubIfExpression(expression, { mode, preflightResult, publishResult }) {
+  const jsExpr = expression
+    .replace(/always\(\)/gi, 'true')
+    .replace(/inputs\.mode/g, JSON.stringify(mode))
+    .replace(/needs\.android-preflight\.result/g, JSON.stringify(preflightResult))
+    .replace(/needs\.android-publish\.result/g, JSON.stringify(publishResult));
+
+  return Function(`return (${jsExpr});`)();
+}
+
+function simulateReleaseWorkflow({ mode, preflightResult, publishResult, verifyResult }, conditions) {
+  const executionOrder = [];
+
+  executionOrder.push('validate-dispatch');
+
+  executionOrder.push('android-preflight');
+
+  const shouldRunPublish = evaluateGithubIfExpression(conditions.publishIf, {
+    mode,
+    preflightResult,
+    publishResult,
+  });
+
+  const resolvedPublishResult = shouldRunPublish && preflightResult === 'success' ? publishResult : 'skipped';
+  if (resolvedPublishResult !== 'skipped') {
+    executionOrder.push('android-publish');
+  }
+
+  const shouldRunVerify = evaluateGithubIfExpression(conditions.verifyIf, {
+    mode,
+    preflightResult,
+    publishResult: resolvedPublishResult,
+  });
+
+  const resolvedVerifyResult = shouldRunVerify ? verifyResult : 'skipped';
+  if (resolvedVerifyResult !== 'skipped') {
+    executionOrder.push('android-verify');
+  }
+
+  executionOrder.push('evidence');
+
+  const stageSummary = {
+    validate_dispatch: 'success',
+    android_preflight: preflightResult,
+    android_publish: resolvedPublishResult,
+    android_verify: resolvedVerifyResult,
+  };
+
+  return { executionOrder, stageSummary };
+}
+
+test('release workflow exposes dispatch contract with Android-only target, mode, and release_id', async () => {
+  const workflow = await readFile(workflowPath, 'utf8');
+
+  assert.match(workflow, /workflow_dispatch:/i);
+  assert.match(workflow, /target:\s*[\s\S]*options:\s*[\s\S]*-\s*android/i);
+  assert.match(workflow, /mode:\s*[\s\S]*options:\s*[\s\S]*-\s*preflight-only[\s\S]*-\s*publish/i);
+  assert.match(workflow, /release_id:/i);
+  assert.match(workflow, /v1 is Android-only/i);
+});
+
+test('release workflow runs preflight before publish and protects publish with release environment', async () => {
+  const workflow = await readFile(workflowPath, 'utf8');
+
+  assert.match(workflow, /android-preflight:/i);
+  assert.match(workflow, /android-publish:[\s\S]*needs:\s*android-preflight/i);
+  assert.match(workflow, /android-publish:[\s\S]*if:\s*\$\{\{\s*inputs\.mode\s*==\s*'publish'\s*\}\}/i);
+  assert.match(workflow, /android-publish:[\s\S]*environment:\s*release/i);
+});
+
+test('release workflow always uploads required evidence bundle files', async () => {
+  const workflow = await readFile(workflowPath, 'utf8');
+
+  assert.match(workflow, /evidence:/i);
+  assert.match(workflow, /if:\s*always\(\)/i);
+  assert.match(workflow, /dispatch\.json/i);
+  assert.match(workflow, /preflight\.log/i);
+  assert.match(workflow, /publish\.log/i);
+  assert.match(workflow, /verify\.log/i);
+  assert.match(workflow, /summary\.json/i);
+  assert.match(workflow, /summary\.md/i);
+});
+
+test('release workflow fail-fast path skips publish and verify when preflight fails', async () => {
+  const workflow = await readFile(workflowPath, 'utf8');
+
+  const conditions = {
+    publishIf: getJobIfExpression(workflow, 'android-publish'),
+    verifyIf: getJobIfExpression(workflow, 'android-verify'),
+  };
+
+  const simulation = simulateReleaseWorkflow(
+    {
+      mode: 'publish',
+      preflightResult: 'failure',
+      publishResult: 'success',
+      verifyResult: 'success',
+    },
+    conditions,
+  );
+
+  assert.equal(simulation.stageSummary.android_preflight, 'failure');
+  assert.equal(simulation.stageSummary.android_publish, 'skipped');
+  assert.equal(simulation.stageSummary.android_verify, 'skipped');
+  assert.deepEqual(simulation.executionOrder, ['validate-dispatch', 'android-preflight', 'evidence']);
+});
+
+test('release workflow publish path runs publish then verify and reports final success states', async () => {
+  const workflow = await readFile(workflowPath, 'utf8');
+
+  const conditions = {
+    publishIf: getJobIfExpression(workflow, 'android-publish'),
+    verifyIf: getJobIfExpression(workflow, 'android-verify'),
+  };
+
+  const simulation = simulateReleaseWorkflow(
+    {
+      mode: 'publish',
+      preflightResult: 'success',
+      publishResult: 'success',
+      verifyResult: 'success',
+    },
+    conditions,
+  );
+
+  assert.deepEqual(simulation.executionOrder, [
+    'validate-dispatch',
+    'android-preflight',
+    'android-publish',
+    'android-verify',
+    'evidence',
+  ]);
+  assert.deepEqual(simulation.stageSummary, {
+    validate_dispatch: 'success',
+    android_preflight: 'success',
+    android_publish: 'success',
+    android_verify: 'success',
+  });
+});

--- a/apps/capacitor-demo/scripts/retry-android-release-verify.mjs
+++ b/apps/capacitor-demo/scripts/retry-android-release-verify.mjs
@@ -1,0 +1,168 @@
+import { writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { spawn } from 'node:child_process';
+
+const PASS = 'PASS';
+const FAIL = 'FAIL';
+const CONFIG_ERROR_EXIT_CODE = 2;
+
+const toPositiveInteger = (value, fieldName) => {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`Invalid ${fieldName}: expected positive integer, received ${value}`);
+  }
+  return parsed;
+};
+
+export const parseRetryConfig = (argv) => {
+  const config = {
+    attempts: 6,
+    backoffMs: 120000,
+    command: 'npm run release:android:verify',
+    summaryFile: undefined,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--attempts' && argv[i + 1]) {
+      config.attempts = toPositiveInteger(argv[i + 1], 'attempts');
+      i += 1;
+      continue;
+    }
+    if (arg === '--backoff-ms' && argv[i + 1]) {
+      config.backoffMs = toPositiveInteger(argv[i + 1], 'backoff-ms');
+      i += 1;
+      continue;
+    }
+    if (arg === '--command' && argv[i + 1]) {
+      config.command = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    if (arg === '--summary-file' && argv[i + 1]) {
+      config.summaryFile = argv[i + 1];
+      i += 1;
+    }
+  }
+
+  return config;
+};
+
+const defaultRunCommand = async (command) => new Promise((resolvePromise) => {
+  const child = spawn(command, {
+    shell: true,
+    stdio: 'inherit',
+    env: process.env,
+  });
+
+  child.on('close', (code) => {
+    resolvePromise({ exitCode: Number.isInteger(code) ? code : 1 });
+  });
+
+  child.on('error', () => {
+    resolvePromise({ exitCode: 1 });
+  });
+});
+
+const wait = (ms) => new Promise((resolvePromise) => {
+  setTimeout(resolvePromise, ms);
+});
+
+export const retryAndroidReleaseVerify = async ({
+  attempts,
+  backoffMs,
+  command,
+  runCommand = defaultRunCommand,
+  sleep = wait,
+} = {}) => {
+  const retries = [];
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const result = await runCommand(command, attempt);
+    const exitCode = Number.isInteger(result?.exitCode) ? result.exitCode : 1;
+    retries.push({
+      attempt,
+      exitCode,
+      status: exitCode === 0 ? PASS : FAIL,
+    });
+
+    if (exitCode === 0) {
+      return {
+        status: PASS,
+        exitCode: 0,
+        attemptsConfigured: attempts,
+        attemptsUsed: attempt,
+        backoffMs,
+        command,
+        retries,
+      };
+    }
+
+    if (attempt < attempts) {
+      await sleep(backoffMs);
+    }
+  }
+
+  return {
+    status: FAIL,
+    exitCode: 1,
+    attemptsConfigured: attempts,
+    attemptsUsed: attempts,
+    backoffMs,
+    command,
+    retries,
+    failures: [`Android verify did not pass after ${attempts} attempt(s).`],
+  };
+};
+
+export const formatVerifyRetrySummary = (result) => {
+  const lines = [
+    `Mode: verify-retry`,
+    `Overall: ${result.status}`,
+    `Attempts configured: ${result.attemptsConfigured}`,
+    `Attempts used: ${result.attemptsUsed}`,
+    `Backoff (ms): ${result.backoffMs}`,
+  ];
+
+  if (Array.isArray(result.retries) && result.retries.length > 0) {
+    lines.push('Attempt results:');
+    for (const retry of result.retries) {
+      lines.push(`- #${retry.attempt}: ${retry.status} (exit ${retry.exitCode})`);
+    }
+  }
+
+  if (Array.isArray(result.failures) && result.failures.length > 0) {
+    lines.push('Failures:');
+    for (const failure of result.failures) {
+      lines.push(`- ${failure}`);
+    }
+  }
+
+  return lines.join('\n');
+};
+
+const writeSummaryJson = async (summaryFile, result) => {
+  if (!summaryFile) {
+    return;
+  }
+
+  const outputPath = resolve(summaryFile);
+  await writeFile(outputPath, `${JSON.stringify(result, null, 2)}\n`, 'utf8');
+};
+
+const isEntrypoint = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+
+if (isEntrypoint) {
+  let config;
+  try {
+    config = parseRetryConfig(process.argv.slice(2));
+  } catch (error) {
+    process.stdout.write(`Mode: verify-retry\nOverall: FAIL\nFailures:\n- ${error.message}\n`);
+    process.exit(CONFIG_ERROR_EXIT_CODE);
+  }
+
+  const result = await retryAndroidReleaseVerify(config);
+  await writeSummaryJson(config.summaryFile, result);
+  process.stdout.write(`${formatVerifyRetrySummary(result)}\n`);
+  process.exit(result.exitCode);
+}

--- a/apps/capacitor-demo/scripts/retry-android-release-verify.test.mjs
+++ b/apps/capacitor-demo/scripts/retry-android-release-verify.test.mjs
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseRetryConfig,
+  retryAndroidReleaseVerify,
+} from './retry-android-release-verify.mjs';
+
+test('verify retry returns PASS when a later attempt succeeds', async () => {
+  let attempts = 0;
+  const sleepCalls = [];
+
+  const result = await retryAndroidReleaseVerify({
+    attempts: 3,
+    backoffMs: 15,
+    command: 'npm run release:android:verify',
+    runCommand: async () => {
+      attempts += 1;
+      if (attempts < 2) {
+        return { exitCode: 1 };
+      }
+      return { exitCode: 0 };
+    },
+    sleep: async (ms) => {
+      sleepCalls.push(ms);
+    },
+  });
+
+  assert.equal(result.status, 'PASS');
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.attemptsUsed, 2);
+  assert.deepEqual(sleepCalls, [15]);
+});
+
+test('verify retry returns FAIL after terminal retries', async () => {
+  const sleepCalls = [];
+
+  const result = await retryAndroidReleaseVerify({
+    attempts: 3,
+    backoffMs: 10,
+    command: 'npm run release:android:verify',
+    runCommand: async () => ({ exitCode: 1 }),
+    sleep: async (ms) => {
+      sleepCalls.push(ms);
+    },
+  });
+
+  assert.equal(result.status, 'FAIL');
+  assert.equal(result.exitCode, 1);
+  assert.equal(result.retries.length, 3);
+  assert.equal(result.failures.length, 1);
+  assert.deepEqual(sleepCalls, [10, 10]);
+});
+
+test('retry config parser rejects malformed values', async () => {
+  assert.throws(() => parseRetryConfig(['--attempts', '0']), /invalid attempts/i);
+  assert.throws(() => parseRetryConfig(['--backoff-ms', '-1']), /invalid backoff-ms/i);
+});

--- a/docs/releases/publication-pipeline-v1-validation.md
+++ b/docs/releases/publication-pipeline-v1-validation.md
@@ -1,167 +1,53 @@
-# Publication Pipeline V1 — Validation Evidence (Local)
+# Publication Pipeline V1 — CI Validation & Audit Evidence
 
-Date: 2026-04-23  
-Change: `publication-pipeline-v1`
+This checklist documents what must be captured from `.github/workflows/release-android.yml` for every v1 run.
 
-This artifact captures the ordered local validation run plus the real publish/verify closeout evidence for Android `0.1.1`.
+## Scope Reminder
 
-## 2026-04-23 — publication-execution-v1 / Batch A (preflight readiness)
+- CI publication is Android-only in v1.
+- iOS remains preflight/manual-handoff only.
 
-Command (run from `apps/capacitor-demo`):
+## Required Audit Fields
 
-```bash
-npm run release:android:preflight
-```
+Record the following for each release run:
 
-Raw output:
+| Field | Source |
+|---|---|
+| `release_id` | `workflow_dispatch` input and `dispatch.json` |
+| `target` | `workflow_dispatch` input (`android`) |
+| `mode` | `workflow_dispatch` input (`preflight-only` or `publish`) |
+| Run URL | GitHub Actions run link |
+| Dispatcher | `github.actor` from run metadata |
+| Environment gate | `release` required for mode `publish` |
+| Approver (publish mode) | Protected environment approvals/audit log |
+| Stage outcomes | `validate-dispatch`, `android-preflight`, `android-publish`, `android-verify` |
 
-```text
-> @legato/capacitor-demo@0.1.1 release:android:preflight
-> node ../../native/android/core/scripts/release-android.mjs preflight --contract ../../packages/capacitor/native-artifacts.json --build-gradle ../../native/android/core/build.gradle --project-dir ../../native/android/core
+## Required Evidence Artifact Bundle
 
-Mode: preflight
-Overall: PASS
-Expected coordinate: dev.dgutierrez:legato-android-core:0.1.1
-Resolved coordinate: dev.dgutierrez:legato-android-core:0.1.1
-```
+Artifact name pattern: `release-evidence-<release_id>`
 
-Interpretation: preflight gate is ready for first maintainer-run Android publish attempt; publish/verify/evidence steps were intentionally not executed in this batch.
+Must include:
 
-## 2026-04-24 — publication-execution-v1 / Batch C closeout (real publish + verify)
+- `dispatch.json`
+- `preflight.log`
+- `publish.log`
+- `verify.log`
+- `summary.json`
+- `summary.md`
 
-Status: `success`
+## Release Outcome Checklist
 
-Closeout evidence (completed publication `0.1.1`):
+| Check | Evidence |
+|---|---|
+| Dispatch contract respected (`target=android`) | `dispatch.json` and `validate-dispatch` status |
+| Preflight succeeded before downstream release stages | `preflight.log` + stage status in `summary.json` |
+| Publish ran only through protected environment (publish mode) | `android-publish` job state + environment approvals |
+| Verify executed with bounded retries | `verify.log` and optional `verify-summary.json` payload |
+| Evidence bundle retained | downloadable `release-evidence-<release_id>` artifact |
+| iOS boundary documented as manual | runbook text in `publication-pipeline-v1.md` |
 
-- Operator: `Daniel Gutierrez (dgutierrez)`
-- Commit SHA used for release runbook closeout: `19c7f96`
-- Publish start UTC: `2026-04-24T00:54:42Z` (first published POM `Last-Modified`)
-- Publish end UTC: `2026-04-24T01:09:17Z` (`maven-metadata.xml` `lastUpdated`)
-- Verify confirmation UTC: `2026-04-24T01:19:58Z` (repo verify rerun)
-- Verify attempt window: `2026-04-24T00:54:42Z` → `2026-04-24T01:19:58Z`
-- Target coordinate: `dev.dgutierrez:legato-android-core:0.1.1`
-- Portal namespace URL: `https://central.sonatype.com/namespace/dev.dgutierrez`
-- POM URL: `https://repo1.maven.org/maven2/dev/dgutierrez/legato-android-core/0.1.1/legato-android-core-0.1.1.pom`
-- Release outcome: `success`
+## Notes for Preflight-only Runs
 
-Verification evidence snapshots:
-
-```text
-$ npm run release:android:verify
-Mode: verify
-Overall: PASS
-Expected coordinate: dev.dgutierrez:legato-android-core:0.1.1
-Resolved coordinate: dev.dgutierrez:legato-android-core:0.1.1
-POM URL: https://repo1.maven.org/maven2/dev/dgutierrez/legato-android-core/0.1.1/legato-android-core-0.1.1.pom
-```
-
-```text
-$ curl -sI https://repo1.maven.org/maven2/dev/dgutierrez/legato-android-core/0.1.1/legato-android-core-0.1.1.pom
-HTTP/2 200
-last-modified: Fri, 24 Apr 2026 00:54:42 GMT
-```
-
-```text
-$ curl -s https://repo1.maven.org/maven2/dev/dgutierrez/legato-android-core/maven-metadata.xml
-<lastUpdated>20260424010917</lastUpdated>
-```
-
-## 1) Android preflight (local rehearsal)
-
-Command:
-
-```bash
-npm run release:android:preflight
-```
-
-Result:
-
-```text
-Mode: preflight
-Overall: PASS
-Expected coordinate: dev.dgutierrez:legato-android-core:0.1.1
-Resolved coordinate: dev.dgutierrez:legato-android-core:0.1.1
-```
-
-## 2) Android publish (local credential boundary check)
-
-Command:
-
-```bash
-npm run release:android:publish
-```
-
-Result:
-
-```text
-Mode: publish
-Overall: FAIL
-Failures:
-- Publish blocked: missing required Maven Central/signing credentials.
-- Missing: ORG_GRADLE_PROJECT_mavenCentralUsername or MAVEN_CENTRAL_USERNAME
-- Missing: ORG_GRADLE_PROJECT_mavenCentralPassword or MAVEN_CENTRAL_PASSWORD
-```
-
-Interpretation: expected in local/dev environments without release secrets.
-
-Signing backend note for first real publish attempt:
-
-- Preferred path is local GPG (`SIGNING_GNUPG_KEY_NAME`, optional `SIGNING_GNUPG_PASSPHRASE`, optional executable/home-dir overrides).
-- In-memory key aliases remain available as fallback only.
-
-## 3) Android verify (local post-publish resolver gate)
-
-Command:
-
-```bash
-npm run release:android:verify
-```
-
-Result:
-
-```text
-Mode: verify
-Overall: FAIL
-Expected coordinate: dev.dgutierrez:legato-android-core:0.1.1
-POM URL: https://repo1.maven.org/maven2/dev/dgutierrez/legato-android-core/0.1.1/legato-android-core-0.1.1.pom
-Failures:
-- Android publish verification failed: Maven Central returned HTTP 404 for the expected POM URL.
-```
-
-Interpretation: expected until first real publish occurs.
-
-## 4) iOS preflight
-
-Command:
-
-```bash
-IOS_RELEASE_TAG=v0.1.1 npm run release:ios:preflight
-```
-
-Result:
-
-```text
-Mode: ios-preflight
-Overall: PASS
-Manual handoff ready: YES
-```
-
-## 5) Namespace migration scope safety
-
-Command:
-
-```bash
-npm run release:scope:check
-```
-
-Result:
-
-```text
-Overall: PASS
-Needle: dev.dgutierrez
-Scanned files: 34
-Expected matches: 6
-Unexpected matches: 0
-```
-
-Interpretation: no `dev.dgutierrez` leakage into out-of-scope files for this v1 migration.
+- `android-publish` is intentionally skipped.
+- `publish.log` may contain a placeholder entry generated by the evidence job.
+- These runs are valid rehearsal executions and still require complete evidence retention.

--- a/docs/releases/publication-pipeline-v1.md
+++ b/docs/releases/publication-pipeline-v1.md
@@ -1,183 +1,104 @@
-# Publication Pipeline V1 — Release Runbook
+# Publication Pipeline V1 — CI Android Release Runbook
 
-This runbook is the release boundary for change `publication-pipeline-v1`.
+This runbook defines change `ci-publication-release-automation-v1`.
 
 ## Scope Boundary
 
-- Android distribution target in v1 is Maven Central.
-- iOS distribution strategy is a remote Swift package (`legato-ios-core`), but publication remains manual in this milestone.
+- Android publication is CI-driven through GitHub Actions in v1.
+- iOS remains preflight/manual-handoff only in v1.
 - **Do not implement automated iOS publication in this v1 milestone.**
 
-## Validation Evidence Closeout (local readiness gates)
+## Workflow Entry Point (manual dispatch only)
 
-Run from `apps/capacitor-demo` in this order:
+Use `.github/workflows/release-android.yml` via **Run workflow** in GitHub Actions (`workflow_dispatch`).
 
-```bash
-npm run release:android:preflight
-npm run release:android:publish
-npm run release:android:verify
-IOS_RELEASE_TAG=v0.1.1 npm run release:ios:preflight
-npm run release:scope:check
-```
+Required inputs:
 
-- `release:android:publish` is expected to fail without maintainer credentials; this is the intended secret boundary.
-- `release:android:verify` is expected to fail until a real Maven Central release exists or propagates.
-- `release:scope:check` confirms v1 namespace migration stayed inside publication-scope files.
-
-Captured command outputs for this batch are recorded in [`publication-pipeline-v1-validation.md`](./publication-pipeline-v1-validation.md).
-
-## Android First Publish — Preflight Readiness (Batch A)
-
-Before any maintainer executes a real `release:android:publish`, complete this preflight gate from the repository root context below.
-
-### Required working directory
-
-- Run from: `apps/capacitor-demo`
-- Why: release scripts in this app bind the exact contract/build/project paths used by v1 publish.
-
-### Tooling prerequisites
-
-1. Node/npm available to run `npm run release:android:preflight`.
-2. Android Gradle toolchain resolvable from `native/android/core`:
-   - prefers `native/android/core/gradlew`
-   - falls back to `gradle` in PATH when wrapper is unavailable
-3. Repo files present and readable:
-   - `packages/capacitor/native-artifacts.json`
-   - `native/android/core/build.gradle`
-
-### Coordinate source-of-truth expectations
-
-Preflight must prove the publish coordinate comes from the native-artifacts contract and matches Gradle resolution:
-
-- Contract source: `packages/capacitor/native-artifacts.json` (`android.group`, `android.artifact`, `android.version`)
-- Gradle probe: `printPublicationCoordinate`
-- Expected result: exact match for `dev.dgutierrez:legato-android-core:<version>` (currently `0.1.1`)
-
-### Fail-fast checks enforced by preflight
-
-- Missing/invalid Android contract fields (`repositoryUrl`, `group`, `artifact`, `version`)
-- Missing publication metadata hooks in `build.gradle`
-- Gradle toolchain not executable (`--version` probe fails)
-- `printPublicationCoordinate` probe failure or coordinate mismatch
-- Placeholder publish-secret values detected in required aliases (`ORG_GRADLE_PROJECT_*` or fallback env names)
-
-If any gate fails, **do not run publish**. Fix the failing gate first and re-run preflight.
-
-## Android Publish Execution (maintainer-authorized)
-
-This section defines the first real publish flow for `dev.dgutierrez:legato-android-core`.
-
-### Ownership matrix (automation vs maintainer secrets)
-
-| Item | Owner | Notes |
+| Input | Allowed values | Purpose |
 |---|---|---|
-| `npm run release:android:preflight` | Automatable | Safe in any environment; no real credentials required. |
-| `npm run release:android:publish` command invocation | Automatable | Command is scripted, but execution is maintainer-authorized only. |
-| Maven Central credentials (`mavenCentralUsername/password`) | Maintainer-only | Must come from maintainer account that owns namespace rights. |
-| Signing backend configuration (`signing.gnupg.*` preferred, in-memory fallback) | Maintainer-only | Prefer local GPG signing (`signing.gnupg.keyName`) for real publish runs; use in-memory key/file only as fallback. Never persist raw keys in repo/logs/CI artifacts. |
-| `npm run release:android:verify` | Automatable | Runs bounded retries against Maven Central/POM reachability. |
-| Release evidence closeout in docs | Operator-owned | Operator identity, UTC timestamps, commit SHA, URLs, and outcomes are mandatory. |
+| `target` | `android` | Hard guard for v1 scope. Any non-Android target is rejected before preflight. |
+| `mode` | `preflight-only` \| `publish` | Safe rehearsal vs protected publish path. |
+| `release_id` | free-form string | Audit correlation key used in logs and evidence artifact names. |
 
-### Credential handling policy (no persistence)
+## Stage contract (ordered, fail-fast)
 
-1. Secrets are user-owned inputs, not repo-owned state.
-2. Do **not** commit secrets to any tracked file (`gradle.properties`, `.env`, docs, scripts).
-3. If local `native/android/core/gradle.properties` is used, keep it untracked and delete/rotate after release.
-4. Prefer ephemeral environment injection per shell session (export only for the command window).
-5. Validation/evidence docs must show **which aliases were used**, never raw secret values.
+1. `validate-dispatch`
+   - Enforces Android-only v1 target and valid mode.
+   - Persists `dispatch.json` for audit.
+2. `android-preflight`
+   - Runs `npm ci`, `npm run release:scope:check`, and `npm run release:android:preflight` from `apps/capacitor-demo`.
+   - Captures `preflight.log`.
+3. `android-publish` (mode=`publish` only)
+   - Requires protected GitHub Environment: `release`.
+   - Runs `npm run release:android:publish` with env-scoped Maven/signing secrets.
+   - Captures `publish.log`.
+4. `android-verify`
+   - Runs after preflight (and publish when mode=`publish`).
+   - Executes retry wrapper around canonical verify command.
+   - Captures `verify.log` and `verify-summary.json`.
+5. `evidence` (always)
+   - Aggregates stage outcomes and uploads the evidence bundle.
 
-Accepted secret aliases for release gate checks:
+## Protected approval + secrets boundary
 
-- `ORG_GRADLE_PROJECT_mavenCentralUsername` or `MAVEN_CENTRAL_USERNAME`
-- `ORG_GRADLE_PROJECT_mavenCentralPassword` or `MAVEN_CENTRAL_PASSWORD`
-- Preferred local-GPG aliases:
-  - `ORG_GRADLE_PROJECT_signingGnupgKeyName` or `SIGNING_GNUPG_KEY_NAME` (or `SIGNING_GNUPG_KEYNAME`)
-  - `ORG_GRADLE_PROJECT_signingGnupgPassphrase` or `SIGNING_GNUPG_PASSPHRASE` (optional when `gpg-agent` already unlocks key)
-  - `ORG_GRADLE_PROJECT_signingGnupgExecutable` or `SIGNING_GNUPG_EXECUTABLE` (optional override)
-  - `ORG_GRADLE_PROJECT_signingGnupgHomeDir` or `SIGNING_GNUPG_HOME_DIR` (optional override)
-- In-memory fallback aliases:
+### Environment gate
+
+- Publish requires environment `release` approval.
+- With mode=`publish`, execution is blocked until required reviewers approve.
+- With mode=`preflight-only`, publish is skipped and no protected publish secrets are required.
+
+### Accepted secret aliases (resolved in publish job)
+
+- Maven credentials:
+  - `ORG_GRADLE_PROJECT_mavenCentralUsername` or `MAVEN_CENTRAL_USERNAME`
+  - `ORG_GRADLE_PROJECT_mavenCentralPassword` or `MAVEN_CENTRAL_PASSWORD`
+- Preferred local-GPG signing aliases:
+  - `ORG_GRADLE_PROJECT_signingGnupgKeyName` or `SIGNING_GNUPG_KEY_NAME` (`SIGNING_GNUPG_KEYNAME` accepted)
+  - `ORG_GRADLE_PROJECT_signingGnupgPassphrase` or `SIGNING_GNUPG_PASSPHRASE`
+  - `ORG_GRADLE_PROJECT_signingGnupgExecutable` or `SIGNING_GNUPG_EXECUTABLE`
+  - `ORG_GRADLE_PROJECT_signingGnupgHomeDir` or `SIGNING_GNUPG_HOME_DIR`
+- In-memory signing fallback aliases:
   - `ORG_GRADLE_PROJECT_signingInMemoryKey` or `SIGNING_KEY`
   - `ORG_GRADLE_PROJECT_signingInMemoryKeyFile` or `SIGNING_KEY_FILE`
   - `ORG_GRADLE_PROJECT_signingInMemoryKeyPassword` or `SIGNING_PASSWORD`
 
-### Ordered publish run (when secrets are present)
+Secret values must never be printed, committed, or attached to artifacts.
 
-Run from `apps/capacitor-demo` in this exact order:
+## Evidence bundle (required on every run)
 
-```bash
-npm run release:android:preflight
-npm run release:android:publish
-npm run release:android:verify
-```
+Artifact name: `release-evidence-<release_id>`
 
-Operational notes:
+Included files:
 
-- `release:android:publish` now prints the expected coordinate, Maven Central namespace URL, POM URL, and next-step guidance.
-- `native/android/core/build.gradle` now auto-switches to `signing.useGpgCmd()` when `signing.gnupg.keyName` is provided, which prevents Gradle `no configured signatory` failures on local-GPG publish runs.
-- On publish failure, stop and classify the error before rerunning.
-- Rerun publish for the same version only when Central confirms the version is not released.
-- Verify uses bounded retry judgment (for example every 10-15 minutes up to the agreed cutoff window).
-- If verify cutoff is reached without HTTP 200 on POM URL, mark release as incomplete/blocked and open follow-up.
+- `dispatch.json`
+- `preflight.log`
+- `publish.log`
+- `verify.log`
+- `summary.json`
+- `summary.md`
 
-### iOS safeguard (unchanged in v1)
+`summary.md` and the Actions Job Summary include stage-by-stage status plus the run URL for post-release monitoring.
 
-iOS remains `release:ios:preflight` + manual handoff only. This runbook does not authorize automated iOS publication.
+Validation checklist and audit template: [`publication-pipeline-v1-validation.md`](./publication-pipeline-v1-validation.md).
 
-## iOS Preflight (automatable)
+## Operator quick paths
 
-Run from `apps/capacitor-demo`:
+### Safe rehearsal (no protected approval)
 
-```bash
-IOS_RELEASE_TAG=v0.1.1 npm run release:ios:preflight
-```
+- Dispatch with: `target=android`, `mode=preflight-only`, `release_id=<ticket-or-tag>`
+- Expected: preflight runs, publish skipped, verify runs against current artifact state.
 
-This preflight validates the iOS release identity contract before any manual handoff:
+### Real release path
 
-1. `packages/capacitor/native-artifacts.json`
-   - `ios.packageUrl`
-   - `ios.packageName`
-   - `ios.product`
-   - `ios.version`
-   - `ios.versionPolicy` (`exact`)
-2. `native/ios/LegatoCore/Package.swift`
-   - package `name` matches contract package name
-   - `.library(name: ...)` includes the expected product
-3. `packages/capacitor/Package.swift`
-   - managed native-artifacts block matches iOS contract fields
-   - remote SwiftPM dependency URL + `exact` version align with contract
-   - plugin `.product(name:, package:)` for `LegatoCore` matches contract identity
-4. Release tag readiness
-   - `--release-tag` (or `IOS_RELEASE_TAG`) must match contract version (`vX.Y.Z` ↔ `X.Y.Z`)
+- Dispatch with: `target=android`, `mode=publish`, `release_id=<release-identifier>`
+- Required: `release` environment approval and valid environment secrets.
+- Expected order: preflight → approved publish → verify → evidence.
 
-Expected successful summary:
+## iOS boundary (unchanged in v1)
 
-- `Mode: ios-preflight`
-- `Overall: PASS`
-- `Manual handoff ready: YES`
+iOS remains outside CI publication automation:
 
-## Manual Handoff (non-automated in v1)
+- iOS Preflight (automatable): `IOS_RELEASE_TAG=vX.Y.Z npm run release:ios:preflight`
+- Manual Handoff (non-automated in v1): publish in the external iOS release authority (`legato-ios-core`) after preflight PASS.
 
-After preflight is PASS, hand off manually to the `legato-ios-core` maintainers/repo owners:
-
-1. Create/push the release tag in `legato-ios-core` using approved maintainer credentials.
-2. Publish the Swift package release in the remote repository.
-3. Confirm release notes and ownership policy compliance.
-
-Manual responsibilities stay outside this repo by design:
-
-- tag authority and protected branch/release permissions
-- remote secret/token ownership
-- publication approvals in external systems
-
-## Runbook Checklist Artifact
-
-Attach this checklist in the PR/release ticket before manual iOS handoff:
-
-| Item | Evidence |
-|---|---|
-| Release tag submitted to preflight | Tag value used in command (example: `v0.1.1`) |
-| Preflight summary output | Captured terminal output showing `Overall: PASS` |
-| Link/path to the output attached in PR | Relative path or CI artifact URL |
-| Manual handoff confirmation | Comment/checklist note naming maintainer + handoff timestamp |
-
-If any checklist item is missing, iOS manual handoff is blocked.
+This workflow intentionally does not auto-publish iOS artifacts.


### PR DESCRIPTION
Closes #50

## Summary
- add an Android-only GitHub Actions release workflow using the existing `release:android:*` scripts
- gate the actual publish step behind a protected `release` environment approval boundary
- add bounded verify retry support and always-on release evidence capture
- keep iOS explicitly in preflight/manual-only mode for this v1 automation milestone

## Changes
| File | Change |
|------|--------|
| `.github/workflows/release-android.yml` | Android-only manual-dispatch release workflow with preflight → publish → verify → evidence stages |
| `apps/capacitor-demo/scripts/retry-android-release-verify.mjs` | bounded retry wrapper for Maven Central propagation timing |
| `apps/capacitor-demo/scripts/retry-android-release-verify.test.mjs` | retry wrapper tests |
| `apps/capacitor-demo/scripts/release-ci-workflow.test.mjs` | workflow contract / stage-order simulation tests |
| `apps/capacitor-demo/scripts/release-android-scripts.test.mjs` | updated script coverage for CI path expectations |
| `apps/capacitor-demo/scripts/publication-pipeline-v1-docs.test.mjs`, `publication-pipeline-v1-validation-docs.test.mjs` | docs/contract coverage for CI release runbook |
| `apps/capacitor-demo/package.json` | CI-facing release script aliases |
| `docs/releases/publication-pipeline-v1.md`, `publication-pipeline-v1-validation.md` | CI workflow usage, approval boundary, evidence expectations, and Android-only scope clarified |

## Test Plan
- [x] `node --test apps/capacitor-demo/scripts/release-android-scripts.test.mjs apps/capacitor-demo/scripts/retry-android-release-verify.test.mjs apps/capacitor-demo/scripts/release-ci-workflow.test.mjs apps/capacitor-demo/scripts/publication-pipeline-v1-docs.test.mjs apps/capacitor-demo/scripts/publication-pipeline-v1-validation-docs.test.mjs`
- [x] `npm run typecheck` (pre-existing milestone gate)
- [x] `bash ./apps/capacitor-demo/android/gradlew test`
- [ ] Actual workflow dispatch with configured GitHub Environment + secrets still needed once the repo settings are in place

## Notes
- This milestone automates Android release flow only. iOS remains preflight/manual-only by design in v1.
- Protected environment behavior is validated structurally and through workflow tests, but still needs a real GitHub Actions run with environment approvals/secrets configured.
