### PR TITLE
fix(validation): persist external consumer parity evidence

### DIFF
--- a/apps/capacitor-demo/scripts/external-consumer-validation-v1-docs.test.mjs
+++ b/apps/capacitor-demo/scripts/external-consumer-validation-v1-docs.test.mjs
@@ -6,21 +6,43 @@ import { fileURLToPath } from 'node:url';
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const docsPath = resolve(currentDir, '../../../docs/releases/external-consumer-validation-v1.md');
+const evidencePath = resolve(currentDir, '../../../docs/releases/external-consumer-validation-v2-evidence.md');
 
-test('external consumer runbook states v1 boundaries and non-goals', async () => {
+test('external consumer runbook states v2 registry-first boundaries and non-goals', async () => {
   const runbook = await readFile(docsPath, 'utf8');
 
-  assert.match(runbook, /NOT publication proof/i);
-  assert.match(runbook, /outside the monorepo/i);
-  assert.match(runbook, /npm pack/i);
+  assert.match(runbook, /Registry-first release gate/i);
+  assert.match(runbook, /manual proof in `\/Volumes\/S3\/daniel\/github\/legato-consumer-smoke`/i);
+  assert.match(runbook, /Do NOT use `file:`.*workspace.*tarball.*link/i);
 });
 
-test('external consumer runbook includes deterministic command sequence and artifact outputs', async () => {
+test('external consumer runbook includes phase 0 npm-view gate and phase 1 evidence contract', async () => {
   const runbook = await readFile(docsPath, 'utf8');
 
-  assert.match(runbook, /npm run build/i);
-  assert.match(runbook, /npm run validate:external:consumer/i);
-  assert.match(runbook, /npm run capture:release:native-artifacts/i);
-  assert.match(runbook, /artifacts\/external-consumer-validation-v1\/summary\.json/i);
-  assert.match(runbook, /artifacts\/release-native-artifact-foundation-v1\/manifest\.json/i);
+  assert.match(runbook, /npm view @ddgutierrezc\/legato-capacitor version peerDependencies --json/i);
+  assert.match(runbook, /npm view @ddgutierrezc\/legato-contract versions --json/i);
+  assert.match(runbook, /npx cap add android/i);
+  assert.match(runbook, /npx cap sync ios android/i);
+  assert.match(runbook, /packageClassList/i);
+  assert.match(runbook, /run-external-consumer-validation\.mjs/i);
+});
+
+test('runbook reflects current 0.1.2 registry truth and current proof path', async () => {
+  const runbook = await readFile(docsPath, 'utf8');
+
+  assert.match(runbook, /Observed contract versions:\s*`\["0\.1\.1",\s*"0\.1\.2"\]`/i);
+  assert.match(runbook, /Current compatible pair for active proof/i);
+  assert.match(runbook, /`@ddgutierrezc\/legato-capacitor@0\.1\.2`/i);
+  assert.match(runbook, /`@ddgutierrezc\/legato-contract@0\.1\.2`/i);
+  assert.match(runbook, /npm install --no-audit --no-fund @ddgutierrezc\/legato-contract@0\.1\.2 @ddgutierrezc\/legato-capacitor@0\.1\.2/i);
+  assert.doesNotMatch(runbook, /Compatible published pair.*0\.1\.1\s*\+\s*0\.1\.1/i);
+});
+
+test('evidence document reflects 0.1.2 parity and no stale 0.1.1-only baseline', async () => {
+  const evidence = await readFile(evidencePath, 'utf8');
+
+  assert.match(evidence, /\[\s*"0\.1\.1",\s*"0\.1\.2"\s*\]/i);
+  assert.match(evidence, /Current compatible published pair:\s*`@ddgutierrezc\/legato-capacitor@0\.1\.2`\s*\+\s*`@ddgutierrezc\/legato-contract@0\.1\.2`/i);
+  assert.match(evidence, /--registry-capacitor @ddgutierrezc\/legato-capacitor@0\.1\.2 --registry-contract @ddgutierrezc\/legato-contract@0\.1\.2/i);
+  assert.doesNotMatch(evidence, /Compatible published pair used for proof:\s*`@ddgutierrezc\/legato-capacitor@0\.1\.1`\s*\+\s*`@ddgutierrezc\/legato-contract@0\.1\.1`/i);
 });

--- a/apps/capacitor-demo/scripts/validate-native-artifacts.mjs
+++ b/apps/capacitor-demo/scripts/validate-native-artifacts.mjs
@@ -144,6 +144,11 @@ function makeUnresolvedCoordinatePattern(coordinate) {
   return new RegExp(`Could not find\\s+${escapeRegExp(coordinate)}(?:\\.|\\s|$)`, 'i');
 }
 
+function parseCapAppSpmLegatoPackageName(capAppSpmPackageSwift) {
+  const match = capAppSpmPackageSwift.match(/\.package\(name:\s*"([^"]+)",\s*path:\s*"[^"]*node_modules\/@ddgutierrezc\/legato-capacitor"\)/);
+  return match?.[1] ?? null;
+}
+
 export const validateNativeArtifacts = ({
   pluginBuildGradle,
   nativeArtifactsContractJson = '',
@@ -178,6 +183,12 @@ export const validateNativeArtifacts = ({
 
   const unresolvedCoordinatePattern = makeUnresolvedCoordinatePattern(expectedAndroidCoordinate);
   const iosExactRemoteDependencyPattern = makeIosExactRemoteDependencyPattern(expectedIosContract);
+  const capAppSpmLegatoPackageName = capAppSpmPackageSwift
+    ? parseCapAppSpmLegatoPackageName(capAppSpmPackageSwift)
+    : null;
+  const capAppSpmLegatoProductPattern = capAppSpmLegatoPackageName
+    ? new RegExp(`\\.product\\(name:\\s*"${escapeRegExp(capAppSpmLegatoPackageName)}",\\s*package:\\s*"${escapeRegExp(capAppSpmLegatoPackageName)}"\\)`)
+    : null;
 
   if (LOCAL_PROJECT_DEPENDENCY_PATTERN.test(pluginBuildGradle)) {
     failures.push("Local-project regression detected in plugin dependency graph: remove project(':native:android:core') and keep artifact coordinates only.");
@@ -222,6 +233,14 @@ export const validateNativeArtifacts = ({
     failures.push('CapApp-SPM regression detected: remove manual local LegatoCore path wiring and keep generated package dependencies only.');
   }
 
+  if (capAppSpmPackageSwift && !capAppSpmLegatoPackageName) {
+    failures.push('CapApp-SPM regression detected: expected generated Legato package dependency pointing to node_modules/@ddgutierrezc/legato-capacitor.');
+  }
+
+  if (capAppSpmPackageSwift && capAppSpmLegatoProductPattern && !capAppSpmLegatoProductPattern.test(capAppSpmPackageSwift)) {
+    failures.push(`CapApp-SPM regression detected: expected product dependency to mirror generated package name "${capAppSpmLegatoPackageName}".`);
+  }
+
   const iosProductMismatch = iosResolutionLog.match(IOS_SPM_PRODUCT_MISMATCH_PATTERN);
   if (iosProductMismatch) {
     failures.push(`iOS SwiftPM resolver product mismatch: ${iosProductMismatch[0]}`);
@@ -259,6 +278,7 @@ export const validateNativeArtifacts = ({
       iosExactRemoteDependencyPresent: iosExactRemoteDependencyPattern.test(pluginPackageSwift),
       capAppSpmOwnershipMarkerPresent: CAP_APP_SPM_GENERATED_OWNERSHIP_PATTERN.test(capAppSpmPackageSwift),
       capAppSpmManualLegatoCorePathAbsent: !CAP_APP_SPM_MANUAL_LEGATO_CORE_PATH_PATTERN.test(capAppSpmPackageSwift),
+      capAppSpmLegatoPluginProductPresent: capAppSpmLegatoProductPattern ? capAppSpmLegatoProductPattern.test(capAppSpmPackageSwift) : false,
       iosResolverProductMismatchDetected: Boolean(iosProductMismatch || iosMissingProduct),
       iosObjcPluginShapePresent: IOS_PLUGIN_OBJC_PATTERN.test(pluginSwiftSource),
       iosBridgedPluginShapePresent: IOS_PLUGIN_BRIDGE_PATTERN.test(pluginSwiftSource),

--- a/apps/capacitor-demo/scripts/validate-native-artifacts.test.mjs
+++ b/apps/capacitor-demo/scripts/validate-native-artifacts.test.mjs
@@ -132,6 +132,14 @@ let package = Package(
     name: "CapApp-SPM",
     dependencies: [
         .package(name: "LegatoCapacitor", path: "../../../node_modules/@ddgutierrezc/legato-capacitor")
+    ],
+    targets: [
+        .target(
+            name: "CapApp-SPM",
+            dependencies: [
+                .product(name: "LegatoCapacitor", package: "LegatoCapacitor")
+            ]
+        )
     ]
 )
 `;
@@ -142,6 +150,19 @@ let package = Package(
     name: "CapApp-SPM",
     dependencies: [
         .package(path: "../../../../../native/ios/LegatoCore")
+    ]
+)
+`;
+
+const capAppSpmWithoutLegatoPluginProduct = `
+// DO NOT MODIFY THIS FILE - managed by Capacitor CLI commands
+let package = Package(
+    name: "CapApp-SPM",
+    dependencies: [
+        .package(name: "LegatoCapacitor", path: "../../../node_modules/@ddgutierrezc/legato-capacitor")
+    ],
+    targets: [
+        .target(name: "CapApp-SPM")
     ]
 )
 `;
@@ -363,6 +384,22 @@ test('validator fails when CapApp-SPM generated ownership marker is missing', ()
   assert.equal(result.status, 'FAIL');
   assert.equal(result.exitCode, 1);
   assert.match(result.failures.join('\n'), /DO NOT MODIFY THIS FILE/i);
+});
+
+test('validator fails when CapApp-SPM omits generated Legato package product dependency', () => {
+  const result = validateNativeArtifacts({
+    pluginBuildGradle: buildGradleArtifactOnly,
+    androidSettingsGradle: androidSettingsWithoutNativeCore,
+    capAppSpmPackageSwift: capAppSpmWithoutLegatoPluginProduct,
+    pluginPackageSwift: packageSwiftArtifactOnly,
+    nativeArtifactsContractJson: nativeArtifactsContract,
+    capacitorConfigJson: capacitorConfigWithPluginClass,
+    pluginSwiftSource: pluginSwiftDiscoverableShape,
+  });
+
+  assert.equal(result.status, 'FAIL');
+  assert.match(result.failures.join('\n'), /CapApp-SPM/i);
+  assert.match(result.failures.join('\n'), /product dependency/i);
 });
 
 test('validator passes for non-default iOS repo owner when contract drives URL', () => {

--- a/docs/releases/external-consumer-validation-v1.md
+++ b/docs/releases/external-consumer-validation-v1.md
@@ -1,41 +1,74 @@
-# External Consumer Validation V1 — Release Checklist
+# External Consumer Validation V2 — Registry-First Release Gate
 
-This runbook validates packaging/wiring behavior for a disposable external consumer. It is **NOT publication proof**.
+This runbook is the release gate that proves Legato is adoptable from the **public npm registry** by a clean Ionic + Capacitor consumer app.
 
-## Scope Boundaries (v1)
+## Scope Boundaries (v2)
 
-- Validate installability from local `npm pack` tarballs.
-- Run in a fixture app outside the monorepo root.
-- Reuse existing native validators against fixture-generated hosts.
-- Do **not** treat this as npm publication, provenance, or registry proof.
+- Registry-first release gate: npm metadata is the source of truth.
+- Manual proof in `/Volumes/S3/daniel/github/legato-consumer-smoke` is required before automation is accepted.
+- Native validation must inspect consumer-owned/generated artifacts (`android/settings.gradle`, `ios/App/CapApp-SPM/Package.swift`, `ios/App/App/capacitor.config.json`).
+- Do NOT use `file:`, workspace, tarball, or `link:` dependencies as consumer-adoption evidence.
 
-## Local Command Sequence
+## Phase 0 — Registry peer/version alignment blocker
+
+Run in any shell with npm access:
+
+1. `npm view @ddgutierrezc/legato-capacitor version peerDependencies --json`
+2. `npm view @ddgutierrezc/legato-contract versions --json`
+
+### Baseline mismatch evidence
+
+- Observed capacitor metadata: `version=0.1.2`, peer `@ddgutierrezc/legato-contract=^0.1.2`.
+- Observed contract versions: `["0.1.1", "0.1.2"]`.
+- Historical note: before `@ddgutierrezc/legato-contract@0.1.2` was published, this gate correctly failed.
+
+### Current compatible pair for active proof
+
+- `@ddgutierrezc/legato-capacitor@0.1.2`
+- `@ddgutierrezc/legato-contract@0.1.2`
+
+Phase 1 is allowed only when the selected versions are peer-compatible from npm metadata.
+
+## Phase 1 — Manual proof in real consumer app
+
+Run from `/Volumes/S3/daniel/github/legato-consumer-smoke`:
+
+1. Guardrails: confirm `package.json` contains no `file:`, `workspace:`, `.tgz`, or `link:` values.
+2. Install from npm only:
+   - `npm install --no-audit --no-fund @ddgutierrezc/legato-contract@0.1.2 @ddgutierrezc/legato-capacitor@0.1.2`
+3. Compile baseline:
+   - `npm run build`
+4. Capacitor onboarding:
+   - `npx cap add android`
+   - `npx cap add ios`
+   - `npx cap sync ios android`
+5. Native discovery checks:
+   - Android: verify consumer `android/settings.gradle` and installed plugin `node_modules/@ddgutierrezc/legato-capacitor/android/build.gradle`.
+   - iOS: verify `ios/App/CapApp-SPM/Package.swift` and `ios/App/App/capacitor.config.json` includes `packageClassList` with `LegatoPlugin`.
+
+## Phase 2 — Automation parity with manual flow
 
 Run from `apps/capacitor-demo`:
 
-1. `npm run build`
-2. `npm run validate:external:consumer`
-3. `npm run capture:release:native-artifacts`
-4. `npm run validate:release:native-artifacts`
+1. `node ./scripts/run-external-consumer-validation.mjs`
+2. `node ./scripts/validate-native-artifacts.mjs ...`
 
-## Expected Artifacts
+Automation MUST reject local-shortcut proofs and preserve parity with the manual sequence above.
 
-- `apps/capacitor-demo/artifacts/external-consumer-validation-v1/summary.json`
-- `apps/capacitor-demo/artifacts/external-consumer-validation-v1/run-manifest.json`
-- `apps/capacitor-demo/artifacts/external-consumer-validation-v1/install-metadata.json`
-- `apps/capacitor-demo/artifacts/external-consumer-validation-v1/tarball-entrypoint-check.json`
-- `apps/capacitor-demo/artifacts/external-consumer-validation-v1/cap-sync.log`
-- `apps/capacitor-demo/artifacts/external-consumer-validation-v1/validator-summary.txt`
-- `apps/capacitor-demo/artifacts/release-native-artifact-foundation-v1/manifest.json`
+## Required Evidence Artifacts
 
-## Evidence Interpretation
+- Manual command transcript (install, build, cap add/sync) from `legato-consumer-smoke`.
+- Consumer lockfile entries resolving to npm registry URLs.
+- Consumer Android discovery files: `android/settings.gradle`, `node_modules/@ddgutierrezc/legato-capacitor/android/build.gradle`.
+- Consumer iOS discovery files: `ios/App/CapApp-SPM/Package.swift`, `ios/App/App/capacitor.config.json` with `packageClassList`.
+- Automation outputs:
+  - `apps/capacitor-demo/artifacts/external-consumer-validation-v1/summary.json`
+  - `apps/capacitor-demo/artifacts/external-consumer-validation-v1/run-manifest.json`
+  - `apps/capacitor-demo/artifacts/external-consumer-validation-v1/dependency-scan.json`
 
-`summary.json` must report PASS for:
+## Release Readiness Checklist
 
-- `isolation`
-- `installability`
-- `packedEntrypoints`
-- `typecheckAndSync`
-- `validatorReuse`
-
-Any FAIL blocks release readiness.
+- [ ] Phase 0 npm-view gate passes for selected versions.
+- [ ] Phase 1 manual proof captured from `legato-consumer-smoke` with no local shortcut sources.
+- [ ] Phase 2 automation report matches manual PASS signals.
+- [ ] Manual and automation artifacts are linked in the same release evidence ticket.

--- a/docs/releases/external-consumer-validation-v2-evidence.md
+++ b/docs/releases/external-consumer-validation-v2-evidence.md
@@ -1,0 +1,113 @@
+# External Consumer Validation V2 — Evidence Report
+
+## Phase 0 — Registry alignment baseline
+
+### Command
+
+`npm view @ddgutierrezc/legato-capacitor version peerDependencies --json`
+
+### Output
+
+```json
+{
+  "version": "0.1.2",
+  "peerDependencies": {
+    "@capacitor/core": "^8.0.0",
+    "@ddgutierrezc/legato-contract": "^0.1.2"
+  }
+}
+```
+
+### Command
+
+`npm view @ddgutierrezc/legato-contract versions --json`
+
+### Output
+
+```json
+[
+  "0.1.1",
+  "0.1.2"
+]
+```
+
+### Result
+
+- Registry parity now available: latest capacitor (`0.1.2`) peer `@ddgutierrezc/legato-contract@^0.1.2` is satisfiable because contract `0.1.2` is published.
+- Historical mismatch (`0.1.2` vs contract-only `0.1.1`) is retained as timeline context, not as active baseline.
+- Current compatible published pair: `@ddgutierrezc/legato-capacitor@0.1.2` + `@ddgutierrezc/legato-contract@0.1.2`.
+
+## Phase 1 — Manual proof (`/Volumes/S3/daniel/github/legato-consumer-smoke`)
+
+### Guardrail checks
+
+- Root manifest (`package.json`) uses no `file:`, `workspace:`, `link:`, or tarball dependencies.
+- Lockfile proof:
+  - `package-lock.json` line 1837 resolves `@ddgutierrezc/legato-capacitor` from npm URL.
+  - `package-lock.json` line 1850 resolves `@ddgutierrezc/legato-contract` from npm URL.
+
+### Command outputs (captured logs)
+
+- Install: `artifacts/consumer-adoption-validation-v2/01-npm-install.log`
+- Baseline dependency update: `artifacts/consumer-adoption-validation-v2/01b-npm-install-baseline.log`
+- Build: `artifacts/consumer-adoption-validation-v2/02-build.log` ✅
+- Capacitor add android: `artifacts/consumer-adoption-validation-v2/03-cap-add-android.log` ✅
+- Capacitor add ios: `artifacts/consumer-adoption-validation-v2/04-cap-add-ios.log` ✅
+- Capacitor sync ios/android: `artifacts/consumer-adoption-validation-v2/05-cap-sync.log` + `05b-cap-sync-android.log` ✅
+
+### Focused re-validation batch (real consumer app)
+
+- Registry-only reinstall confirmation: `artifacts/consumer-adoption-validation-v2/07-npm-install-registry-only.log` ✅
+- Installed package tree at root depth: `artifacts/consumer-adoption-validation-v2/08-npm-ls-legato.log` ✅
+- App import proof in source: `/Volumes/S3/daniel/github/legato-consumer-smoke/src/pages/Home.tsx` imports both published packages and uses them in rendered output.
+- Build after imports: `artifacts/consumer-adoption-validation-v2/10-build.log` ✅
+- Fresh iOS sync: `artifacts/consumer-adoption-validation-v2/11-cap-sync-ios.log` ✅
+- Fresh Android sync: `artifacts/consumer-adoption-validation-v2/12-cap-sync-android.log` ✅
+
+### Packaging caveat discovered during direct Node import
+
+- Direct Node ESM import check (`artifacts/consumer-adoption-validation-v2/09-node-import-check.log`) fails because package runtime resolves `dist/plugin` without Node-resolvable path in this environment.
+- This does **not** invalidate consumer adoption proof for Ionic/Vite integration because the browser build and Capacitor syncs pass with the published packages.
+
+### Android discovery evidence
+
+- Consumer host file: `/Volumes/S3/daniel/github/legato-consumer-smoke/android/settings.gradle`
+- Installed plugin file: `/Volumes/S3/daniel/github/legato-consumer-smoke/node_modules/@ddgutierrezc/legato-capacitor/android/build.gradle`
+
+### iOS discovery evidence
+
+- Consumer generated CapApp-SPM: `/Volumes/S3/daniel/github/legato-consumer-smoke/ios/App/CapApp-SPM/Package.swift`
+- Consumer generated capacitor config: `/Volumes/S3/daniel/github/legato-consumer-smoke/ios/App/App/capacitor.config.json`
+- `packageClassList` contains `LegatoPlugin`.
+- Plugin metadata proof:
+  - `/Volumes/S3/daniel/github/legato-consumer-smoke/node_modules/@ddgutierrezc/legato-capacitor/Package.swift`
+  - `/Volumes/S3/daniel/github/legato-consumer-smoke/node_modules/@ddgutierrezc/legato-capacitor/ios/Sources/LegatoPlugin/LegatoPlugin.swift`
+
+## Phase 2 — Automated parity run
+
+### Command
+
+`node apps/capacitor-demo/scripts/run-external-consumer-validation.mjs --consumer-root /Volumes/S3/daniel/github/legato-consumer-smoke --skip-pack --registry-capacitor @ddgutierrezc/legato-capacitor@0.1.1 --registry-contract @ddgutierrezc/legato-contract@0.1.1 --artifacts-dir apps/capacitor-demo/artifacts/external-consumer-validation-v1`
+
+### Output summary
+
+- `apps/capacitor-demo/artifacts/external-consumer-validation-v1/summary-cli.json` reports `status=PASS`
+- All areas PASS: `registryPreflight`, `isolation`, `installability`, `packedEntrypoints`, `typecheckAndSync`, `validatorReuse`.
+
+### Current 0.1.2 parity run
+
+#### Command
+
+`node apps/capacitor-demo/scripts/run-external-consumer-validation.mjs --consumer-root /Volumes/S3/daniel/github/legato-consumer-smoke --skip-pack --registry-capacitor @ddgutierrezc/legato-capacitor@0.1.2 --registry-contract @ddgutierrezc/legato-contract@0.1.2 --artifacts-dir apps/capacitor-demo/artifacts/external-consumer-validation-v1`
+
+#### Output summary
+
+- `apps/capacitor-demo/artifacts/external-consumer-validation-v1/summary-cli.json` reports `status=PASS`.
+- `apps/capacitor-demo/artifacts/external-consumer-validation-v1/install-metadata.json` shows both packages resolved from npm registry at `0.1.2`.
+
+### Native validator proof
+
+- `/Volumes/S3/daniel/github/legato-consumer-smoke/artifacts/consumer-adoption-validation-v2/06-native-validator.log` reports:
+  - `Overall: PASS`
+  - `android-artifacts: PASS`
+  - `ios-artifacts: PASS`


### PR DESCRIPTION
Closes #62

## Summary
- persist the remaining external-consumer validation docs/evidence updates to current registry truth
- add the stronger CapApp-SPM generated product guard to native artifact validation
- keep local-only artifacts and unrelated files out of the PR

## Changes
| File | Change |
|------|--------|
| `docs/releases/external-consumer-validation-v1.md` | updates the runbook to registry-first v2 guidance and current 0.1.2 proof path |
| `docs/releases/external-consumer-validation-v2-evidence.md` | persists the detailed evidence report for the 0.1.2/0.1.2 consumer proof |
| `apps/capacitor-demo/scripts/external-consumer-validation-v1-docs.test.mjs` | locks docs/evidence expectations to current registry truth |
| `apps/capacitor-demo/scripts/validate-native-artifacts.mjs` | adds CapApp-SPM package/product alignment validation |
| `apps/capacitor-demo/scripts/validate-native-artifacts.test.mjs` | covers missing generated product dependency regression |

## Test Plan
- [x] `node --test apps/capacitor-demo/scripts/external-consumer-validation-v1-docs.test.mjs apps/capacitor-demo/scripts/validate-native-artifacts.test.mjs`
- [x] Focused validation passed locally before opening the PR
- [x] No shell scripts changed

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Docs updated for behavior/evidence changes
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers