### PR TITLE
docs(packages): strengthen public package documentation

### DIFF
--- a/.github/workflows/npm-release-readiness.yml
+++ b/.github/workflows/npm-release-readiness.yml
@@ -5,9 +5,11 @@ on:
     paths:
       - 'packages/contract/**'
       - 'packages/capacitor/**'
+      - 'README.md'
       - 'apps/capacitor-demo/scripts/**'
       - 'apps/capacitor-demo/package.json'
       - 'apps/capacitor-demo/package-lock.json'
+      - 'docs/maintainers/**'
       - 'docs/releases/npm-tech-preview-checklist.md'
       - '.github/workflows/npm-release-readiness.yml'
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -1,67 +1,41 @@
 # legato
-La metáfora es perfecta: en música, legato significa tocar notas de forma suave y continua, sin interrupciones entre ellas — exactamente lo que hace tu librería: audio que fluye sin interrupciones entre frameworks.
 
-## Demo apps
+Legato provides a contract package and a Capacitor integration package for continuous audio playback flows.
 
-- `apps/capacitor-demo`: minimal Capacitor v8 host scaffold showing TypeScript-level wiring for `@ddgutierrezc/legato-capacitor`.
+## Package decision matrix
 
-## npm packages: which package should I install?
+| If you need... | Install | Read first |
+|---|---|---|
+| Shared playback types/events/contracts with no Capacitor runtime | `@ddgutierrezc/legato-contract` | [`packages/contract/README.md`](packages/contract/README.md) |
+| Capacitor plugin runtime + namespaced APIs (`audioPlayer`, `mediaSession`) | `@ddgutierrezc/legato-capacitor` + `@ddgutierrezc/legato-contract` | [`packages/capacitor/README.md`](packages/capacitor/README.md) |
 
-- `@ddgutierrezc/legato-capacitor` → install this in Capacitor host apps that need the Legato plugin bridge.
-- `@ddgutierrezc/legato-contract` → install this in library/tooling code that only needs shared Legato types/contracts (no Capacitor plugin runtime).
+## Install
 
-Quick links:
+```bash
+npm install @ddgutierrezc/legato-contract
+```
 
-- Capacitor package docs: `packages/capacitor/README.md`
-- Contract package docs: `packages/contract/README.md`
+or
 
-## npm ergonomics non-goals (scope lock)
+```bash
+npm install @ddgutierrezc/legato-capacitor @ddgutierrezc/legato-contract
+```
+
+## Usage
+
+- Contract-only consumers: use shared symbols like `LEGATO_EVENT_NAMES` from `@ddgutierrezc/legato-contract`.
+- Capacitor consumers: start from `@ddgutierrezc/legato-capacitor` and use `audioPlayer` / `mediaSession`.
+
+## Maintainers
+
+Maintainer-only scope and operational boundaries are documented in [`docs/maintainers/package-documentation-foundation-v1-scope.md`](docs/maintainers/package-documentation-foundation-v1-scope.md).
+
+## Non-goals for package-documentation-foundation-v1
 
 - Non-goal: runtime behavior expansion in native/player engines.
 - Non-goal: release-lane redesign.
-- Non-goal: platform bootstrap automation beyond current maintainer-safe patch set.
+- Non-goal: platform bootstrap automation.
 
-## Milestones
+## Contributing
 
-- 2026-04-19: first successful **Android Capacitor smoke** in a real host app for `@ddgutierrezc/legato-capacitor` minimal flow.
-  - See: `specs/milestones/2026-04-19-android-capacitor-smoke.md`
-- 2026-04-19: generated **iOS Capacitor host scaffold** for `apps/capacitor-demo` with Capacitor-managed SPM plugin wiring (`CapacitorLegato`, no direct host `LegatoCore` link required).
-
-## Architecture decisions
-
-### Native dependency composition
-
-Legato currently uses **manual dependency composition** on both Android and iOS:
-
-- **Android**: `LegatoAndroidCoreDependencies` + `LegatoAndroidCoreFactory.create(...)`
-- **iOS**: `LegatoiOSCoreDependencies` + `LegatoiOSCoreFactory.make(...)`
-
-This means the project relies on:
-
-- constructor injection,
-- explicit dependency bags,
-- manual composition roots/factories,
-- and a small number of explicit shared coordinators where lifecycle sharing is required.
-
-### Why we are not using DI containers today
-
-For the current size and lifecycle shape of the project, we are **not** adopting Koin/Swinject/Factory as runtime containers yet.
-
-Rationale:
-
-- the native graph is still relatively small and explicit,
-- the current factories are readable and predictable,
-- Capacitor plugin lifecycle is bridge/service-driven and does not automatically become simpler with a container,
-- most recent bugs were runtime/lifecycle issues, not missing-container issues,
-- constructor injection is already in place, so testability and future migration remain possible.
-
-### Re-evaluation trigger
-
-We should revisit DI containers only if one or more of these become true:
-
-- composition roots become large enough that manual factories stop being readable,
-- shared scopes/lifecycles multiply beyond plugin + service coordination,
-- test setup cost becomes dominated by manual graph assembly,
-- we start adding many environment-specific implementations that are hard to wire explicitly.
-
-Until then, **manual composition is the project standard**.
+If you update README/package docs, also run docs drift checks from `apps/capacitor-demo`.

--- a/apps/capacitor-demo/package.json
+++ b/apps/capacitor-demo/package.json
@@ -18,7 +18,7 @@
     "validate:npm:readiness": "node ./scripts/run-npm-readiness.mjs",
     "release:npm:policy": "node ./scripts/run-npm-release-policy.mjs",
     "release:npm:execute": "node ./scripts/release-npm-execution.mjs",
-    "test:npm:readiness": "node --test ./scripts/run-external-consumer-validation.test.mjs ./scripts/npm-release-readiness-workflow.test.mjs ./scripts/npm-tech-preview-checklist-docs.test.mjs",
+    "test:npm:readiness": "node --test ./scripts/run-external-consumer-validation.test.mjs ./scripts/npm-release-readiness-workflow.test.mjs ./scripts/npm-tech-preview-checklist-docs.test.mjs ./scripts/package-documentation-foundation-v1-docs.test.mjs",
     "test:release:confidence": "node --test ./scripts/release-control-workflow.test.mjs ./scripts/release-ios-execution.test.mjs ./scripts/aggregate-release-summary.test.mjs ./scripts/publication-pipeline-v2-docs.test.mjs ./scripts/validate-mixed-canary-head.test.mjs",
     "release:confidence:fresh-head:check": "node ./scripts/validate-mixed-canary-head.mjs --evidence-file ../../docs/releases/closure-evidence-canary-mixed-app-005.md",
     "release:control:contract:check": "node ./scripts/release-control-contract.mjs",

--- a/apps/capacitor-demo/scripts/package-documentation-foundation-v1-docs.test.mjs
+++ b/apps/capacitor-demo/scripts/package-documentation-foundation-v1-docs.test.mjs
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '../../..');
+
+const rootReadmePath = resolve(repoRoot, 'README.md');
+const contractReadmePath = resolve(repoRoot, 'packages/contract/README.md');
+const capacitorReadmePath = resolve(repoRoot, 'packages/capacitor/README.md');
+const scopeDocPath = resolve(repoRoot, 'docs/maintainers/package-documentation-foundation-v1-scope.md');
+const sourceMapPath = resolve(repoRoot, 'docs/maintainers/package-documentation-foundation-v1-source-map.md');
+const operatorGuidePath = resolve(repoRoot, 'docs/maintainers/legato-capacitor-operator-guide.md');
+
+test('root README stays consumer-first with package decision matrix and maintainer-doc link', async () => {
+  const rootReadme = await readFile(rootReadmePath, 'utf8');
+
+  assert.match(rootReadme, /package decision matrix/i);
+  assert.match(rootReadme, /@ddgutierrezc\/legato-contract/i);
+  assert.match(rootReadme, /@ddgutierrezc\/legato-capacitor/i);
+  assert.match(rootReadme, /\(packages\/contract\/README\.md\)/i);
+  assert.match(rootReadme, /\(packages\/capacitor\/README\.md\)/i);
+  assert.match(rootReadme, /docs\/maintainers\/package-documentation-foundation-v1-scope\.md/i);
+});
+
+test('contract README documents verified event exports and links to source map', async () => {
+  const contractReadme = await readFile(contractReadmePath, 'utf8');
+
+  assert.match(contractReadme, /LEGATO_EVENT_NAMES/);
+  assert.doesNotMatch(contractReadme, /\bLEGATO_EVENTS\b/);
+  assert.match(contractReadme, /public surface/i);
+  assert.match(contractReadme, /docs\/maintainers\/package-documentation-foundation-v1-source-map\.md/i);
+});
+
+test('capacitor README keeps consumer onboarding and links maintainer operator guide', async () => {
+  const capacitorReadme = await readFile(capacitorReadmePath, 'utf8');
+
+  assert.match(capacitorReadme, /capacitor-native integration/i);
+  assert.match(capacitorReadme, /audioPlayer/);
+  assert.match(capacitorReadme, /mediaSession/);
+  assert.match(capacitorReadme, /docs\/maintainers\/legato-capacitor-operator-guide\.md/i);
+  assert.match(capacitorReadme, /legato native doctor/i);
+});
+
+test('maintainer docs enforce scope non-goals and source-of-truth references', async () => {
+  const [scopeDoc, sourceMap, operatorGuide] = await Promise.all([
+    readFile(scopeDocPath, 'utf8'),
+    readFile(sourceMapPath, 'utf8'),
+    readFile(operatorGuidePath, 'utf8'),
+  ]);
+
+  assert.match(scopeDoc, /non-goal/i);
+  assert.match(scopeDoc, /no full diátaxis rollout|no full diataxis rollout/i);
+  assert.match(scopeDoc, /no invented api docs|do not invent/i);
+  assert.match(scopeDoc, /packages\/contract\/src\/index\.ts/i);
+  assert.match(scopeDoc, /packages\/capacitor\/src\/index\.ts/i);
+
+  assert.match(sourceMap, /packages\/contract\/src\/events\.ts/i);
+  assert.match(sourceMap, /packages\/capacitor\/src\/cli\/native-setup-cli\.mjs/i);
+  assert.match(sourceMap, /legato native doctor/i);
+
+  assert.match(operatorGuide, /repo-owned maintainer cli/i);
+  assert.match(operatorGuide, /does not mutate capacitor-generated files/i);
+});

--- a/docs/maintainers/legato-capacitor-operator-guide.md
+++ b/docs/maintainers/legato-capacitor-operator-guide.md
@@ -1,0 +1,48 @@
+# Legato Capacitor operator guide
+
+Maintainer-only operational details for `@ddgutierrezc/legato-capacitor`.
+
+## Local repo integration notes
+
+- Publish-facing entrypoints (`main`/`types`/`exports` + `legato` CLI bin) resolve to `dist/**`.
+- Build before pack/publish so `dist` is complete (`npm run build` in `packages/capacitor`).
+- Tarball readiness checks run via `npm run pack:check` in `packages/capacitor`.
+- Cross-package external-consumer validation runs from `apps/capacitor-demo` (`npm run validate:npm:readiness`).
+
+## iOS Swift Package Manager integration
+
+- Package name/product: `DdgutierrezcLegatoCapacitor`.
+- Plugin target: `LegatoPlugin`.
+- Transitive native dependency: `LegatoCore` (remote Swift package URL + exact version in `Package.swift`).
+
+Safety boundary:
+
+- Never hand-edit `ios/App/CapApp-SPM/Package.swift`; regenerate with `npx cap sync ios`.
+
+## Native setup CLI (repo-owned maintainer CLI)
+
+This package ships the `legato` command for repository maintenance workflows.
+
+Supported commands:
+
+- `legato native doctor`
+- `legato native configure --dry-run`
+- `legato native configure --apply`
+
+Ownership/safety boundaries:
+
+- Repo-owned maintainer CLI, not a general consumer bootstrap CLI.
+- Does not mutate Capacitor-generated files (`ios/App/CapApp-SPM/**`).
+- `--apply` is conservative and may report `SKIP` for unsupported file shapes.
+
+## Native artifact distribution contract
+
+| Platform | Policy | Source of truth |
+|---|---|---|
+| Android | Maven Central coordinate `dev.dgutierrez:legato-android-core:0.1.1` | `packages/capacitor/native-artifacts.json` |
+| iOS | SwiftPM remote package `LegatoCore` pinned with `exact(0.1.1)` | `packages/capacitor/native-artifacts.json` |
+
+## Consumer-facing docs
+
+- Package onboarding: [`../../packages/capacitor/README.md`](../../packages/capacitor/README.md)
+- Scope boundaries: [`./package-documentation-foundation-v1-scope.md`](./package-documentation-foundation-v1-scope.md)

--- a/docs/maintainers/package-documentation-foundation-v1-scope.md
+++ b/docs/maintainers/package-documentation-foundation-v1-scope.md
@@ -1,0 +1,35 @@
+# Package documentation foundation v1 scope
+
+This document defines scope boundaries for `package-documentation-foundation-v1`.
+
+## In-scope outcomes
+
+- Root `README.md` is a GitHub landing page with package-selection guidance.
+- `packages/contract/README.md` and `packages/capacitor/README.md` are consumer-first and source-backed.
+- Maintainer-heavy operational details are linked from READMEs instead of expanded inline.
+- Docs drift checks exist in `apps/capacitor-demo/scripts/package-documentation-foundation-v1-docs.test.mjs`.
+
+## Non-goals
+
+- Non-goal: no full Diátaxis rollout across the repository.
+- Non-goal: no invented API docs or undocumented behavior claims.
+- Non-goal: no runtime behavior expansion.
+- Non-goal: no release-lane redesign.
+- Non-goal: no platform bootstrap automation changes.
+
+## Canonical source-of-truth files
+
+- `packages/contract/src/index.ts`
+- `packages/contract/src/events.ts`
+- `packages/capacitor/src/index.ts`
+- `packages/capacitor/src/plugin.ts`
+- `packages/capacitor/src/cli/native-setup-cli.mjs`
+- `apps/capacitor-demo/package.json`
+- `.github/workflows/npm-release-readiness.yml`
+
+## Implementation notes
+
+- Root/package onboarding remains consumer-first.
+- Maintainer operations are linked via `docs/maintainers/legato-capacitor-operator-guide.md`.
+- Verification is enforced by `node --test ./scripts/package-documentation-foundation-v1-docs.test.mjs` from `apps/capacitor-demo`.
+- Confirmation: implementation stayed within scope (no full docs migration and no fabricated API surface).

--- a/docs/maintainers/package-documentation-foundation-v1-source-map.md
+++ b/docs/maintainers/package-documentation-foundation-v1-source-map.md
@@ -1,0 +1,44 @@
+# Package documentation foundation v1 source map
+
+Verified documentation claims MUST map to source files below.
+
+## Contract package export map
+
+Source: `packages/contract/src/index.ts`
+
+- Re-export modules: `track`, `state`, `queue`, `snapshot`, `errors`, `capability`, `invariants`
+- Event constants: `PLAYER_EVENT_NAMES`, `MEDIA_SESSION_EVENT_NAMES`, `LEGACY_PLAYER_EVENT_NAMES`, `LEGATO_EVENT_NAMES`
+- Event types and payload maps from `events.ts`
+
+Source: `packages/contract/src/events.ts`
+
+- `PLAYER_EVENT_NAMES` playback events
+- `MEDIA_SESSION_EVENT_NAMES` remote events
+- `LEGACY_PLAYER_EVENT_NAMES` union set
+- `LEGATO_EVENT_NAMES` alias of `LEGACY_PLAYER_EVENT_NAMES`
+
+## Capacitor package export map
+
+Source: `packages/capacitor/src/index.ts`
+
+- Runtime entry points: `Legato`, `audioPlayer`, `mediaSession`
+- Event helper exports: `AUDIO_PLAYER_EVENTS`, `MEDIA_SESSION_EVENTS`, `LEGATO_EVENTS`
+- Listener helpers: `addAudioPlayerListener`, `addMediaSessionListener`, `addLegatoListener`
+- Sync helpers: `createAudioPlayerSync`, `createLegatoSync`
+
+Source: `packages/capacitor/src/plugin.ts`
+
+- Confirms `audioPlayer` and `mediaSession` boundaries route through shared plugin delegate.
+
+## CLI command map
+
+Source: `packages/capacitor/src/cli/native-setup-cli.mjs` (`printUsage`)
+
+- `legato native doctor [--json]`
+- `legato native configure --dry-run [--json]`
+- `legato native configure --apply [--json]`
+
+CLI scope note from source:
+
+- Repo-owned maintainer CLI.
+- Does not mutate Capacitor-generated files such as `ios/App/CapApp-SPM/**`.

--- a/packages/capacitor/README.md
+++ b/packages/capacitor/README.md
@@ -2,23 +2,36 @@
 
 Modern Capacitor binding MVP for Legato.
 
+This package provides Capacitor-native integration and is not a replacement for contract-only consumers.
+
 ## npm quickstart
 
 ```bash
 npm install @ddgutierrezc/legato-capacitor @ddgutierrezc/legato-contract
 ```
 
-First invocation:
+## First-use flow
+
+First health check:
 
 ```bash
 npx legato native doctor
 ```
 
+Minimal API start:
+
+```ts
+import { audioPlayer, mediaSession } from '@ddgutierrezc/legato-capacitor';
+
+await audioPlayer.setup();
+await mediaSession.setup();
+```
+
 Audience and prerequisites:
 
-- Intended audience: maintainers/integrators working in the Legato repository layout.
+- Intended audience: Capacitor integrators adding Legato playback to host apps.
 - Requires a supported Node.js + npm toolchain and a Capacitor project context.
-- `legato native` is a repo-owned maintainer helper, not a generic consumer bootstrap CLI.
+- `legato native` is a repo-owned maintainer helper; consumer onboarding should start with install + API usage.
 - Unsupported environment disclosure: non-LTS or end-of-life Node.js runtimes are not supported for this onboarding path.
 - Remediation: use a supported Node.js LTS release (and matching npm), then rerun install + `npx legato native doctor`.
 
@@ -100,79 +113,18 @@ await remoteHandle.remove();
 await sync.stop();
 ```
 
+## Package role boundary
+
+- Choose `@ddgutierrezc/legato-contract` when you only need shared contracts/types.
+- Choose `@ddgutierrezc/legato-capacitor` when you need Capacitor plugin runtime integration.
+
+## Maintainer operations
+
+Maintainer-heavy CLI/release/SPM operational details are documented in [`../../docs/maintainers/legato-capacitor-operator-guide.md`](../../docs/maintainers/legato-capacitor-operator-guide.md).
+
 ## MVP limitations
 
 - Native runtime playback wiring (ExoPlayer/AVPlayer) is still pending in core.
 - This binding only bridges the current native core semantics/state/events.
 - Behavior is intentionally minimal and contract-first.
 - Android background playback/service wiring is groundwork-only in Milestone 1 (contract + stub service), not production parity.
-
-## Local repo integration notes
-
-- Publish-facing entrypoints (`main`/`types`/`exports` + `legato` CLI bin) resolve to built artifacts in `dist/**`.
-- Build before packing/publishing so `dist` is complete (`npm run build`).
-- Tarball readiness checks are available via `npm run pack:check` in `packages/capacitor`.
-- `@ddgutierrezc/legato-contract` is a peer dependency and should be installed by host apps.
-- This package can be validated in a packed external-consumer flow through `apps/capacitor-demo` (`npm run validate:npm:readiness`).
-
-## iOS Swift Package Manager integration
-
-This package now includes a root `Package.swift` for Capacitor iOS SPM hosts.
-
-- Package name/product: `DdgutierrezcLegatoCapacitor`
-- Plugin target: `LegatoPlugin`
-- Transitive native dependency: `LegatoCore` (resolved via remote Swift package URL + exact version pin in `Package.swift`)
-
-When this package is consumed by Capacitor-generated iOS SPM integration, the expected product name is `DdgutierrezcLegatoCapacitor`.
-
-To keep iOS SPM integration clean and compatible with `npx cap sync ios` generated files:
-
-- Do not modify `ios/App/CapApp-SPM` generated sources/packages.
-- The plugin package itself provides the standard Capacitor SPM linkage shape (`Capacitor` + `Cordova`) through the `DdgutierrezcLegatoCapacitor` product so `npx cap sync ios` generated wiring can remain the source of truth.
-
-### iOS artifact mirror/tag expectations (release)
-
-For `legato-ios-core` distribution, release tags must satisfy these minimum expectations:
-
-- `https://github.com/ddgutierrezc/legato-ios-core.git` contains a valid root `Package.swift` exposing product `LegatoCore`.
-- Every version consumed by `@ddgutierrezc/legato-capacitor` is published as an immutable semver tag (example: `0.1.1`).
-- `packages/capacitor/native-artifacts.json` remains the single source of truth for the exact iOS version pin.
-- Any product/package identity mismatch discovered in SwiftPM resolver logs must block release until fixed.
-
-## Native setup CLI (Milestone 1 foundation)
-
-This package now ships a repo-owned CLI entrypoint: `legato`.
-
-Current supported commands:
-
-- `legato native doctor` → inspect required native host setup, no file writes.
-- `legato native configure --dry-run` → print the planned idempotent mutations without applying them.
-- `legato native configure --apply` → apply only safe mutations in the supported repo-owned patch set.
-
-Ownership/safety boundaries:
-
-- The CLI never mutates Capacitor-generated artifacts (for example, `ios/App/CapApp-SPM/**`).
-- `--apply` is intentionally conservative: unsupported file shapes are reported as `SKIP` for manual review.
-
-Android values used by CLI checks/templates are centralized in:
-
-- `src/cli/android-groundwork-contract.mjs`
-
-This contract currently covers:
-- playback service class identity,
-- required Android permissions,
-- baseline audio-focus policy intent.
-
-It exists to reduce drift across CLI and manifest scaffolding while full runtime parity is still pending.
-
-<!-- NATIVE_ARTIFACTS:BEGIN -->
-### Native artifact distribution contract (foundation)
-
-| Platform | Policy | Source of truth |
-|---|---|---|
-| Android | Maven Central coordinate `dev.dgutierrez:legato-android-core:0.1.1` | `native-artifacts.json` |
-| iOS | SwiftPM remote package `LegatoCore` at `https://github.com/ddgutierrezc/legato-ios-core.git` pinned with `exact(0.1.1)` | `native-artifacts.json` |
-
-> This section is generated by `scripts/sync-native-artifacts.mjs`.
-> Android adapter switch-over is active (artifact coordinates only). iOS adapter switch-over is active (remote Swift package + exact pinning).
-<!-- NATIVE_ARTIFACTS:END -->

--- a/packages/contract/README.md
+++ b/packages/contract/README.md
@@ -8,11 +8,31 @@ Library-only contract package for Legato shared types, events, and invariants.
 npm install @ddgutierrezc/legato-contract
 ```
 
+## Package role
+
+Use this package when you need shared contract primitives only.
+
+- Includes types, event-name constants, snapshots, queue/state models, and invariants.
+- Does not include Capacitor runtime/plugin behavior.
+- Does not ship a CLI.
+
 ## First import
 
 ```ts
-import { LEGATO_EVENTS } from '@ddgutierrezc/legato-contract';
+import { LEGATO_EVENT_NAMES } from '@ddgutierrezc/legato-contract';
 ```
+
+## Public surface
+
+`packages/contract/src/index.ts` exports the following groups:
+
+- `track`, `state`, `queue`, `snapshot`, `errors`
+- Event types: `PlayerEventName`, `MediaSessionEventName`, `LegacyPlayerEventName`, `LegatoEventName`
+- Event payload types/maps
+- Event constants: `PLAYER_EVENT_NAMES`, `MEDIA_SESSION_EVENT_NAMES`, `LEGACY_PLAYER_EVENT_NAMES`, `LEGATO_EVENT_NAMES`
+- `capability`, `invariants`
+
+Maintainer verification map: [`../../docs/maintainers/package-documentation-foundation-v1-source-map.md`](../../docs/maintainers/package-documentation-foundation-v1-source-map.md)
 
 ## Package role boundary
 


### PR DESCRIPTION
Closes #66

## Summary
- strengthen the root README as a GitHub landing page with clearer package guidance and maintainer-doc links
- improve `@ddgutierrezc/legato-contract` and `@ddgutierrezc/legato-capacitor` READMEs for npm consumers
- add docs drift guards and maintainers-only linked docs without expanding into a full docs-platform migration

## Changes
| File | Change |
|------|--------|
| `README.md` | refocuses the repo landing page around package roles, quick decisions, and maintainer doc links |
| `packages/contract/README.md` | clarifies package role and documents verified exports/source map |
| `packages/capacitor/README.md` | improves install/onboarding guidance and separates maintainer-heavy details |
| `docs/maintainers/*` | adds maintainer-focused companion docs and scope/source maps |
| `apps/capacitor-demo/scripts/package-documentation-foundation-v1-docs.test.mjs` | adds docs drift guards for the new package-documentation baseline |
| `apps/capacitor-demo/package.json` | wires the new docs test into readiness validation |
| `.github/workflows/npm-release-readiness.yml` | ensures docs/readiness checks remain part of CI flow |

## Test Plan
- [x] `node --test scripts/package-documentation-foundation-v1-docs.test.mjs`
- [x] `npm run test:npm:readiness`
- [x] No shell scripts changed

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Docs updated intentionally for consumer-facing clarity
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers