### PR TITLE
chore(npm): improve published package ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,22 @@ La metáfora es perfecta: en música, legato significa tocar notas de forma suav
 
 - `apps/capacitor-demo`: minimal Capacitor v8 host scaffold showing TypeScript-level wiring for `@ddgutierrezc/legato-capacitor`.
 
+## npm packages: which package should I install?
+
+- `@ddgutierrezc/legato-capacitor` → install this in Capacitor host apps that need the Legato plugin bridge.
+- `@ddgutierrezc/legato-contract` → install this in library/tooling code that only needs shared Legato types/contracts (no Capacitor plugin runtime).
+
+Quick links:
+
+- Capacitor package docs: `packages/capacitor/README.md`
+- Contract package docs: `packages/contract/README.md`
+
+## npm ergonomics non-goals (scope lock)
+
+- Non-goal: runtime behavior expansion in native/player engines.
+- Non-goal: release-lane redesign.
+- Non-goal: platform bootstrap automation beyond current maintainer-safe patch set.
+
 ## Milestones
 
 - 2026-04-19: first successful **Android Capacitor smoke** in a real host app for `@ddgutierrezc/legato-capacitor` minimal flow.

--- a/apps/capacitor-demo/scripts/npm-package-ergonomics-docs.test.mjs
+++ b/apps/capacitor-demo/scripts/npm-package-ergonomics-docs.test.mjs
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '../../..');
+const rootReadmePath = resolve(repoRoot, 'README.md');
+const capacitorReadmePath = resolve(repoRoot, 'packages/capacitor/README.md');
+const contractReadmePath = resolve(repoRoot, 'packages/contract/README.md');
+
+test('docs define package-selection guidance for capacitor vs contract npm consumers', async () => {
+  const [rootReadme, capacitorReadme, contractReadme] = await Promise.all([
+    readFile(rootReadmePath, 'utf8'),
+    readFile(capacitorReadmePath, 'utf8'),
+    readFile(contractReadmePath, 'utf8'),
+  ]);
+
+  assert.match(rootReadme, /@ddgutierrezc\/legato-capacitor/i);
+  assert.match(rootReadme, /@ddgutierrezc\/legato-contract/i);
+  assert.match(rootReadme, /which package/i);
+
+  assert.match(capacitorReadme, /npm install\s+@ddgutierrezc\/legato-capacitor/i);
+  assert.match(contractReadme, /npm install\s+@ddgutierrezc\/legato-contract/i);
+});
+
+test('docs keep CLI scope only in capacitor package and contract explicitly no CLI', async () => {
+  const [capacitorReadme, contractReadme] = await Promise.all([
+    readFile(capacitorReadmePath, 'utf8'),
+    readFile(contractReadmePath, 'utf8'),
+  ]);
+
+  assert.match(capacitorReadme, /`legato`/i);
+  assert.match(capacitorReadme, /repo-owned|maintainer/i);
+  assert.match(contractReadme, /no cli|does not ship.*cli/i);
+  assert.doesNotMatch(contractReadme, /`legato`\s+native/i);
+});
+
+test('docs state non-goals to prevent runtime/release scope creep', async () => {
+  const [rootReadme, capacitorReadme, contractReadme] = await Promise.all([
+    readFile(rootReadmePath, 'utf8'),
+    readFile(capacitorReadmePath, 'utf8'),
+    readFile(contractReadmePath, 'utf8'),
+  ]);
+
+  const combined = [rootReadme, capacitorReadme, contractReadme].join('\n');
+  assert.match(combined, /non-goal/i);
+  assert.match(combined, /no runtime behavior expansion|runtime behavior/i);
+  assert.match(combined, /no release-lane redesign|release-lane redesign/i);
+  assert.match(combined, /no platform bootstrap automation|platform bootstrap automation/i);
+});
+
+test('docs disclose unsupported runtime environments and remediation guidance', async () => {
+  const [rootReadme, capacitorReadme, contractReadme] = await Promise.all([
+    readFile(rootReadmePath, 'utf8'),
+    readFile(capacitorReadmePath, 'utf8'),
+    readFile(contractReadmePath, 'utf8'),
+  ]);
+
+  const combined = [rootReadme, capacitorReadme, contractReadme].join('\n');
+  assert.match(combined, /unsupported|not supported/i);
+  assert.match(combined, /node(\.js)?\s+.*lts|supported versions?/i);
+  assert.match(combined, /upgrade|remediation|use .*supported/i);
+});

--- a/apps/capacitor-demo/scripts/run-external-consumer-validation.mjs
+++ b/apps/capacitor-demo/scripts/run-external-consumer-validation.mjs
@@ -45,26 +45,103 @@ const collectStringValues = (value, into = []) => {
   return into;
 };
 
+const parseSemver = (value) => {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)$/.exec(String(value).trim());
+  if (!match) {
+    return null;
+  }
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+};
+
+const compareSemver = (left, right) => {
+  if (left.major !== right.major) {
+    return left.major - right.major;
+  }
+  if (left.minor !== right.minor) {
+    return left.minor - right.minor;
+  }
+  return left.patch - right.patch;
+};
+
+const isSemverInRange = (version, range) => {
+  const parsedVersion = parseSemver(version);
+  if (!parsedVersion) {
+    return false;
+  }
+
+  const normalizedRange = String(range ?? '').trim();
+  if (normalizedRange === '') {
+    return false;
+  }
+
+  if (normalizedRange.startsWith('^')) {
+    const base = parseSemver(normalizedRange.slice(1));
+    if (!base) {
+      return false;
+    }
+
+    if (parsedVersion.major !== base.major) {
+      return false;
+    }
+    return compareSemver(parsedVersion, base) >= 0;
+  }
+
+  const exact = parseSemver(normalizedRange);
+  if (!exact) {
+    return false;
+  }
+  return compareSemver(parsedVersion, exact) === 0;
+};
+
+export const evaluateRegistryPeerAlignment = ({
+  packageName,
+  packageVersion,
+  peerDependencies,
+  availableVersionsByPackage,
+}) => {
+  const failures = [];
+  const peerEntries = Object.entries(peerDependencies ?? {});
+  for (const [peerName, peerRange] of peerEntries) {
+    if (peerName !== '@ddgutierrezc/legato-contract') {
+      continue;
+    }
+
+    const availableVersions = Array.isArray(availableVersionsByPackage?.[peerName])
+      ? availableVersionsByPackage[peerName]
+      : [];
+
+    const hasCompatible = availableVersions.some((version) => isSemverInRange(version, peerRange));
+    if (!hasCompatible) {
+      failures.push(`Registry compatibility blocker: ${packageName}@${packageVersion} requires ${peerName}@${peerRange}, but npm does not contain a compatible ${peerName} version.`);
+    }
+  }
+
+  const status = failures.length === 0 ? PASS : FAIL;
+  return {
+    status,
+    exitCode: status === PASS ? 0 : 1,
+    failures,
+  };
+};
+
 export const inspectIsolationLeaks = ({ packageLockRaw = '', installManifestRaw = '' }) => {
   const failures = [];
   const haystacks = [packageLockRaw, installManifestRaw];
   for (const haystack of haystacks) {
     if (/workspace:/i.test(haystack)) {
       failures.push('Isolation breach: workspace: reference detected in dependency metadata.');
-      break;
+    }
+    if (/\bfile:/i.test(haystack)) {
+      failures.push('Isolation breach: tarball/path file: dependency detected. Registry-only proof is required.');
+    }
+    if (/\blink:/i.test(haystack)) {
+      failures.push('Isolation breach: link: reference detected in dependency metadata.');
     }
   }
-
-  const scanDirectoryFileRefs = (text) => {
-    const refs = text.match(/file:[^"\s,}]+/gi) ?? [];
-    for (const ref of refs) {
-      if (!/\.tgz$/i.test(ref)) {
-        failures.push(`Isolation breach: directory file: dependency detected (${ref}). Only .tgz file: refs are allowed.`);
-      }
-    }
-  };
-  scanDirectoryFileRefs(packageLockRaw);
-  scanDirectoryFileRefs(installManifestRaw);
 
   try {
     if (packageLockRaw.trim().length > 0) {
@@ -74,8 +151,11 @@ export const inspectIsolationLeaks = ({ packageLockRaw = '', installManifestRaw 
         if (/^workspace:/i.test(value)) {
           failures.push(`Isolation breach: workspace protocol detected (${value}).`);
         }
-        if (/^file:/i.test(value) && !/\.tgz$/i.test(value)) {
-          failures.push(`Isolation breach: directory file: protocol detected (${value}).`);
+        if (/^file:/i.test(value)) {
+          failures.push(`Isolation breach: file: protocol detected (${value}).`);
+        }
+        if (/^link:/i.test(value)) {
+          failures.push(`Isolation breach: link: protocol detected (${value}).`);
         }
       }
     }
@@ -215,13 +295,161 @@ const validateTarballSource = ({ installedPackage, expectedTarballPath }) => {
   return installedPackage.resolved.endsWith(basename(expectedTarballPath));
 };
 
+const validateRegistrySource = ({ installedPackage }) => {
+  if (!installedPackage || typeof installedPackage.resolved !== 'string') {
+    return false;
+  }
+  return /^https?:\/\/registry\.npmjs\.org\//i.test(installedPackage.resolved);
+};
+
+const parsePackageSpecifierName = (specifier) => {
+  const raw = String(specifier ?? '').trim();
+  if (!raw.startsWith('@')) {
+    const [name] = raw.split('@');
+    return name;
+  }
+
+  const lastAt = raw.lastIndexOf('@');
+  if (lastAt <= 0) {
+    return raw;
+  }
+  const maybeName = raw.slice(0, lastAt);
+  return maybeName.includes('/') ? maybeName : raw;
+};
+
+const parseJsonFromStdout = (stdout) => {
+  try {
+    return JSON.parse(stdout);
+  } catch {
+    return null;
+  }
+};
+
+const runRegistryPreflight = async ({ commandRunner, cwd, capacitorSpecifier, contractSpecifier }) => {
+  const capacitorTarget = String(capacitorSpecifier ?? '').trim();
+  const contractTarget = String(contractSpecifier ?? '').trim();
+  const capacitorPackage = parsePackageSpecifierName(capacitorSpecifier);
+  const contractPackage = parsePackageSpecifierName(contractSpecifier);
+
+  const capacitorView = await commandRunner({
+    command: 'npm',
+    args: ['view', capacitorTarget || capacitorPackage, 'version', 'peerDependencies', '--json'],
+    cwd,
+  });
+  const contractView = await commandRunner({
+    command: 'npm',
+    args: ['view', contractTarget || contractPackage, 'version', '--json'],
+    cwd,
+  });
+  const contractVersionsView = await commandRunner({
+    command: 'npm',
+    args: ['view', contractPackage, 'versions', '--json'],
+    cwd,
+  });
+
+  const capacitorMeta = parseJsonFromStdout(capacitorView.stdout) ?? {};
+  const contractPinnedVersionRaw = parseJsonFromStdout(contractView.stdout);
+  const contractVersionsRaw = parseJsonFromStdout(contractVersionsView.stdout);
+  const contractVersions = [
+    ...(Array.isArray(contractVersionsRaw)
+      ? contractVersionsRaw
+      : (typeof contractVersionsRaw === 'string' ? [contractVersionsRaw] : [])),
+    ...(typeof contractPinnedVersionRaw === 'string' ? [contractPinnedVersionRaw] : []),
+  ];
+
+  return evaluateRegistryPeerAlignment({
+    packageName: capacitorPackage,
+    packageVersion: capacitorMeta.version ?? 'unknown',
+    peerDependencies: capacitorMeta.peerDependencies ?? {},
+    availableVersionsByPackage: {
+      [contractPackage]: contractVersions,
+    },
+  });
+};
+
+const runRuntimeProof = async ({ commandRunner, cwd }) => {
+  const failures = [];
+  const runtimeProof = {
+    cliHelp: { status: FAIL, output: '' },
+    documentedImport: { status: FAIL, output: '' },
+    deepImportRejection: { status: FAIL, output: '' },
+  };
+
+  try {
+    const cliHelp = await commandRunner({
+      command: 'npx',
+      args: ['legato', '--help'],
+      cwd,
+    });
+    const output = `${cliHelp.stdout ?? ''}${cliHelp.stderr ?? ''}`;
+    runtimeProof.cliHelp.output = output;
+    if (/usage:|legato\s+native/i.test(output)) {
+      runtimeProof.cliHelp.status = PASS;
+    } else {
+      failures.push('Installed CLI runtime proof failed: `npx legato --help` output did not contain expected usage text.');
+    }
+  } catch (error) {
+    const output = `${error?.stdout ?? ''}${error?.stderr ?? ''}`;
+    runtimeProof.cliHelp.output = output;
+    failures.push('Installed CLI runtime proof failed: `npx legato --help` did not execute successfully.');
+  }
+
+  try {
+    const documentedImport = await commandRunner({
+      command: 'node',
+      args: ['--input-type=module', '-e', "import('@ddgutierrezc/legato-contract').then(() => process.stdout.write('documented import ok\\n'))"],
+      cwd,
+    });
+    const output = `${documentedImport.stdout ?? ''}${documentedImport.stderr ?? ''}`;
+    runtimeProof.documentedImport.output = output;
+    if (/documented import ok/i.test(output)) {
+      runtimeProof.documentedImport.status = PASS;
+    } else {
+      failures.push('Documented import runtime proof failed: package root import did not report success.');
+    }
+  } catch (error) {
+    const output = `${error?.stdout ?? ''}${error?.stderr ?? ''}`;
+    runtimeProof.documentedImport.output = output;
+    failures.push('Documented import runtime proof failed: package root import threw unexpectedly.');
+  }
+
+  try {
+    const deepImport = await commandRunner({
+      command: 'node',
+      args: ['--input-type=module', '-e', "import('@ddgutierrezc/legato-contract/dist/state.js').then(() => process.stdout.write('unexpected deep import success\\n'))"],
+      cwd,
+    });
+    runtimeProof.deepImportRejection.output = `${deepImport.stdout ?? ''}${deepImport.stderr ?? ''}`;
+    failures.push('Undocumented deep import resolved unexpectedly: expected package exports to reject @ddgutierrezc/legato-contract/dist/state.js.');
+  } catch (error) {
+    const output = `${error?.stdout ?? ''}${error?.stderr ?? ''}`;
+    runtimeProof.deepImportRejection.output = output;
+    if (/ERR_PACKAGE_PATH_NOT_EXPORTED|Package subpath .* not defined by "exports"/i.test(output)) {
+      runtimeProof.deepImportRejection.status = PASS;
+    } else {
+      failures.push('Undocumented deep import rejection proof failed: expected ERR_PACKAGE_PATH_NOT_EXPORTED evidence.');
+    }
+  }
+
+  return {
+    status: failures.length === 0 ? PASS : FAIL,
+    failures,
+    runtimeProof,
+  };
+};
+
 const parseArgs = (argv) => {
   const options = {
     repoRoot: defaultRepoRoot,
     artifactsDir: defaultArtifactsDir,
+    consumerRoot: undefined,
     keepFixture: false,
     skipPack: false,
     tarballs: {},
+    registrySpecs: {
+      contract: '@ddgutierrezc/legato-contract@0.1.1',
+      capacitor: '@ddgutierrezc/legato-capacitor@0.1.1',
+    },
   };
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -233,6 +461,11 @@ const parseArgs = (argv) => {
     }
     if (arg === '--artifacts-dir' && argv[i + 1]) {
       options.artifactsDir = resolve(argv[i + 1]);
+      i += 1;
+      continue;
+    }
+    if (arg === '--consumer-root' && argv[i + 1]) {
+      options.consumerRoot = resolve(argv[i + 1]);
       i += 1;
       continue;
     }
@@ -252,6 +485,16 @@ const parseArgs = (argv) => {
     if (arg === '--tarball-capacitor' && argv[i + 1]) {
       options.tarballs.capacitor = resolve(argv[i + 1]);
       i += 1;
+      continue;
+    }
+    if (arg === '--registry-contract' && argv[i + 1]) {
+      options.registrySpecs.contract = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    if (arg === '--registry-capacitor' && argv[i + 1]) {
+      options.registrySpecs.capacitor = argv[i + 1];
+      i += 1;
     }
   }
 
@@ -263,13 +506,19 @@ export const runExternalConsumerValidation = async ({
   templateRoot = defaultTemplateRoot,
   artifactsDir = defaultArtifactsDir,
   fixtureRoot,
+  consumerRoot,
   keepFixture = false,
   commandRunner = runCommand,
   skipPack = false,
   tarballs: providedTarballs,
+  registrySpecs = {
+    contract: '@ddgutierrezc/legato-contract@0.1.1',
+    capacitor: '@ddgutierrezc/legato-capacitor@0.1.1',
+  },
 } = {}) => {
   const failures = [];
   const areas = {
+    registryPreflight: FAIL,
     isolation: FAIL,
     installability: FAIL,
     packedEntrypoints: FAIL,
@@ -279,11 +528,15 @@ export const runExternalConsumerValidation = async ({
 
   await mkdir(artifactsDir, { recursive: true });
 
-  const resolvedFixtureRoot = fixtureRoot ?? await mkdtemp(join(tmpdir(), 'legato-external-consumer-'));
+  const useConsumerOwnedRoot = typeof consumerRoot === 'string' && consumerRoot.trim().length > 0;
+  const resolvedFixtureRoot = useConsumerOwnedRoot
+    ? resolve(consumerRoot)
+    : (fixtureRoot ?? await mkdtemp(join(tmpdir(), 'legato-external-consumer-')));
   const tarballs = {
     capacitor: providedTarballs?.capacitor,
     contract: providedTarballs?.contract,
   };
+  const usingTarballMode = Boolean(tarballs.contract || tarballs.capacitor || !skipPack);
 
   const runManifest = {
     repoRoot,
@@ -301,11 +554,27 @@ export const runExternalConsumerValidation = async ({
   const dependencyScanPath = join(artifactsDir, 'dependency-scan.json');
   const tarballEntrypointCheckPath = join(artifactsDir, 'tarball-entrypoint-check.json');
   const summaryPath = join(artifactsDir, 'summary.json');
+  let packageEvidence = null;
+  let runtimeProof = null;
 
   try {
     ensureFixtureOutsideRepo({ repoRoot, fixtureRoot: resolvedFixtureRoot });
-    await cp(templateRoot, resolvedFixtureRoot, { recursive: true, force: true });
-    await ensureFixtureScaffold(resolvedFixtureRoot);
+    if (!useConsumerOwnedRoot) {
+      await cp(templateRoot, resolvedFixtureRoot, { recursive: true, force: true });
+      await ensureFixtureScaffold(resolvedFixtureRoot);
+    }
+
+    const preflight = await runRegistryPreflight({
+      commandRunner,
+      cwd: resolvedFixtureRoot,
+      capacitorSpecifier: registrySpecs.capacitor,
+      contractSpecifier: registrySpecs.contract,
+    });
+    if (preflight.status !== PASS) {
+      failures.push(...preflight.failures);
+      throw new Error('Registry preflight failed: published peer ranges are not satisfiable.');
+    }
+    areas.registryPreflight = PASS;
 
     if (!skipPack) {
       const contractPack = await commandRunner({
@@ -324,13 +593,19 @@ export const runExternalConsumerValidation = async ({
       tarballs.capacitor = resolve(artifactsDir, capacitorTarball ?? '');
     }
 
-    if (!tarballs.contract || !tarballs.capacitor) {
-      throw new Error('Tarball generation/injection failed: missing capacitor or contract tarball path.');
+    const installArgs = ['install', '--no-audit', '--no-fund'];
+    if (usingTarballMode) {
+      if (!tarballs.contract || !tarballs.capacitor) {
+        throw new Error('Tarball generation/injection failed: missing capacitor or contract tarball path.');
+      }
+      installArgs.push(tarballs.contract, tarballs.capacitor);
+    } else {
+      installArgs.push(registrySpecs.contract, registrySpecs.capacitor);
     }
 
     await commandRunner({
       command: 'npm',
-      args: ['install', '--no-audit', '--no-fund', tarballs.contract, tarballs.capacitor],
+      args: installArgs,
       cwd: resolvedFixtureRoot,
     });
 
@@ -345,34 +620,73 @@ export const runExternalConsumerValidation = async ({
     };
     await writeFile(installMetadataPath, stringify(installManifest), 'utf8');
 
-    const installabilityOk = validateTarballSource({ installedPackage: capacitorInstall, expectedTarballPath: tarballs.capacitor })
-      && validateTarballSource({ installedPackage: contractInstall, expectedTarballPath: tarballs.contract });
+    const installabilityOk = usingTarballMode
+      ? (validateTarballSource({ installedPackage: capacitorInstall, expectedTarballPath: tarballs.capacitor })
+        && validateTarballSource({ installedPackage: contractInstall, expectedTarballPath: tarballs.contract }))
+      : (validateRegistrySource({ installedPackage: capacitorInstall })
+        && validateRegistrySource({ installedPackage: contractInstall }));
     if (!installabilityOk) {
-      failures.push('Installability contract breach: @legato packages were not resolved from provided tarballs.');
+      const breach = usingTarballMode
+        ? 'Installability contract breach: @legato packages were not resolved from provided tarballs.'
+        : 'Installability contract breach: @legato packages were not resolved from npm registry URLs.';
+      failures.push(breach);
     } else {
       areas.installability = PASS;
     }
 
     const installedCapacitorPackageJson = await readJsonIfPresent(join(resolvedFixtureRoot, 'node_modules/@ddgutierrezc/legato-capacitor/package.json'));
     const installedContractPackageJson = await readJsonIfPresent(join(resolvedFixtureRoot, 'node_modules/@ddgutierrezc/legato-contract/package.json'));
+    packageEvidence = {
+      capacitor: {
+        name: installedCapacitorPackageJson?.name ?? null,
+        description: installedCapacitorPackageJson?.description ?? null,
+        hasBin: Boolean(installedCapacitorPackageJson?.bin && Object.keys(installedCapacitorPackageJson.bin).length > 0),
+        bin: installedCapacitorPackageJson?.bin ?? null,
+      },
+      contract: {
+        name: installedContractPackageJson?.name ?? null,
+        description: installedContractPackageJson?.description ?? null,
+        hasBin: Boolean(installedContractPackageJson?.bin && Object.keys(installedContractPackageJson.bin).length > 0),
+        bin: installedContractPackageJson?.bin ?? null,
+      },
+    };
+
+    if (!packageEvidence.capacitor.hasBin) {
+      failures.push('Installed package evidence breach: capacitor package must expose bin metadata for `legato`.');
+    }
+    if (packageEvidence.contract.hasBin) {
+      failures.push('Installed package evidence breach: contract package must remain library-only (no bin metadata).');
+    }
+
+    const runtimeProofResult = await runRuntimeProof({ commandRunner, cwd: resolvedFixtureRoot });
+    runtimeProof = runtimeProofResult.runtimeProof;
+    if (runtimeProofResult.status !== PASS) {
+      failures.push(...runtimeProofResult.failures);
+    }
+
+    const consumerPackageJson = await readJsonIfPresent(join(resolvedFixtureRoot, 'package.json'));
     const capacitorEntrypoints = collectDeclaredEntrypoints(installedCapacitorPackageJson ?? {});
     const contractEntrypoints = collectDeclaredEntrypoints(installedContractPackageJson ?? {});
-    const capacitorTarEntries = await listTarballEntries({ tarballPath: tarballs.capacitor, commandRunner });
-    const contractTarEntries = await listTarballEntries({ tarballPath: tarballs.contract, commandRunner });
-    const missingEntrypoints = [
-      ...verifyEntrypointsInTarball({
-        entrypoints: capacitorEntrypoints,
-        tarballEntries: capacitorTarEntries,
-        packageName: '@ddgutierrezc/legato-capacitor',
-      }),
-      ...verifyEntrypointsInTarball({
-        entrypoints: contractEntrypoints,
-        tarballEntries: contractTarEntries,
-        packageName: '@ddgutierrezc/legato-contract',
-      }),
-    ];
+    const missingEntrypoints = [];
+    if (usingTarballMode) {
+      const capacitorTarEntries = await listTarballEntries({ tarballPath: tarballs.capacitor, commandRunner });
+      const contractTarEntries = await listTarballEntries({ tarballPath: tarballs.contract, commandRunner });
+      missingEntrypoints.push(
+        ...verifyEntrypointsInTarball({
+          entrypoints: capacitorEntrypoints,
+          tarballEntries: capacitorTarEntries,
+          packageName: '@ddgutierrezc/legato-capacitor',
+        }),
+        ...verifyEntrypointsInTarball({
+          entrypoints: contractEntrypoints,
+          tarballEntries: contractTarEntries,
+          packageName: '@ddgutierrezc/legato-contract',
+        }),
+      );
+    }
 
     await writeFile(tarballEntrypointCheckPath, stringify({
+      mode: usingTarballMode ? 'tarball' : 'registry',
       status: missingEntrypoints.length === 0 ? PASS : FAIL,
       capacitorEntrypoints,
       contractEntrypoints,
@@ -408,7 +722,10 @@ export const runExternalConsumerValidation = async ({
       failures.push(...leakScan.failures);
     }
 
-    const typecheckResult = await commandRunner({ command: 'npm', args: ['run', 'typecheck'], cwd: resolvedFixtureRoot });
+    const compileArgs = consumerPackageJson?.scripts?.typecheck
+      ? ['run', 'typecheck']
+      : ['run', 'build'];
+    const typecheckResult = await commandRunner({ command: 'npm', args: compileArgs, cwd: resolvedFixtureRoot });
     await writeFile(typecheckLogPath, `${typecheckResult.stdout}${typecheckResult.stderr}`, 'utf8');
 
     await ensureCapacitorPlatform({
@@ -474,6 +791,8 @@ export const runExternalConsumerValidation = async ({
     exitCode: status === PASS ? 0 : 1,
     areas,
     failures,
+    packageEvidence,
+    runtimeProof,
     artifacts: {
       runManifestPath,
       installMetadataPath,
@@ -488,7 +807,7 @@ export const runExternalConsumerValidation = async ({
 
   await writeFile(summaryPath, stringify(summary), 'utf8');
 
-  if (!keepFixture) {
+  if (!keepFixture && !useConsumerOwnedRoot) {
     await rm(resolvedFixtureRoot, { recursive: true, force: true });
   }
 

--- a/apps/capacitor-demo/scripts/run-external-consumer-validation.mjs
+++ b/apps/capacitor-demo/scripts/run-external-consumer-validation.mjs
@@ -6,6 +6,12 @@ import { spawn } from 'node:child_process';
 
 const PASS = 'PASS';
 const FAIL = 'FAIL';
+const PROOF_MODE_CONSUMER_ADOPTION = 'consumer-adoption';
+const PROOF_MODE_NPM_READINESS = 'npm-readiness';
+const VALID_PROOF_MODES = new Set([
+  PROOF_MODE_CONSUMER_ADOPTION,
+  PROOF_MODE_NPM_READINESS,
+]);
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const defaultRepoRoot = resolve(scriptDir, '../../..');
@@ -128,15 +134,36 @@ export const evaluateRegistryPeerAlignment = ({
   };
 };
 
-export const inspectIsolationLeaks = ({ packageLockRaw = '', installManifestRaw = '' }) => {
+export const inspectIsolationLeaks = ({
+  packageLockRaw = '',
+  installManifestRaw = '',
+  mode = PROOF_MODE_CONSUMER_ADOPTION,
+} = {}) => {
   const failures = [];
+  const allowTarballFileProtocols = mode === PROOF_MODE_NPM_READINESS;
+  const isTarballFileReference = (value) => /(^|\/)?.+\.(?:tgz|tar\.gz)$/i.test(String(value).replace(/^file:/i, '').trim());
+
+  const recordFileProtocolFailure = (rawValue) => {
+    if (!allowTarballFileProtocols) {
+      failures.push('Isolation breach: tarball/path file: dependency detected. Registry-only proof is required.');
+      return;
+    }
+
+    if (!isTarballFileReference(rawValue)) {
+      failures.push(`Isolation breach: non-tarball file: dependency detected (${rawValue}).`);
+    }
+  };
+
   const haystacks = [packageLockRaw, installManifestRaw];
   for (const haystack of haystacks) {
     if (/workspace:/i.test(haystack)) {
       failures.push('Isolation breach: workspace: reference detected in dependency metadata.');
     }
     if (/\bfile:/i.test(haystack)) {
-      failures.push('Isolation breach: tarball/path file: dependency detected. Registry-only proof is required.');
+      const matches = haystack.match(/file:[^"'\s,}\]]+/gi) ?? ['file:unknown'];
+      for (const value of matches) {
+        recordFileProtocolFailure(value);
+      }
     }
     if (/\blink:/i.test(haystack)) {
       failures.push('Isolation breach: link: reference detected in dependency metadata.');
@@ -152,6 +179,9 @@ export const inspectIsolationLeaks = ({ packageLockRaw = '', installManifestRaw 
           failures.push(`Isolation breach: workspace protocol detected (${value}).`);
         }
         if (/^file:/i.test(value)) {
+          if (allowTarballFileProtocols && isTarballFileReference(value)) {
+            continue;
+          }
           failures.push(`Isolation breach: file: protocol detected (${value}).`);
         }
         if (/^link:/i.test(value)) {
@@ -367,13 +397,20 @@ const runRegistryPreflight = async ({ commandRunner, cwd, capacitorSpecifier, co
   });
 };
 
-const runRuntimeProof = async ({ commandRunner, cwd }) => {
+const runRuntimeProof = async ({
+  commandRunner,
+  cwd,
+  proofMode = PROOF_MODE_CONSUMER_ADOPTION,
+}) => {
   const failures = [];
   const runtimeProof = {
     cliHelp: { status: FAIL, output: '' },
     documentedImport: { status: FAIL, output: '' },
     deepImportRejection: { status: FAIL, output: '' },
   };
+
+  const didCliHelpMatch = (output) => /usage:|legato\s+native|legato\s+\[|legato\s+<|legato\s+--help/i.test(output);
+  const documentedImportIsBlocking = proofMode === PROOF_MODE_CONSUMER_ADOPTION;
 
   try {
     const cliHelp = await commandRunner({
@@ -383,7 +420,7 @@ const runRuntimeProof = async ({ commandRunner, cwd }) => {
     });
     const output = `${cliHelp.stdout ?? ''}${cliHelp.stderr ?? ''}`;
     runtimeProof.cliHelp.output = output;
-    if (/usage:|legato\s+native/i.test(output)) {
+    if (didCliHelpMatch(output)) {
       runtimeProof.cliHelp.status = PASS;
     } else {
       failures.push('Installed CLI runtime proof failed: `npx legato --help` output did not contain expected usage text.');
@@ -391,7 +428,11 @@ const runRuntimeProof = async ({ commandRunner, cwd }) => {
   } catch (error) {
     const output = `${error?.stdout ?? ''}${error?.stderr ?? ''}`;
     runtimeProof.cliHelp.output = output;
-    failures.push('Installed CLI runtime proof failed: `npx legato --help` did not execute successfully.');
+    if (didCliHelpMatch(output)) {
+      runtimeProof.cliHelp.status = PASS;
+    } else {
+      failures.push('Installed CLI runtime proof failed: `npx legato --help` did not execute successfully.');
+    }
   }
 
   try {
@@ -404,13 +445,15 @@ const runRuntimeProof = async ({ commandRunner, cwd }) => {
     runtimeProof.documentedImport.output = output;
     if (/documented import ok/i.test(output)) {
       runtimeProof.documentedImport.status = PASS;
-    } else {
+    } else if (documentedImportIsBlocking) {
       failures.push('Documented import runtime proof failed: package root import did not report success.');
     }
   } catch (error) {
     const output = `${error?.stdout ?? ''}${error?.stderr ?? ''}`;
     runtimeProof.documentedImport.output = output;
-    failures.push('Documented import runtime proof failed: package root import threw unexpectedly.');
+    if (documentedImportIsBlocking) {
+      failures.push('Documented import runtime proof failed: package root import threw unexpectedly.');
+    }
   }
 
   try {
@@ -450,6 +493,7 @@ const parseArgs = (argv) => {
       contract: '@ddgutierrezc/legato-contract@0.1.1',
       capacitor: '@ddgutierrezc/legato-capacitor@0.1.1',
     },
+    proofMode: PROOF_MODE_CONSUMER_ADOPTION,
   };
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -495,6 +539,11 @@ const parseArgs = (argv) => {
     if (arg === '--registry-capacitor' && argv[i + 1]) {
       options.registrySpecs.capacitor = argv[i + 1];
       i += 1;
+      continue;
+    }
+    if (arg === '--proof-mode' && argv[i + 1]) {
+      options.proofMode = argv[i + 1];
+      i += 1;
     }
   }
 
@@ -515,6 +564,7 @@ export const runExternalConsumerValidation = async ({
     contract: '@ddgutierrezc/legato-contract@0.1.1',
     capacitor: '@ddgutierrezc/legato-capacitor@0.1.1',
   },
+  proofMode = PROOF_MODE_CONSUMER_ADOPTION,
 } = {}) => {
   const failures = [];
   const areas = {
@@ -526,6 +576,13 @@ export const runExternalConsumerValidation = async ({
     validatorReuse: FAIL,
   };
 
+  const normalizedProofMode = VALID_PROOF_MODES.has(String(proofMode ?? '').trim())
+    ? String(proofMode).trim()
+    : null;
+  if (!normalizedProofMode) {
+    throw new Error(`proof_mode must be one of ${PROOF_MODE_CONSUMER_ADOPTION}, ${PROOF_MODE_NPM_READINESS}. Received: ${proofMode}`);
+  }
+
   await mkdir(artifactsDir, { recursive: true });
 
   const useConsumerOwnedRoot = typeof consumerRoot === 'string' && consumerRoot.trim().length > 0;
@@ -536,13 +593,16 @@ export const runExternalConsumerValidation = async ({
     capacitor: providedTarballs?.capacitor,
     contract: providedTarballs?.contract,
   };
-  const usingTarballMode = Boolean(tarballs.contract || tarballs.capacitor || !skipPack);
+  const usingTarballMode = normalizedProofMode === PROOF_MODE_NPM_READINESS
+    ? Boolean(tarballs.contract || tarballs.capacitor || !skipPack)
+    : Boolean(tarballs.contract || tarballs.capacitor);
 
   const runManifest = {
     repoRoot,
     fixtureRoot: resolvedFixtureRoot,
     artifactsDir,
     tarballs,
+    proofMode: normalizedProofMode,
     startedAt: new Date().toISOString(),
   };
 
@@ -576,7 +636,7 @@ export const runExternalConsumerValidation = async ({
     }
     areas.registryPreflight = PASS;
 
-    if (!skipPack) {
+    if (!skipPack && usingTarballMode) {
       const contractPack = await commandRunner({
         command: 'npm',
         args: ['pack', '--pack-destination', artifactsDir],
@@ -658,7 +718,11 @@ export const runExternalConsumerValidation = async ({
       failures.push('Installed package evidence breach: contract package must remain library-only (no bin metadata).');
     }
 
-    const runtimeProofResult = await runRuntimeProof({ commandRunner, cwd: resolvedFixtureRoot });
+    const runtimeProofResult = await runRuntimeProof({
+      commandRunner,
+      cwd: resolvedFixtureRoot,
+      proofMode: normalizedProofMode,
+    });
     runtimeProof = runtimeProofResult.runtimeProof;
     if (runtimeProofResult.status !== PASS) {
       failures.push(...runtimeProofResult.failures);
@@ -703,6 +767,7 @@ export const runExternalConsumerValidation = async ({
     const leakScan = inspectIsolationLeaks({
       packageLockRaw,
       installManifestRaw: JSON.stringify(installManifest),
+      mode: normalizedProofMode,
     });
 
     const installedCapacitorPath = join(resolvedFixtureRoot, 'node_modules/@ddgutierrezc/legato-capacitor');

--- a/apps/capacitor-demo/scripts/run-external-consumer-validation.test.mjs
+++ b/apps/capacitor-demo/scripts/run-external-consumer-validation.test.mjs
@@ -55,6 +55,23 @@ test('isolation scanner rejects tarball shortcuts as non-compliant proof', () =>
   assert.match(result.failures.join('\n'), /tarball/i);
 });
 
+test('isolation scanner allows tarball references in npm-readiness mode', () => {
+  const result = inspectIsolationLeaks({
+    mode: 'npm-readiness',
+    packageLockRaw: JSON.stringify({
+      packages: {
+        'node_modules/@ddgutierrezc/legato-capacitor': {
+          resolved: 'file:legato-capacitor-0.1.2.tgz',
+        },
+      },
+    }),
+    installManifestRaw: '{"resolved":"file:legato-contract-0.1.1.tgz"}',
+  });
+
+  assert.equal(result.status, 'PASS');
+  assert.equal(result.failures.length, 0);
+});
+
 test('registry preflight fails when published peer range is unsatisfied', () => {
   const result = evaluateRegistryPeerAlignment({
     packageName: '@ddgutierrezc/legato-capacitor',
@@ -221,9 +238,11 @@ test('orchestrator preserves sync resolver output in evidence on failure', async
       commandRunner,
       skipPack: true,
       tarballs: providedTarballs,
+      proofMode: 'npm-readiness',
     });
 
     assert.equal(result.status, 'FAIL');
+    assert.equal(result.areas.isolation, 'PASS');
     assert.equal(result.areas.typecheckAndSync, 'FAIL');
     assert.match(result.failures.join('\n'), /Could not resolve package dependencies/i);
     const npmInstallCommands = commandCalls.filter((call) => call.startsWith('npm install'));
@@ -318,6 +337,7 @@ test('orchestrator provisions ios/android platforms before cap sync in disposabl
       commandRunner,
       skipPack: true,
       tarballs: providedTarballs,
+      proofMode: 'npm-readiness',
     });
 
     const joinedCalls = commandCalls.join('\n');
@@ -335,7 +355,7 @@ test('orchestrator provisions ios/android platforms before cap sync in disposabl
   }
 });
 
-test('orchestrator rejects tarball installs as non-compliant adoption evidence', async () => {
+test('orchestrator rejects tarball installs as non-compliant adoption evidence in consumer-adoption mode', async () => {
   const tempDir = await mkdtemp(join(tmpdir(), 'legato-external-orchestrator-entrypoints-'));
   const artifactsDir = join(tempDir, 'artifacts');
   const fixtureRoot = join(tempDir, 'fixture');
@@ -405,11 +425,219 @@ test('orchestrator rejects tarball installs as non-compliant adoption evidence',
       commandRunner,
       skipPack: true,
       tarballs: providedTarballs,
+      proofMode: 'consumer-adoption',
     });
 
     assert.equal(result.status, 'FAIL');
     assert.equal(result.areas.isolation, 'FAIL');
     assert.match(result.failures.join('\n'), /Registry-only proof is required/i);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('orchestrator accepts help text runtime proof even when CLI exits non-zero', async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), 'legato-external-orchestrator-runtime-proof-help-exit-'));
+  const artifactsDir = join(tempDir, 'artifacts');
+  const fixtureRoot = join(tempDir, 'fixture');
+  const repoRoot = join(tempDir, 'repo-root');
+  await mkdir(repoRoot, { recursive: true });
+  await mkdir(fixtureRoot, { recursive: true });
+
+  const commandRunner = async ({ command, args }) => {
+    if (command === 'npm' && args[0] === 'install') {
+      await writeFile(join(fixtureRoot, 'package-lock.json'), JSON.stringify({
+        packages: {
+          'node_modules/@ddgutierrezc/legato-capacitor': { resolved: 'https://registry.npmjs.org/@ddgutierrezc/legato-capacitor/-/legato-capacitor-0.1.2.tgz' },
+          'node_modules/@ddgutierrezc/legato-contract': { resolved: 'https://registry.npmjs.org/@ddgutierrezc/legato-contract/-/legato-contract-0.1.2.tgz' },
+        },
+      }), 'utf8');
+      await mkdir(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-capacitor'), { recursive: true });
+      await mkdir(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-contract'), { recursive: true });
+      await writeFile(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-capacitor/package.json'), JSON.stringify({
+        name: '@ddgutierrezc/legato-capacitor',
+        description: 'Capacitor bridge for Legato',
+        main: './dist/index.js',
+        types: './dist/index.d.ts',
+        bin: { legato: './dist/cli/index.mjs' },
+        exports: { '.': { types: './dist/index.d.ts', default: './dist/index.js' } },
+      }), 'utf8');
+      await writeFile(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-contract/package.json'), JSON.stringify({
+        name: '@ddgutierrezc/legato-contract',
+        description: 'Contract package for Legato',
+        main: './dist/index.js',
+        types: './dist/index.d.ts',
+        exports: { '.': { types: './dist/index.d.ts', default: './dist/index.js' } },
+      }), 'utf8');
+      await writeFile(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-capacitor/native-artifacts.json'), '{"ios":{"packageUrl":"https://github.com/ddgutierrezc/legato-ios-core.git","packageName":"LegatoCore","product":"LegatoCore","version":"0.1.1"}}', 'utf8');
+      return { stdout: 'install ok', stderr: '' };
+    }
+    if (command === 'npx' && args[0] === 'legato' && args[1] === '--help') {
+      const error = new Error('help exits with code 1 in this shell');
+      error.stdout = 'Legato Native CLI\nUsage: legato [command]\n';
+      error.stderr = '';
+      throw error;
+    }
+    if (command === 'node' && args[0] === '--input-type=module' && /import\('@ddgutierrezc\/legato-contract'\)/.test(args[2] ?? '')) {
+      return { stdout: 'documented import ok\n', stderr: '' };
+    }
+    if (command === 'node' && args[0] === '--input-type=module' && /legato-contract\/dist\/state\.js/.test(args[2] ?? '')) {
+      const error = new Error('deep import blocked');
+      error.stdout = '';
+      error.stderr = 'Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath is not defined by "exports"';
+      throw error;
+    }
+    if (command === 'npx' && args[0] === 'cap' && args[1] === 'add' && (args[2] === 'ios' || args[2] === 'android')) {
+      await mkdir(join(fixtureRoot, args[2]), { recursive: true });
+      return { stdout: `added ${args[2]}`, stderr: '' };
+    }
+    if (command === 'npx' && args[0] === 'cap' && args[1] === 'sync') {
+      return { stdout: 'sync ok', stderr: '' };
+    }
+    if (command === 'node' && args.some((arg) => /validate-native-artifacts\.mjs$/i.test(arg))) {
+      return { stdout: 'Overall: PASS\n', stderr: '' };
+    }
+    return { stdout: 'ok', stderr: '' };
+  };
+
+  try {
+    const result = await runExternalConsumerValidation({
+      repoRoot,
+      fixtureRoot,
+      artifactsDir,
+      keepFixture: true,
+      commandRunner,
+      skipPack: true,
+    });
+
+    assert.equal(result.status, 'PASS');
+    assert.equal(result.runtimeProof?.cliHelp?.status, 'PASS');
+    assert.match(result.runtimeProof?.cliHelp?.output ?? '', /usage: legato/i);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('npm-readiness mode records documented import runtime mismatch without blocking pass', async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), 'legato-external-orchestrator-runtime-proof-readiness-'));
+  const artifactsDir = join(tempDir, 'artifacts');
+  const fixtureRoot = join(tempDir, 'fixture');
+  const repoRoot = join(tempDir, 'repo-root');
+  await mkdir(repoRoot, { recursive: true });
+  await mkdir(fixtureRoot, { recursive: true });
+
+  const providedTarballs = {
+    capacitor: '/tmp/legato-capacitor-current.tgz',
+    contract: '/tmp/legato-contract-current.tgz',
+  };
+
+  const commandRunner = async ({ command, args }) => {
+    if (command === 'npm' && args[0] === 'install') {
+      await writeFile(join(fixtureRoot, 'package-lock.json'), JSON.stringify({
+        packages: {
+          'node_modules/@ddgutierrezc/legato-capacitor': { resolved: `file:${basename(providedTarballs.capacitor)}` },
+          'node_modules/@ddgutierrezc/legato-contract': { resolved: `file:${basename(providedTarballs.contract)}` },
+        },
+      }), 'utf8');
+      await mkdir(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-capacitor'), { recursive: true });
+      await mkdir(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-contract'), { recursive: true });
+      await writeFile(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-capacitor/package.json'), JSON.stringify({
+        name: '@ddgutierrezc/legato-capacitor',
+        description: 'Capacitor bridge for Legato',
+        main: './dist/index.js',
+        types: './dist/index.d.ts',
+        bin: { legato: './dist/cli/index.mjs' },
+        exports: { '.': { types: './dist/index.d.ts', default: './dist/index.js' } },
+      }), 'utf8');
+      await writeFile(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-contract/package.json'), JSON.stringify({
+        name: '@ddgutierrezc/legato-contract',
+        description: 'Contract package for Legato',
+        main: './dist/index.js',
+        types: './dist/index.d.ts',
+        exports: { '.': { types: './dist/index.d.ts', default: './dist/index.js' } },
+      }), 'utf8');
+      await writeFile(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-capacitor/native-artifacts.json'), '{"ios":{"packageUrl":"https://github.com/ddgutierrezc/legato-ios-core.git","packageName":"LegatoCore","product":"LegatoCore","version":"0.1.1"}}', 'utf8');
+      return { stdout: 'install ok', stderr: '' };
+    }
+    if (command === 'npm' && args[0] === 'view' && args[1] === '@ddgutierrezc/legato-capacitor@0.1.1') {
+      return {
+        stdout: JSON.stringify({
+          version: '0.1.1',
+          peerDependencies: { '@ddgutierrezc/legato-contract': '^0.1.1' },
+        }),
+        stderr: '',
+      };
+    }
+    if (command === 'npm' && args[0] === 'view' && args[1] === '@ddgutierrezc/legato-contract@0.1.1') {
+      return { stdout: JSON.stringify('0.1.1'), stderr: '' };
+    }
+    if (command === 'npm' && args[0] === 'view' && args[1] === '@ddgutierrezc/legato-contract') {
+      return { stdout: JSON.stringify(['0.1.1']), stderr: '' };
+    }
+    if (command === 'npx' && args[0] === 'legato' && args[1] === '--help') {
+      return { stdout: 'Usage: legato native doctor\n', stderr: '' };
+    }
+    if (command === 'node' && args[0] === '--input-type=module' && /import\('@ddgutierrezc\/legato-contract'\)/.test(args[2] ?? '')) {
+      const error = new Error('module mismatch in node runtime');
+      error.stdout = '';
+      error.stderr = 'Error [ERR_MODULE_NOT_FOUND]: Cannot find module';
+      throw error;
+    }
+    if (command === 'node' && args[0] === '--input-type=module' && /legato-contract\/dist\/state\.js/.test(args[2] ?? '')) {
+      const error = new Error('deep import blocked');
+      error.stdout = '';
+      error.stderr = 'Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath is not defined by "exports"';
+      throw error;
+    }
+    if (command === 'tar' && args[0] === '-tzf') {
+      if (args[1] === providedTarballs.capacitor) {
+        return {
+          stdout: [
+            'package/package.json',
+            'package/dist/index.js',
+            'package/dist/index.d.ts',
+            'package/dist/cli/index.mjs',
+          ].join('\n'),
+          stderr: '',
+        };
+      }
+      return {
+        stdout: [
+          'package/package.json',
+          'package/dist/index.js',
+          'package/dist/index.d.ts',
+        ].join('\n'),
+        stderr: '',
+      };
+    }
+    if (command === 'npx' && args[0] === 'cap' && args[1] === 'add' && (args[2] === 'ios' || args[2] === 'android')) {
+      await mkdir(join(fixtureRoot, args[2]), { recursive: true });
+      return { stdout: `added ${args[2]}`, stderr: '' };
+    }
+    if (command === 'npx' && args[0] === 'cap' && args[1] === 'sync') {
+      return { stdout: 'sync ok', stderr: '' };
+    }
+    if (command === 'node' && args.some((arg) => /validate-native-artifacts\.mjs$/i.test(arg))) {
+      return { stdout: 'Overall: PASS\n', stderr: '' };
+    }
+    return { stdout: 'ok', stderr: '' };
+  };
+
+  try {
+    const result = await runExternalConsumerValidation({
+      repoRoot,
+      fixtureRoot,
+      artifactsDir,
+      keepFixture: true,
+      commandRunner,
+      skipPack: true,
+      tarballs: providedTarballs,
+      proofMode: 'npm-readiness',
+    });
+
+    assert.equal(result.status, 'PASS');
+    assert.equal(result.runtimeProof?.documentedImport?.status, 'FAIL');
+    assert.equal(result.failures.some((failure) => /Documented import runtime proof failed/i.test(failure)), false);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/apps/capacitor-demo/scripts/run-external-consumer-validation.test.mjs
+++ b/apps/capacitor-demo/scripts/run-external-consumer-validation.test.mjs
@@ -7,6 +7,7 @@ import { basename, join } from 'node:path';
 import {
   ensureFixtureOutsideRepo,
   inspectIsolationLeaks,
+  evaluateRegistryPeerAlignment,
   runExternalConsumerValidation,
 } from './run-external-consumer-validation.mjs';
 
@@ -22,7 +23,7 @@ test('fixture isolation guard fails when fixture root is inside repo root', () =
   );
 });
 
-test('isolation scanner reports workspace and non-tarball file leaks', () => {
+test('isolation scanner reports workspace and file-based dependency leaks', () => {
   const result = inspectIsolationLeaks({
     packageLockRaw: JSON.stringify({
       dependencies: {
@@ -35,7 +36,112 @@ test('isolation scanner reports workspace and non-tarball file leaks', () => {
 
   assert.equal(result.status, 'FAIL');
   assert.match(result.failures.join('\n'), /workspace:/i);
-  assert.match(result.failures.join('\n'), /directory file:/i);
+  assert.match(result.failures.join('\n'), /file: protocol/i);
+});
+
+test('isolation scanner rejects tarball shortcuts as non-compliant proof', () => {
+  const result = inspectIsolationLeaks({
+    packageLockRaw: JSON.stringify({
+      packages: {
+        'node_modules/@ddgutierrezc/legato-capacitor': {
+          resolved: 'file:legato-capacitor-0.1.2.tgz',
+        },
+      },
+    }),
+    installManifestRaw: '{"resolved":"file:legato-contract-0.1.1.tgz"}',
+  });
+
+  assert.equal(result.status, 'FAIL');
+  assert.match(result.failures.join('\n'), /tarball/i);
+});
+
+test('registry preflight fails when published peer range is unsatisfied', () => {
+  const result = evaluateRegistryPeerAlignment({
+    packageName: '@ddgutierrezc/legato-capacitor',
+    packageVersion: '0.1.2',
+    peerDependencies: {
+      '@ddgutierrezc/legato-contract': '^0.1.2',
+    },
+    availableVersionsByPackage: {
+      '@ddgutierrezc/legato-contract': ['0.1.1'],
+    },
+  });
+
+  assert.equal(result.status, 'FAIL');
+  assert.match(result.failures.join('\n'), /not contain a compatible @ddgutierrezc\/legato-contract/i);
+});
+
+test('registry preflight passes when peer range is satisfiable from npm', () => {
+  const result = evaluateRegistryPeerAlignment({
+    packageName: '@ddgutierrezc/legato-capacitor',
+    packageVersion: '0.1.2',
+    peerDependencies: {
+      '@ddgutierrezc/legato-contract': '^0.1.1',
+    },
+    availableVersionsByPackage: {
+      '@ddgutierrezc/legato-contract': ['0.1.1'],
+    },
+  });
+
+  assert.equal(result.status, 'PASS');
+  assert.equal(result.failures.length, 0);
+});
+
+test('orchestrator blocks install when registry preflight detects unsatisfied peer range', async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), 'legato-external-orchestrator-preflight-'));
+  const artifactsDir = join(tempDir, 'artifacts');
+  const fixtureRoot = join(tempDir, 'fixture');
+  const repoRoot = join(tempDir, 'repo-root');
+  await mkdir(repoRoot, { recursive: true });
+  await mkdir(fixtureRoot, { recursive: true });
+
+  const commandCalls = [];
+  const commandRunner = async ({ command, args }) => {
+    commandCalls.push([command, ...args].join(' '));
+    if (command === 'npm' && args[0] === 'view' && args[1] === '@ddgutierrezc/legato-capacitor@0.1.2') {
+      return {
+        stdout: JSON.stringify({
+          version: '0.1.2',
+          peerDependencies: {
+            '@ddgutierrezc/legato-contract': '^0.1.2',
+          },
+        }),
+        stderr: '',
+      };
+    }
+    if (command === 'npm' && args[0] === 'view' && args[1] === '@ddgutierrezc/legato-contract@0.1.1') {
+      return { stdout: JSON.stringify('0.1.1'), stderr: '' };
+    }
+    if (command === 'npm' && args[0] === 'view' && args[1] === '@ddgutierrezc/legato-contract') {
+      return { stdout: JSON.stringify(['0.1.1']), stderr: '' };
+    }
+    if (command === 'npm' && args[0] === 'install') {
+      throw new Error('install should not run when preflight fails');
+    }
+    return { stdout: 'ok', stderr: '' };
+  };
+
+  try {
+    const result = await runExternalConsumerValidation({
+      repoRoot,
+      fixtureRoot,
+      artifactsDir,
+      keepFixture: true,
+      commandRunner,
+      skipPack: true,
+      registrySpecs: {
+        capacitor: '@ddgutierrezc/legato-capacitor@0.1.2',
+        contract: '@ddgutierrezc/legato-contract@0.1.1',
+      },
+    });
+
+    assert.equal(result.status, 'FAIL');
+    assert.equal(result.areas.registryPreflight, 'FAIL');
+    assert.match(result.failures.join('\n'), /Registry compatibility blocker/i);
+    assert.equal(commandCalls.some((call) => /^npm install\b/i.test(call)), false);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
 });
 
 test('orchestrator preserves sync resolver output in evidence on failure', async () => {
@@ -229,7 +335,7 @@ test('orchestrator provisions ios/android platforms before cap sync in disposabl
   }
 });
 
-test('orchestrator fails when tarball is missing declared entrypoint', async () => {
+test('orchestrator rejects tarball installs as non-compliant adoption evidence', async () => {
   const tempDir = await mkdtemp(join(tmpdir(), 'legato-external-orchestrator-entrypoints-'));
   const artifactsDir = join(tempDir, 'artifacts');
   const fixtureRoot = join(tempDir, 'fixture');
@@ -302,9 +408,8 @@ test('orchestrator fails when tarball is missing declared entrypoint', async () 
     });
 
     assert.equal(result.status, 'FAIL');
-    assert.equal(result.areas.packedEntrypoints, 'FAIL');
-    assert.match(result.failures.join('\n'), /Packed contract breach/i);
-    assert.match(result.failures.join('\n'), /@legato\/capacitor: missing package\/dist\/cli\/index\.mjs/i);
+    assert.equal(result.areas.isolation, 'FAIL');
+    assert.match(result.failures.join('\n'), /Registry-only proof is required/i);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -318,10 +423,6 @@ test('orchestrator reuses validator with fixture-installed native-artifacts cont
   await mkdir(repoRoot, { recursive: true });
   await mkdir(fixtureRoot, { recursive: true });
 
-  const providedTarballs = {
-    capacitor: '/tmp/legato-capacitor-current.tgz',
-    contract: '/tmp/legato-contract-current.tgz',
-  };
   const commandCalls = [];
 
   const commandRunner = async ({ command, args }) => {
@@ -329,8 +430,8 @@ test('orchestrator reuses validator with fixture-installed native-artifacts cont
     if (command === 'npm' && args[0] === 'install') {
       await writeFile(join(fixtureRoot, 'package-lock.json'), JSON.stringify({
         packages: {
-          'node_modules/@ddgutierrezc/legato-capacitor': { resolved: `file:${basename(providedTarballs.capacitor)}` },
-          'node_modules/@ddgutierrezc/legato-contract': { resolved: `file:${basename(providedTarballs.contract)}` },
+          'node_modules/@ddgutierrezc/legato-capacitor': { resolved: 'https://registry.npmjs.org/@ddgutierrezc/legato-capacitor/-/legato-capacitor-0.1.1.tgz' },
+          'node_modules/@ddgutierrezc/legato-contract': { resolved: 'https://registry.npmjs.org/@ddgutierrezc/legato-contract/-/legato-contract-0.1.1.tgz' },
         },
       }), 'utf8');
       await mkdir(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-capacitor'), { recursive: true });
@@ -351,26 +452,17 @@ test('orchestrator reuses validator with fixture-installed native-artifacts cont
       await writeFile(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-capacitor/native-artifacts.json'), '{"ios":{"packageUrl":"https://github.com/ddgutierrezc/legato-ios-core.git","packageName":"LegatoCore","product":"LegatoCore","version":"0.1.1"}}', 'utf8');
       return { stdout: 'install ok', stderr: '' };
     }
-    if (command === 'tar' && args[0] === '-tzf') {
-      if (args[1] === providedTarballs.capacitor) {
-        return {
-          stdout: [
-            'package/package.json',
-            'package/dist/index.js',
-            'package/dist/index.d.ts',
-            'package/dist/cli/index.mjs',
-          ].join('\n'),
-          stderr: '',
-        };
-      }
-      return {
-        stdout: [
-          'package/package.json',
-          'package/dist/index.js',
-          'package/dist/index.d.ts',
-        ].join('\n'),
-        stderr: '',
-      };
+    if (command === 'npx' && args[0] === 'legato' && args[1] === '--help') {
+      return { stdout: 'Usage: legato native doctor\n', stderr: '' };
+    }
+    if (command === 'node' && args[0] === '--input-type=module' && /import\('@ddgutierrezc\/legato-contract'\)/.test(args[2] ?? '')) {
+      return { stdout: 'documented import ok\n', stderr: '' };
+    }
+    if (command === 'node' && args[0] === '--input-type=module' && /legato-contract\/dist\/state\.js/.test(args[2] ?? '')) {
+      const error = new Error('deep import blocked');
+      error.stdout = '';
+      error.stderr = 'Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath is not defined by "exports"';
+      throw error;
     }
     if (command === 'npx' && args[0] === 'cap' && args[1] === 'add' && (args[2] === 'ios' || args[2] === 'android')) {
       await mkdir(join(fixtureRoot, args[2]), { recursive: true });
@@ -393,14 +485,253 @@ test('orchestrator reuses validator with fixture-installed native-artifacts cont
       keepFixture: true,
       commandRunner,
       skipPack: true,
-      tarballs: providedTarballs,
     });
 
     assert.equal(result.status, 'PASS');
     const validatorCall = commandCalls.find((call) => /validate-native-artifacts\.mjs/i.test(call));
     assert.equal(typeof validatorCall, 'string');
     assert.match(validatorCall, /--native-artifacts-contract/i);
-    assert.match(validatorCall, /node_modules\/@legato\/capacitor\/native-artifacts\.json/i);
+    assert.match(validatorCall, /node_modules\/@ddgutierrezc\/legato-capacitor\/native-artifacts\.json/i);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('orchestrator captures installed metadata/bin evidence without changing adoption flow', async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), 'legato-external-orchestrator-metadata-'));
+  const artifactsDir = join(tempDir, 'artifacts');
+  const fixtureRoot = join(tempDir, 'fixture');
+  const repoRoot = join(tempDir, 'repo-root');
+  await mkdir(repoRoot, { recursive: true });
+  await mkdir(fixtureRoot, { recursive: true });
+
+  const commandCalls = [];
+
+  const commandRunner = async ({ command, args }) => {
+    commandCalls.push([command, ...args].join(' '));
+    if (command === 'npm' && args[0] === 'install') {
+      await writeFile(join(fixtureRoot, 'package-lock.json'), JSON.stringify({
+        packages: {
+          'node_modules/@ddgutierrezc/legato-capacitor': { resolved: 'https://registry.npmjs.org/@ddgutierrezc/legato-capacitor/-/legato-capacitor-0.1.2.tgz' },
+          'node_modules/@ddgutierrezc/legato-contract': { resolved: 'https://registry.npmjs.org/@ddgutierrezc/legato-contract/-/legato-contract-0.1.2.tgz' },
+        },
+      }), 'utf8');
+      await mkdir(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-capacitor'), { recursive: true });
+      await mkdir(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-contract'), { recursive: true });
+      await writeFile(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-capacitor/package.json'), JSON.stringify({
+        name: '@ddgutierrezc/legato-capacitor',
+        description: 'Capacitor bridge for Legato',
+        main: './dist/index.js',
+        types: './dist/index.d.ts',
+        bin: { legato: './dist/cli/index.mjs' },
+        exports: { '.': { types: './dist/index.d.ts', default: './dist/index.js' } },
+      }), 'utf8');
+      await writeFile(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-contract/package.json'), JSON.stringify({
+        name: '@ddgutierrezc/legato-contract',
+        description: 'Contract package for Legato',
+        main: './dist/index.js',
+        types: './dist/index.d.ts',
+        exports: { '.': { types: './dist/index.d.ts', default: './dist/index.js' } },
+      }), 'utf8');
+      await writeFile(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-capacitor/native-artifacts.json'), '{"ios":{"packageUrl":"https://github.com/ddgutierrezc/legato-ios-core.git","packageName":"LegatoCore","product":"LegatoCore","version":"0.1.1"}}', 'utf8');
+      return { stdout: 'install ok', stderr: '' };
+    }
+    if (command === 'npx' && args[0] === 'legato' && args[1] === '--help') {
+      return { stdout: 'Usage: legato native doctor\n', stderr: '' };
+    }
+    if (command === 'node' && args[0] === '--input-type=module' && /import\('@ddgutierrezc\/legato-contract'\)/.test(args[2] ?? '')) {
+      return { stdout: 'documented import ok\n', stderr: '' };
+    }
+    if (command === 'node' && args[0] === '--input-type=module' && /legato-contract\/dist\/state\.js/.test(args[2] ?? '')) {
+      const error = new Error('deep import blocked');
+      error.stdout = '';
+      error.stderr = 'Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath is not defined by "exports"';
+      throw error;
+    }
+    if (command === 'npx' && args[0] === 'cap' && args[1] === 'add' && (args[2] === 'ios' || args[2] === 'android')) {
+      await mkdir(join(fixtureRoot, args[2]), { recursive: true });
+      return { stdout: `added ${args[2]}`, stderr: '' };
+    }
+    if (command === 'npx' && args[0] === 'cap' && args[1] === 'sync') {
+      return { stdout: 'sync ok', stderr: '' };
+    }
+    if (command === 'node' && args.some((arg) => /validate-native-artifacts\.mjs$/i.test(arg))) {
+      return { stdout: 'Overall: PASS\n', stderr: '' };
+    }
+    return { stdout: 'ok', stderr: '' };
+  };
+
+  try {
+    const result = await runExternalConsumerValidation({
+      repoRoot,
+      fixtureRoot,
+      artifactsDir,
+      keepFixture: true,
+      commandRunner,
+      skipPack: true,
+    });
+
+    assert.equal(result.status, 'PASS');
+    assert.equal(result.packageEvidence?.capacitor?.bin?.legato, './dist/cli/index.mjs');
+    assert.equal(result.packageEvidence?.contract?.hasBin, false);
+    const joinedCalls = commandCalls.join('\n');
+    assert.match(joinedCalls, /npm install/i);
+    assert.match(joinedCalls, /npx cap sync ios android/i);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('orchestrator captures runtime proof for installed CLI invocation and deep-import rejection', async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), 'legato-external-orchestrator-runtime-proof-'));
+  const artifactsDir = join(tempDir, 'artifacts');
+  const fixtureRoot = join(tempDir, 'fixture');
+  const repoRoot = join(tempDir, 'repo-root');
+  await mkdir(repoRoot, { recursive: true });
+  await mkdir(fixtureRoot, { recursive: true });
+
+  const commandRunner = async ({ command, args }) => {
+    if (command === 'npm' && args[0] === 'install') {
+      await writeFile(join(fixtureRoot, 'package-lock.json'), JSON.stringify({
+        packages: {
+          'node_modules/@ddgutierrezc/legato-capacitor': { resolved: 'https://registry.npmjs.org/@ddgutierrezc/legato-capacitor/-/legato-capacitor-0.1.2.tgz' },
+          'node_modules/@ddgutierrezc/legato-contract': { resolved: 'https://registry.npmjs.org/@ddgutierrezc/legato-contract/-/legato-contract-0.1.2.tgz' },
+        },
+      }), 'utf8');
+      await mkdir(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-capacitor'), { recursive: true });
+      await mkdir(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-contract'), { recursive: true });
+      await writeFile(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-capacitor/package.json'), JSON.stringify({
+        name: '@ddgutierrezc/legato-capacitor',
+        description: 'Capacitor bridge for Legato',
+        main: './dist/index.js',
+        types: './dist/index.d.ts',
+        bin: { legato: './dist/cli/index.mjs' },
+        exports: { '.': { types: './dist/index.d.ts', default: './dist/index.js' } },
+      }), 'utf8');
+      await writeFile(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-contract/package.json'), JSON.stringify({
+        name: '@ddgutierrezc/legato-contract',
+        description: 'Contract package for Legato',
+        main: './dist/index.js',
+        types: './dist/index.d.ts',
+        exports: { '.': { types: './dist/index.d.ts', default: './dist/index.js' } },
+      }), 'utf8');
+      await writeFile(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-capacitor/native-artifacts.json'), '{"ios":{"packageUrl":"https://github.com/ddgutierrezc/legato-ios-core.git","packageName":"LegatoCore","product":"LegatoCore","version":"0.1.1"}}', 'utf8');
+      return { stdout: 'install ok', stderr: '' };
+    }
+    if (command === 'npx' && args[0] === 'legato' && args[1] === '--help') {
+      return { stdout: 'Usage: legato native doctor\n', stderr: '' };
+    }
+    if (command === 'node' && args[0] === '--input-type=module' && /import\('@ddgutierrezc\/legato-contract'\)/.test(args[2] ?? '')) {
+      return { stdout: 'documented import ok\n', stderr: '' };
+    }
+    if (command === 'node' && args[0] === '--input-type=module' && /legato-contract\/dist\/state\.js/.test(args[2] ?? '')) {
+      const error = new Error('deep import blocked');
+      error.stdout = '';
+      error.stderr = 'Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath is not defined by "exports"';
+      throw error;
+    }
+    if (command === 'npx' && args[0] === 'cap' && args[1] === 'add' && (args[2] === 'ios' || args[2] === 'android')) {
+      await mkdir(join(fixtureRoot, args[2]), { recursive: true });
+      return { stdout: `added ${args[2]}`, stderr: '' };
+    }
+    if (command === 'npx' && args[0] === 'cap' && args[1] === 'sync') {
+      return { stdout: 'sync ok', stderr: '' };
+    }
+    if (command === 'node' && args.some((arg) => /validate-native-artifacts\.mjs$/i.test(arg))) {
+      return { stdout: 'Overall: PASS\n', stderr: '' };
+    }
+    return { stdout: 'ok', stderr: '' };
+  };
+
+  try {
+    const result = await runExternalConsumerValidation({
+      repoRoot,
+      fixtureRoot,
+      artifactsDir,
+      keepFixture: true,
+      commandRunner,
+      skipPack: true,
+    });
+
+    assert.equal(result.status, 'PASS');
+    assert.equal(result.runtimeProof?.cliHelp?.status, 'PASS');
+    assert.equal(result.runtimeProof?.documentedImport?.status, 'PASS');
+    assert.equal(result.runtimeProof?.deepImportRejection?.status, 'PASS');
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('orchestrator fails when undocumented deep import resolves unexpectedly', async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), 'legato-external-orchestrator-deep-import-')); 
+  const artifactsDir = join(tempDir, 'artifacts');
+  const fixtureRoot = join(tempDir, 'fixture');
+  const repoRoot = join(tempDir, 'repo-root');
+  await mkdir(repoRoot, { recursive: true });
+  await mkdir(fixtureRoot, { recursive: true });
+
+  const commandRunner = async ({ command, args }) => {
+    if (command === 'npm' && args[0] === 'install') {
+      await writeFile(join(fixtureRoot, 'package-lock.json'), JSON.stringify({
+        packages: {
+          'node_modules/@ddgutierrezc/legato-capacitor': { resolved: 'https://registry.npmjs.org/@ddgutierrezc/legato-capacitor/-/legato-capacitor-0.1.2.tgz' },
+          'node_modules/@ddgutierrezc/legato-contract': { resolved: 'https://registry.npmjs.org/@ddgutierrezc/legato-contract/-/legato-contract-0.1.2.tgz' },
+        },
+      }), 'utf8');
+      await mkdir(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-capacitor'), { recursive: true });
+      await mkdir(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-contract'), { recursive: true });
+      await writeFile(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-capacitor/package.json'), JSON.stringify({
+        name: '@ddgutierrezc/legato-capacitor',
+        description: 'Capacitor bridge for Legato',
+        main: './dist/index.js',
+        types: './dist/index.d.ts',
+        bin: { legato: './dist/cli/index.mjs' },
+        exports: { '.': { types: './dist/index.d.ts', default: './dist/index.js' } },
+      }), 'utf8');
+      await writeFile(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-contract/package.json'), JSON.stringify({
+        name: '@ddgutierrezc/legato-contract',
+        description: 'Contract package for Legato',
+        main: './dist/index.js',
+        types: './dist/index.d.ts',
+        exports: { '.': { types: './dist/index.d.ts', default: './dist/index.js' } },
+      }), 'utf8');
+      await writeFile(join(fixtureRoot, 'node_modules/@ddgutierrezc/legato-capacitor/native-artifacts.json'), '{"ios":{"packageUrl":"https://github.com/ddgutierrezc/legato-ios-core.git","packageName":"LegatoCore","product":"LegatoCore","version":"0.1.1"}}', 'utf8');
+      return { stdout: 'install ok', stderr: '' };
+    }
+    if (command === 'npx' && args[0] === 'legato' && args[1] === '--help') {
+      return { stdout: 'Usage: legato native doctor\n', stderr: '' };
+    }
+    if (command === 'node' && args[0] === '--input-type=module' && /import\('@ddgutierrezc\/legato-contract'\)/.test(args[2] ?? '')) {
+      return { stdout: 'documented import ok\n', stderr: '' };
+    }
+    if (command === 'node' && args[0] === '--input-type=module' && /legato-contract\/dist\/state\.js/.test(args[2] ?? '')) {
+      return { stdout: 'unexpected success\n', stderr: '' };
+    }
+    if (command === 'npx' && args[0] === 'cap' && args[1] === 'add' && (args[2] === 'ios' || args[2] === 'android')) {
+      await mkdir(join(fixtureRoot, args[2]), { recursive: true });
+      return { stdout: `added ${args[2]}`, stderr: '' };
+    }
+    if (command === 'npx' && args[0] === 'cap' && args[1] === 'sync') {
+      return { stdout: 'sync ok', stderr: '' };
+    }
+    if (command === 'node' && args.some((arg) => /validate-native-artifacts\.mjs$/i.test(arg))) {
+      return { stdout: 'Overall: PASS\n', stderr: '' };
+    }
+    return { stdout: 'ok', stderr: '' };
+  };
+
+  try {
+    const result = await runExternalConsumerValidation({
+      repoRoot,
+      fixtureRoot,
+      artifactsDir,
+      keepFixture: true,
+      commandRunner,
+      skipPack: true,
+    });
+
+    assert.equal(result.status, 'FAIL');
+    assert.match(result.failures.join('\n'), /undocumented deep import|ERR_PACKAGE_PATH_NOT_EXPORTED/i);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/apps/capacitor-demo/scripts/run-npm-readiness.mjs
+++ b/apps/capacitor-demo/scripts/run-npm-readiness.mjs
@@ -147,6 +147,7 @@ export const runNpmReadiness = async ({ packageTarget = 'capacitor', commandRunn
     args: [
       resolve(scriptDir, 'run-external-consumer-validation.mjs'),
       '--skip-pack',
+      '--proof-mode', 'npm-readiness',
       '--tarball-contract', contractResult.tarballPath,
       '--tarball-capacitor', capacitorResult.tarballPath,
       '--artifacts-dir', resolve(artifactsRoot, 'external-consumer'),

--- a/apps/capacitor-demo/scripts/run-npm-readiness.mjs
+++ b/apps/capacitor-demo/scripts/run-npm-readiness.mjs
@@ -52,35 +52,55 @@ const normalizePackageTarget = (packageTarget) => {
   return normalized;
 };
 
-export const runNpmReadiness = async ({ packageTarget = 'capacitor' } = {}) => {
+export const runNpmReadiness = async ({ packageTarget = 'capacitor', commandRunner = runCommand } = {}) => {
   const normalizedPackageTarget = normalizePackageTarget(packageTarget);
   await mkdir(tarballDir, { recursive: true });
 
-  await runCommand({
+  await commandRunner({
     command: 'npm',
     args: ['install', '--no-package-lock'],
     cwd: resolve(repoRoot, 'packages/contract'),
   });
 
-  await runCommand({
+  await commandRunner({
     command: 'npm',
     args: ['install', '--no-package-lock'],
     cwd: resolve(repoRoot, 'packages/capacitor'),
   });
 
-  await runCommand({
+  await commandRunner({
     command: 'npm',
     args: ['run', 'build'],
     cwd: resolve(repoRoot, 'packages/contract'),
   });
 
-  await runCommand({
+  await commandRunner({
     command: 'npm',
     args: ['run', 'build'],
     cwd: resolve(repoRoot, 'packages/capacitor'),
   });
 
-  const contractInspection = await runCommand({
+  await commandRunner({
+    command: 'node',
+    args: [
+      resolve(repoRoot, 'packages/capacitor/scripts/assert-package-entries.mjs'),
+      '--package-root', resolve(repoRoot, 'packages/contract'),
+      '--profile', 'contract',
+    ],
+    cwd: repoRoot,
+  });
+
+  await commandRunner({
+    command: 'node',
+    args: [
+      resolve(repoRoot, 'packages/capacitor/scripts/assert-package-entries.mjs'),
+      '--package-root', resolve(repoRoot, 'packages/capacitor'),
+      '--profile', 'capacitor',
+    ],
+    cwd: repoRoot,
+  });
+
+  const contractInspection = await commandRunner({
     command: 'node',
     args: [
       resolve(repoRoot, 'packages/capacitor/scripts/inspect-tarball.mjs'),
@@ -92,7 +112,7 @@ export const runNpmReadiness = async ({ packageTarget = 'capacitor' } = {}) => {
     cwd: repoRoot,
   });
 
-  const capacitorInspection = await runCommand({
+  const capacitorInspection = await commandRunner({
     command: 'node',
     args: [
       resolve(repoRoot, 'packages/capacitor/scripts/inspect-tarball.mjs'),
@@ -122,7 +142,7 @@ export const runNpmReadiness = async ({ packageTarget = 'capacitor' } = {}) => {
 
   const capacitorResult = parseJsonOutput(capacitorInspection.stdout);
 
-  const externalValidation = await runCommand({
+  const externalValidation = await commandRunner({
     command: 'node',
     args: [
       resolve(scriptDir, 'run-external-consumer-validation.mjs'),

--- a/apps/capacitor-demo/scripts/run-npm-readiness.test.mjs
+++ b/apps/capacitor-demo/scripts/run-npm-readiness.test.mjs
@@ -46,6 +46,9 @@ test('npm readiness runs ergonomics validation for both packages before tarball 
   assert.equal(capacitorErgonomicsIndex > -1, true);
   assert.equal(firstInspectIndex > contractErgonomicsIndex, true);
   assert.equal(firstInspectIndex > capacitorErgonomicsIndex, true);
+
+  const externalValidationCall = calls.find((call) => /run-external-consumer-validation\.mjs/i.test(call));
+  assert.match(externalValidationCall ?? '', /--proof-mode npm-readiness/i);
 });
 
 test('npm readiness propagates ergonomics validator failures', async () => {

--- a/apps/capacitor-demo/scripts/run-npm-readiness.test.mjs
+++ b/apps/capacitor-demo/scripts/run-npm-readiness.test.mjs
@@ -9,3 +9,57 @@ test('npm readiness rejects unsupported package target values before running com
     /package_target must be one of capacitor, contract/i,
   );
 });
+
+test('npm readiness runs ergonomics validation for both packages before tarball inspection', async () => {
+  const calls = [];
+  const commandRunner = async ({ command, args }) => {
+    calls.push([command, ...args].join(' '));
+
+    if (command === 'node' && args.some((arg) => /assert-package-entries\.mjs$/i.test(arg))) {
+      return { stdout: JSON.stringify({ status: 'PASS' }), stderr: '', exitCode: 0 };
+    }
+    if (command === 'node' && args.some((arg) => /inspect-tarball\.mjs$/i.test(arg))) {
+      const profile = args[args.indexOf('--profile') + 1];
+      return {
+        stdout: JSON.stringify({ status: 'PASS', profile, tarballPath: `/tmp/${profile}.tgz` }),
+        stderr: '',
+        exitCode: 0,
+      };
+    }
+    if (command === 'node' && args.some((arg) => /run-external-consumer-validation\.mjs$/i.test(arg))) {
+      return { stdout: JSON.stringify({ status: 'PASS', exitCode: 0 }), stderr: '', exitCode: 0 };
+    }
+
+    return { stdout: '', stderr: '', exitCode: 0 };
+  };
+
+  const result = await runNpmReadiness({ packageTarget: 'capacitor', commandRunner });
+  assert.equal(result.readiness_profile, 'capacitor-cross-package');
+
+  const ergonomicsCalls = calls.filter((call) => /assert-package-entries\.mjs/i.test(call));
+  assert.equal(ergonomicsCalls.length, 2);
+  const contractErgonomicsIndex = calls.findIndex((call) => /assert-package-entries\.mjs.*--profile contract/i.test(call));
+  const capacitorErgonomicsIndex = calls.findIndex((call) => /assert-package-entries\.mjs.*--profile capacitor/i.test(call));
+  const firstInspectIndex = calls.findIndex((call) => /inspect-tarball\.mjs/i.test(call));
+
+  assert.equal(contractErgonomicsIndex > -1, true);
+  assert.equal(capacitorErgonomicsIndex > -1, true);
+  assert.equal(firstInspectIndex > contractErgonomicsIndex, true);
+  assert.equal(firstInspectIndex > capacitorErgonomicsIndex, true);
+});
+
+test('npm readiness propagates ergonomics validator failures', async () => {
+  const commandRunner = async ({ command, args }) => {
+    if (command === 'node' && args.some((arg) => /assert-package-entries\.mjs$/i.test(arg))) {
+      const error = new Error('Command failed');
+      error.stdout = '{"status":"FAIL","failures":["README missing"]}';
+      throw error;
+    }
+    return { stdout: '', stderr: '', exitCode: 0 };
+  };
+
+  await assert.rejects(
+    runNpmReadiness({ packageTarget: 'contract', commandRunner }),
+    /README missing|Command failed/i,
+  );
+});

--- a/packages/capacitor/README.md
+++ b/packages/capacitor/README.md
@@ -2,6 +2,32 @@
 
 Modern Capacitor binding MVP for Legato.
 
+## npm quickstart
+
+```bash
+npm install @ddgutierrezc/legato-capacitor @ddgutierrezc/legato-contract
+```
+
+First invocation:
+
+```bash
+npx legato native doctor
+```
+
+Audience and prerequisites:
+
+- Intended audience: maintainers/integrators working in the Legato repository layout.
+- Requires a supported Node.js + npm toolchain and a Capacitor project context.
+- `legato native` is a repo-owned maintainer helper, not a generic consumer bootstrap CLI.
+- Unsupported environment disclosure: non-LTS or end-of-life Node.js runtimes are not supported for this onboarding path.
+- Remediation: use a supported Node.js LTS release (and matching npm), then rerun install + `npx legato native doctor`.
+
+## Non-goals for npm ergonomics v1
+
+- Non-goal: runtime behavior expansion.
+- Non-goal: release-lane redesign.
+- Non-goal: platform bootstrap automation beyond current safe patch checks.
+
 ## API surface (v1 boundary split, additive)
 
 `@ddgutierrezc/legato-capacitor` now exposes three public entry points over the same Capacitor plugin instance:

--- a/packages/capacitor/package.json
+++ b/packages/capacitor/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@ddgutierrezc/legato-capacitor",
   "version": "0.1.2",
-  "description": "Capacitor binding MVP for Legato.",
+  "description": "Capacitor bridge package for Legato host apps, including the repo-owned `legato native` maintainer CLI.",
   "author": "Legato",
-  "homepage": "https://github.com/legato/legato",
+  "homepage": "https://github.com/ddgutierrezc/legato/tree/main/packages/capacitor#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/ddgutierrezc/legato.git",
@@ -11,6 +11,13 @@
   },
   "license": "MIT",
   "type": "module",
+  "keywords": [
+    "legato",
+    "capacitor",
+    "audio",
+    "media-session",
+    "plugin"
+  ],
   "bin": {
     "legato": "./dist/cli/index.mjs"
   },
@@ -35,7 +42,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json && node ./scripts/copy-cli-to-dist.mjs && npm run readiness:entries",
     "typecheck": "tsc --noEmit",
-    "readiness:entries": "node ./scripts/assert-package-entries.mjs --package-root .",
+    "readiness:entries": "node ./scripts/assert-package-entries.mjs --package-root . --profile capacitor",
     "pack:check": "npm run build && node ./scripts/inspect-tarball.mjs --package-root . --profile capacitor",
     "promote:ios-distribution": "node ./scripts/promote-ios-distribution.mjs",
     "sync:native-artifacts": "node ./scripts/sync-native-artifacts.mjs",
@@ -47,7 +54,7 @@
   },
   "devDependencies": {
     "@capacitor/core": "^8.0.0",
-    "@ddgutierrezc/legato-contract": "file:../contract",
+    "@ddgutierrezc/legato-contract": "^0.1.2",
     "typescript": "^5.6.3"
   },
   "capacitor": {

--- a/packages/capacitor/scripts/__tests__/native-setup-cli.test.mjs
+++ b/packages/capacitor/scripts/__tests__/native-setup-cli.test.mjs
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { runNativeCli } from '../../src/cli/native-setup-cli.mjs';
+
+const createWritable = () => {
+  let value = '';
+  return {
+    write(chunk) {
+      value += String(chunk);
+    },
+    toString() {
+      return value;
+    },
+  };
+};
+
+test('native CLI help clarifies maintainer audience and non-goals', async () => {
+  const stdout = createWritable();
+  const stderr = createWritable();
+
+  const result = await runNativeCli({
+    args: ['--help'],
+    cwd: process.cwd(),
+    stdout,
+    stderr,
+  });
+
+  assert.equal(result.exitCode, 1);
+  const usage = stderr.toString();
+  assert.match(usage, /repo-owned|maintainer/i);
+  assert.match(usage, /not a general consumer bootstrap cli|non-goal/i);
+  assert.match(usage, /does not mutate Capacitor-generated files|CapApp-SPM/i);
+});

--- a/packages/capacitor/scripts/__tests__/package-ergonomics.test.mjs
+++ b/packages/capacitor/scripts/__tests__/package-ergonomics.test.mjs
@@ -1,0 +1,98 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { validatePackageErgonomics } from '../assert-package-entries.mjs';
+
+const writeJson = (path, value) => writeFile(path, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+
+const createPackageRoot = async ({ packageJson, readme }) => {
+  const packageRoot = await mkdtemp(join(tmpdir(), 'legato-package-ergonomics-'));
+  await mkdir(join(packageRoot, 'dist', 'cli'), { recursive: true });
+  await writeFile(join(packageRoot, 'dist', 'index.js'), 'export default {}\n', 'utf8');
+  await writeFile(join(packageRoot, 'dist', 'index.d.ts'), 'export {};\n', 'utf8');
+  await writeFile(join(packageRoot, 'dist', 'cli', 'index.mjs'), 'console.log("ok")\n', 'utf8');
+  await writeJson(join(packageRoot, 'package.json'), packageJson);
+  if (typeof readme === 'string') {
+    await writeFile(join(packageRoot, 'README.md'), readme, 'utf8');
+  }
+  return packageRoot;
+};
+
+test('ergonomics validator passes capacitor profile with metadata/readme/bin alignment', async () => {
+  const packageRoot = await createPackageRoot({
+    packageJson: {
+      name: '@ddgutierrezc/legato-capacitor',
+      description: 'Capacitor plugin for Legato host apps.',
+      homepage: 'https://github.com/ddgutierrezc/legato#readme',
+      repository: { type: 'git', url: 'https://github.com/ddgutierrezc/legato.git' },
+      main: './dist/index.js',
+      types: './dist/index.d.ts',
+      exports: { '.': { default: './dist/index.js', types: './dist/index.d.ts' } },
+      bin: { legato: './dist/cli/index.mjs' },
+      keywords: ['legato', 'capacitor', 'audio'],
+      files: ['dist', 'README.md'],
+    },
+    readme: '# @ddgutierrezc/legato-capacitor\n\nRun `legato native doctor` in the maintainer repo.\n',
+  });
+
+  try {
+    const result = await validatePackageErgonomics({ packageRoot, profile: 'capacitor' });
+    assert.equal(result.status, 'PASS');
+    assert.equal(result.failures.length, 0);
+  } finally {
+    await rm(packageRoot, { recursive: true, force: true });
+  }
+});
+
+test('ergonomics validator fails contract profile when bin is declared', async () => {
+  const packageRoot = await createPackageRoot({
+    packageJson: {
+      name: '@ddgutierrezc/legato-contract',
+      description: 'Contract package for Legato.',
+      homepage: 'https://github.com/ddgutierrezc/legato#readme',
+      repository: { type: 'git', url: 'https://github.com/ddgutierrezc/legato.git' },
+      main: './dist/index.js',
+      types: './dist/index.d.ts',
+      exports: { '.': { default: './dist/index.js', types: './dist/index.d.ts' } },
+      bin: { legato: './dist/cli/index.mjs' },
+      keywords: ['legato', 'contract'],
+      files: ['dist', 'README.md'],
+    },
+    readme: '# @ddgutierrezc/legato-contract\n\nLibrary-only package.\n',
+  });
+
+  try {
+    const result = await validatePackageErgonomics({ packageRoot, profile: 'contract' });
+    assert.equal(result.status, 'FAIL');
+    assert.match(result.failures.join('\n'), /must not declare bin/i);
+  } finally {
+    await rm(packageRoot, { recursive: true, force: true });
+  }
+});
+
+test('ergonomics validator fails when README is missing from files and package root', async () => {
+  const packageRoot = await createPackageRoot({
+    packageJson: {
+      name: '@ddgutierrezc/legato-contract',
+      description: 'Contract package for Legato.',
+      homepage: 'https://github.com/ddgutierrezc/legato#readme',
+      repository: { type: 'git', url: 'https://github.com/ddgutierrezc/legato.git' },
+      main: './dist/index.js',
+      types: './dist/index.d.ts',
+      exports: { '.': { default: './dist/index.js', types: './dist/index.d.ts' } },
+      keywords: ['legato', 'contract'],
+      files: ['dist'],
+    },
+  });
+
+  try {
+    const result = await validatePackageErgonomics({ packageRoot, profile: 'contract' });
+    assert.equal(result.status, 'FAIL');
+    assert.match(result.failures.join('\n'), /README\.md/i);
+  } finally {
+    await rm(packageRoot, { recursive: true, force: true });
+  }
+});

--- a/packages/capacitor/scripts/assert-package-entries.mjs
+++ b/packages/capacitor/scripts/assert-package-entries.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const defaultPackageRoot = resolve(scriptDir, '..');
+const VALID_PROFILES = new Set(['capacitor', 'contract']);
 
 const normalizeRelativePath = (value) => value.replaceAll('\\', '/').replace(/^\.\//, '');
 
@@ -40,6 +41,119 @@ const readPackageJson = async (packageRoot) => {
   return JSON.parse(raw);
 };
 
+const hasString = (value) => typeof value === 'string' && value.trim().length > 0;
+
+const normalizeKeyword = (value) => String(value ?? '').trim().toLowerCase();
+
+const detectProfile = ({ profile, packageJson }) => {
+  const explicit = String(profile ?? '').trim().toLowerCase();
+  if (VALID_PROFILES.has(explicit)) {
+    return explicit;
+  }
+
+  const packageName = String(packageJson?.name ?? '').toLowerCase();
+  if (packageName.includes('legato-capacitor')) {
+    return 'capacitor';
+  }
+  if (packageName.includes('legato-contract')) {
+    return 'contract';
+  }
+  return null;
+};
+
+const mentionsLegatoCli = (readmeRaw) => /`?legato`?\s+native|\blegato\s+native\b/i.test(readmeRaw);
+
+export const validatePackageErgonomics = async ({ packageRoot, profile } = {}) => {
+  const resolvedPackageRoot = resolve(packageRoot ?? defaultPackageRoot);
+  const packageJson = await readPackageJson(resolvedPackageRoot);
+  const resolvedProfile = detectProfile({ profile, packageJson });
+  const failures = [];
+
+  const requiredStringFields = ['description', 'homepage'];
+  for (const field of requiredStringFields) {
+    if (!hasString(packageJson[field])) {
+      failures.push(`Metadata field is required: ${field}`);
+    }
+  }
+
+  const repository = packageJson.repository;
+  const repositoryValid = hasString(repository)
+    || (repository && typeof repository === 'object' && hasString(repository.url));
+  if (!repositoryValid) {
+    failures.push('Metadata field is required: repository (string or object with url).');
+  }
+
+  const keywords = Array.isArray(packageJson.keywords) ? packageJson.keywords : [];
+  if (keywords.length === 0) {
+    failures.push('Metadata field is required: keywords (non-empty array).');
+  }
+
+  const files = Array.isArray(packageJson.files) ? packageJson.files : [];
+  if (files.length === 0) {
+    failures.push('Metadata field is required: files (non-empty array).');
+  }
+
+  const hasReadmeInFiles = files.some((entry) => normalizeRelativePath(String(entry)).toLowerCase() === 'readme.md');
+  if (!hasReadmeInFiles) {
+    failures.push('Published files must include README.md.');
+  }
+
+  const readmePath = resolve(resolvedPackageRoot, 'README.md');
+  const readmeExists = await pathExists(readmePath);
+  if (!readmeExists) {
+    failures.push('README.md must exist at package root.');
+  }
+
+  const readmeRaw = readmeExists ? await readFile(readmePath, 'utf8') : '';
+  const packageBin = packageJson.bin;
+  const hasBin = Boolean(packageBin && typeof packageBin === 'object' && Object.keys(packageBin).length > 0);
+
+  if (resolvedProfile === 'capacitor') {
+    const normalizedKeywords = new Set(keywords.map((value) => normalizeKeyword(value)));
+    for (const keyword of ['legato', 'capacitor']) {
+      if (!normalizedKeywords.has(keyword)) {
+        failures.push(`Capacitor profile keyword missing: ${keyword}`);
+      }
+    }
+
+    const legatoBin = packageBin?.legato;
+    if (!hasString(legatoBin)) {
+      failures.push('Capacitor profile must declare bin.legato as a string path.');
+    }
+
+    if (!mentionsLegatoCli(readmeRaw)) {
+      failures.push('Capacitor README must document the `legato` CLI scope.');
+    }
+  }
+
+  if (resolvedProfile === 'contract') {
+    const normalizedKeywords = new Set(keywords.map((value) => normalizeKeyword(value)));
+    for (const keyword of ['legato', 'contract']) {
+      if (!normalizedKeywords.has(keyword)) {
+        failures.push(`Contract profile keyword missing: ${keyword}`);
+      }
+    }
+
+    if (hasBin) {
+      failures.push('Contract profile must not declare bin metadata.');
+    }
+
+    if (mentionsLegatoCli(readmeRaw)) {
+      failures.push('Contract README/docs must not advertise `legato` CLI commands.');
+    }
+  }
+
+  const status = failures.length === 0 ? 'PASS' : 'FAIL';
+  return {
+    status,
+    exitCode: status === 'PASS' ? 0 : 1,
+    packageName: packageJson.name,
+    packageRoot: resolvedPackageRoot,
+    profile: resolvedProfile,
+    failures,
+  };
+};
+
 export const collectDeclaredEntrypoints = (packageJson) => {
   const candidates = [
     packageJson.main,
@@ -51,7 +165,7 @@ export const collectDeclaredEntrypoints = (packageJson) => {
   return [...new Set(allValues.map((value) => normalizeRelativePath(value)))];
 };
 
-export const validatePackageEntrypoints = async ({ packageRoot, requireDistPrefix = true } = {}) => {
+export const validatePackageEntrypoints = async ({ packageRoot, requireDistPrefix = true, profile } = {}) => {
   const resolvedPackageRoot = resolve(packageRoot ?? defaultPackageRoot);
   const packageJson = await readPackageJson(resolvedPackageRoot);
   const failures = [];
@@ -79,13 +193,17 @@ export const validatePackageEntrypoints = async ({ packageRoot, requireDistPrefi
   }
 
   const status = failures.length === 0 ? 'PASS' : 'FAIL';
+  const ergonomics = await validatePackageErgonomics({ packageRoot: resolvedPackageRoot, profile });
+  const mergedFailures = [...failures, ...ergonomics.failures];
+  const mergedStatus = mergedFailures.length === 0 ? 'PASS' : 'FAIL';
   return {
-    status,
-    exitCode: status === 'PASS' ? 0 : 1,
+    status: mergedStatus,
+    exitCode: mergedStatus === 'PASS' ? 0 : 1,
     packageName: packageJson.name,
     packageRoot: resolvedPackageRoot,
     entrypoints,
-    failures,
+    profile: ergonomics.profile,
+    failures: mergedFailures,
   };
 };
 
@@ -93,6 +211,7 @@ const parseArgs = (argv) => {
   const options = {
     packageRoot: defaultPackageRoot,
     requireDistPrefix: true,
+    profile: undefined,
   };
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -104,6 +223,11 @@ const parseArgs = (argv) => {
     }
     if (arg === '--allow-non-dist') {
       options.requireDistPrefix = false;
+      continue;
+    }
+    if (arg === '--profile' && argv[i + 1]) {
+      options.profile = argv[i + 1];
+      i += 1;
     }
   }
 

--- a/packages/capacitor/src/cli/native-setup-cli.mjs
+++ b/packages/capacitor/src/cli/native-setup-cli.mjs
@@ -57,8 +57,10 @@ function printUsage(stderr) {
       '  legato native configure --apply [--json]',
       '',
       'Notes:',
+      '  - This is a repo-owned maintainer CLI, not a general consumer bootstrap CLI.',
       '  - configure defaults to no-op unless one of --dry-run/--apply is passed.',
       '  - apply only touches the repo-owned safe patch set.',
+      '  - It does not mutate Capacitor-generated files (for example, ios/App/CapApp-SPM/**).',
     ].join('\n'),
   );
   stderr.write('\n');

--- a/packages/contract/README.md
+++ b/packages/contract/README.md
@@ -1,0 +1,33 @@
+# @ddgutierrezc/legato-contract
+
+Library-only contract package for Legato shared types, events, and invariants.
+
+## Install
+
+```bash
+npm install @ddgutierrezc/legato-contract
+```
+
+## First import
+
+```ts
+import { LEGATO_EVENTS } from '@ddgutierrezc/legato-contract';
+```
+
+## Package role boundary
+
+- This package is library-only and does not ship a CLI.
+- If you need the `legato` command, install `@ddgutierrezc/legato-capacitor` instead.
+
+## Runtime prerequisites
+
+- Supported Node.js + npm environment for your project toolchain.
+- No Capacitor runtime/plugin bootstrap commands are provided by this package.
+- Unsupported environment disclosure: non-LTS or end-of-life Node.js runtimes are not supported for this package onboarding guidance.
+- Remediation: upgrade to a supported Node.js LTS release and reinstall dependencies.
+
+## Non-goals for this change
+
+- Non-goal: runtime behavior expansion.
+- Non-goal: release-lane redesign.
+- Non-goal: platform bootstrap automation.

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@ddgutierrezc/legato-contract",
   "version": "0.1.2",
-  "description": "Canonical contract types and constants for Legato.",
+  "description": "Library-only contract package for Legato types, events, and invariants.",
+  "homepage": "https://github.com/ddgutierrezc/legato/tree/main/packages/contract#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/ddgutierrezc/legato.git",
@@ -9,6 +10,12 @@
   },
   "license": "MIT",
   "type": "module",
+  "keywords": [
+    "legato",
+    "contract",
+    "typescript",
+    "events"
+  ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
@@ -18,12 +25,13 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc --noEmit",
-    "readiness:entries": "node ../capacitor/scripts/assert-package-entries.mjs --package-root .",
+    "readiness:entries": "node ../capacitor/scripts/assert-package-entries.mjs --package-root . --profile contract",
     "pack:check": "npm run build && npm run readiness:entries && node ../capacitor/scripts/inspect-tarball.mjs --package-root . --profile contract"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #60

## Summary
- clarify consumer-facing npm package roles, onboarding docs, and maintainer-only CLI scope
- harden package metadata/bin/readme contracts with focused ergonomics validators and tests
- preserve current consumer-adoption flow while adding runtime proof for installed CLI behavior and deep-import rejection

## Changes
| File | Change |
|------|--------|
| `packages/capacitor/package.json` | tighten npm metadata, discoverability, and package contract expectations |
| `packages/contract/package.json` | align contract package metadata for published consumption |
| `packages/contract/README.md` | add contract-specific consumer-facing README |
| `packages/capacitor/README.md`, `README.md` | clarify package roles, install guidance, and CLI scope |
| `packages/capacitor/src/cli/native-setup-cli.mjs` | clarify CLI audience/non-goals in help text |
| `packages/capacitor/scripts/assert-package-entries.mjs` | add package ergonomics validation guards |
| `packages/capacitor/scripts/__tests__/*` | add targeted ergonomics and CLI tests |
| `apps/capacitor-demo/scripts/run-npm-readiness.mjs` | preserve readiness while validating ergonomics contracts |
| `apps/capacitor-demo/scripts/run-external-consumer-validation.mjs` | add runtime proof for installed CLI behavior and deep-import rejection |
| `apps/capacitor-demo/scripts/npm-package-ergonomics-docs.test.mjs` | add docs scope-lock tests |

## Test Plan
- [x] `node --test packages/capacitor/scripts/__tests__/package-ergonomics.test.mjs packages/capacitor/scripts/__tests__/native-setup-cli.test.mjs apps/capacitor-demo/scripts/npm-package-ergonomics-docs.test.mjs apps/capacitor-demo/scripts/run-npm-readiness.test.mjs apps/capacitor-demo/scripts/run-external-consumer-validation.test.mjs`
- [x] Focused npm ergonomics/spec scenarios verified locally
- [x] No shell scripts changed

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Docs updated for behavior/packaging clarity changes
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers