### PR TITLE
fix(contract): ship Node ESM packaging fix

### DIFF
--- a/apps/capacitor-demo/scripts/package-documentation-foundation-v1-docs.test.mjs
+++ b/apps/capacitor-demo/scripts/package-documentation-foundation-v1-docs.test.mjs
@@ -58,6 +58,9 @@ test('maintainer docs enforce scope non-goals and source-of-truth references', a
   assert.match(scopeDoc, /packages\/capacitor\/src\/index\.ts/i);
 
   assert.match(sourceMap, /packages\/contract\/src\/events\.ts/i);
+  assert.match(sourceMap, /packages\/contract\/package\.json/i);
+  assert.match(sourceMap, /root-only exports|exports\["\."\]/i);
+  assert.match(sourceMap, /run-external-consumer-validation\.mjs/i);
   assert.match(sourceMap, /packages\/capacitor\/src\/cli\/native-setup-cli\.mjs/i);
   assert.match(sourceMap, /legato native doctor/i);
 

--- a/apps/capacitor-demo/scripts/run-external-consumer-validation.mjs
+++ b/apps/capacitor-demo/scripts/run-external-consumer-validation.mjs
@@ -13,13 +13,6 @@ const VALID_PROOF_MODES = new Set([
   PROOF_MODE_NPM_READINESS,
 ]);
 
-const isKnownContractRootImportPackagingMismatch = (output) => {
-  const normalized = String(output ?? '');
-  return /ERR_MODULE_NOT_FOUND/i.test(normalized)
-    && /@ddgutierrezc\/legato-contract\/dist\/[a-z0-9_-]+/i.test(normalized)
-    && /@ddgutierrezc\/legato-contract\/dist\/index\.js/i.test(normalized);
-};
-
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const defaultRepoRoot = resolve(scriptDir, '../../..');
 const defaultTemplateRoot = resolve(scriptDir, 'external-consumer-template');
@@ -417,7 +410,7 @@ const runRuntimeProof = async ({
   };
 
   const didCliHelpMatch = (output) => /usage:|legato\s+native|legato\s+\[|legato\s+<|legato\s+--help/i.test(output);
-  const documentedImportIsBlocking = proofMode === PROOF_MODE_CONSUMER_ADOPTION;
+  const documentedImportIsBlocking = true;
 
   try {
     const cliHelp = await commandRunner({
@@ -452,15 +445,13 @@ const runRuntimeProof = async ({
     runtimeProof.documentedImport.output = output;
     if (/documented import ok/i.test(output)) {
       runtimeProof.documentedImport.status = PASS;
-    } else if (documentedImportIsBlocking && !isKnownContractRootImportPackagingMismatch(output)) {
-      failures.push('Documented import runtime proof failed: package root import did not report success.');
     } else if (documentedImportIsBlocking) {
-      // Known published-contract packaging mismatch (extensionless dist re-exports) — record evidence without failing.
+      failures.push('Documented import runtime proof failed: package root import did not report success.');
     }
   } catch (error) {
     const output = `${error?.stdout ?? ''}${error?.stderr ?? ''}`;
     runtimeProof.documentedImport.output = output;
-    if (documentedImportIsBlocking && !isKnownContractRootImportPackagingMismatch(output)) {
+    if (documentedImportIsBlocking) {
       failures.push('Documented import runtime proof failed: package root import threw unexpectedly.');
     }
   }

--- a/apps/capacitor-demo/scripts/run-external-consumer-validation.test.mjs
+++ b/apps/capacitor-demo/scripts/run-external-consumer-validation.test.mjs
@@ -518,7 +518,7 @@ test('orchestrator accepts help text runtime proof even when CLI exits non-zero'
   }
 });
 
-test('npm-readiness mode records documented import runtime mismatch without blocking pass', async () => {
+test('npm-readiness mode fails when documented root import runtime check fails', async () => {
   const tempDir = await mkdtemp(join(tmpdir(), 'legato-external-orchestrator-runtime-proof-readiness-'));
   const artifactsDir = join(tempDir, 'artifacts');
   const fixtureRoot = join(tempDir, 'fixture');
@@ -635,15 +635,15 @@ test('npm-readiness mode records documented import runtime mismatch without bloc
       proofMode: 'npm-readiness',
     });
 
-    assert.equal(result.status, 'PASS');
+    assert.equal(result.status, 'FAIL');
     assert.equal(result.runtimeProof?.documentedImport?.status, 'FAIL');
-    assert.equal(result.failures.some((failure) => /Documented import runtime proof failed/i.test(failure)), false);
+    assert.equal(result.failures.some((failure) => /Documented import runtime proof failed/i.test(failure)), true);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
 });
 
-test('consumer-adoption mode does not block on known contract root-import packaging mismatch', async () => {
+test('consumer-adoption mode fails on known contract root-import packaging mismatch', async () => {
   const tempDir = await mkdtemp(join(tmpdir(), 'legato-external-orchestrator-runtime-proof-consumer-known-mismatch-'));
   const artifactsDir = join(tempDir, 'artifacts');
   const fixtureRoot = join(tempDir, 'fixture');
@@ -735,9 +735,9 @@ test('consumer-adoption mode does not block on known contract root-import packag
       proofMode: 'consumer-adoption',
     });
 
-    assert.equal(result.status, 'PASS');
+    assert.equal(result.status, 'FAIL');
     assert.equal(result.runtimeProof?.documentedImport?.status, 'FAIL');
-    assert.equal(result.failures.some((failure) => /Documented import runtime proof failed/i.test(failure)), false);
+    assert.equal(result.failures.some((failure) => /Documented import runtime proof failed/i.test(failure)), true);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/apps/capacitor-demo/scripts/run-npm-readiness.mjs
+++ b/apps/capacitor-demo/scripts/run-npm-readiness.mjs
@@ -93,15 +93,36 @@ export const runNpmReadiness = async ({ packageTarget = 'capacitor', commandRunn
   const contractResult = parseJsonOutput(contractInspection.stdout);
 
   if (normalizedPackageTarget === 'contract') {
+    const externalValidation = await commandRunner({
+      command: 'node',
+      args: [
+        resolve(scriptDir, 'run-external-consumer-validation.mjs'),
+        '--skip-pack',
+        '--proof-mode', 'npm-readiness',
+        '--tarball-contract', contractResult.tarballPath,
+        '--registry-contract', '@ddgutierrezc/legato-contract@0.1.1',
+        '--registry-capacitor', '@ddgutierrezc/legato-capacitor@0.1.1',
+        '--artifacts-dir', resolve(artifactsRoot, 'external-consumer'),
+      ],
+      cwd: resolve(repoRoot, 'apps/capacitor-demo'),
+    });
+    const externalValidationResult = parseJsonOutput(externalValidation.stdout);
+    if (externalValidationResult?.status !== 'PASS') {
+      const combined = Array.isArray(externalValidationResult?.failures)
+        ? externalValidationResult.failures.join('; ')
+        : 'external consumer validation failed';
+      throw new Error(`external consumer validation failed for contract target: ${combined}`);
+    }
+
     return {
       package_target: normalizedPackageTarget,
       readiness_profile: 'contract-only',
       contractResult,
       capacitorResult: null,
-      externalValidation: null,
+      externalValidation: externalValidationResult,
       cross_package_validation: {
         status: 'SKIPPED',
-        reason: 'contract publish readiness validates contract tarball quality without requiring capacitor+contract pair installability.',
+        reason: 'contract publish readiness skips capacitor tarball build/install but still executes runtime validation against the packed contract artifact.',
       },
     };
   }

--- a/apps/capacitor-demo/scripts/run-npm-readiness.test.mjs
+++ b/apps/capacitor-demo/scripts/run-npm-readiness.test.mjs
@@ -68,7 +68,7 @@ test('npm readiness propagates ergonomics validator failures', async () => {
   );
 });
 
-test('npm readiness contract target skips capacitor install/build/inspection and external validation', async () => {
+test('npm readiness contract target runs external runtime validation with contract tarball only', async () => {
   const calls = [];
   const commandRunner = async ({ command, args }) => {
     const call = [command, ...args].join(' ');
@@ -87,6 +87,10 @@ test('npm readiness contract target skips capacitor install/build/inspection and
       return { stdout: JSON.stringify({ status: 'PASS' }), stderr: '', exitCode: 0 };
     }
 
+    if (command === 'node' && args.some((arg) => /run-external-consumer-validation\.mjs$/i.test(arg))) {
+      return { stdout: JSON.stringify({ status: 'PASS', exitCode: 0 }), stderr: '', exitCode: 0 };
+    }
+
     return { stdout: '', stderr: '', exitCode: 0 };
   };
 
@@ -95,11 +99,42 @@ test('npm readiness contract target skips capacitor install/build/inspection and
   assert.equal(result.package_target, 'contract');
   assert.equal(result.readiness_profile, 'contract-only');
   assert.equal(result.capacitorResult, null);
-  assert.equal(result.externalValidation, null);
+  assert.equal(result.externalValidation?.status, 'PASS');
 
   assert.equal(calls.some((call) => /packages\/contract/i.test(call)), true);
   assert.equal(calls.some((call) => /packages\/capacitor/i.test(call) && /npm install|npm run build/i.test(call)), false);
   assert.equal(calls.some((call) => /inspect-tarball\.mjs.*--profile capacitor/i.test(call)), false);
   assert.equal(calls.some((call) => /assert-package-entries\.mjs.*--profile capacitor/i.test(call)), false);
-  assert.equal(calls.some((call) => /run-external-consumer-validation\.mjs/i.test(call)), false);
+  const externalValidationCall = calls.find((call) => /run-external-consumer-validation\.mjs/i.test(call));
+  assert.match(externalValidationCall ?? '', /--proof-mode npm-readiness/i);
+  assert.match(externalValidationCall ?? '', /--tarball-contract \/tmp\/contract\.tgz/i);
+  assert.match(externalValidationCall ?? '', /--registry-capacitor @ddgutierrezc\/legato-capacitor@0\.1\.1/i);
+  assert.match(externalValidationCall ?? '', /--registry-contract @ddgutierrezc\/legato-contract@0\.1\.1/i);
+});
+
+test('npm readiness contract target bubbles external runtime-validation failures', async () => {
+  const commandRunner = async ({ command, args }) => {
+    if (command === 'node' && args.some((arg) => /inspect-tarball\.mjs$/i.test(arg))) {
+      return {
+        stdout: JSON.stringify({ status: 'PASS', profile: 'contract', tarballPath: '/tmp/contract.tgz' }),
+        stderr: '',
+        exitCode: 0,
+      };
+    }
+
+    if (command === 'node' && args.some((arg) => /assert-package-entries\.mjs$/i.test(arg))) {
+      return { stdout: JSON.stringify({ status: 'PASS' }), stderr: '', exitCode: 0 };
+    }
+
+    if (command === 'node' && args.some((arg) => /run-external-consumer-validation\.mjs$/i.test(arg))) {
+      return { stdout: JSON.stringify({ status: 'FAIL', exitCode: 1, failures: ['Documented import runtime proof failed'] }), stderr: '', exitCode: 0 };
+    }
+
+    return { stdout: '', stderr: '', exitCode: 0 };
+  };
+
+  await assert.rejects(
+    runNpmReadiness({ packageTarget: 'contract', commandRunner }),
+    /Documented import runtime proof failed|external consumer validation failed/i,
+  );
 });

--- a/docs/maintainers/package-documentation-foundation-v1-source-map.md
+++ b/docs/maintainers/package-documentation-foundation-v1-source-map.md
@@ -17,6 +17,16 @@ Source: `packages/contract/src/events.ts`
 - `LEGACY_PLAYER_EVENT_NAMES` union set
 - `LEGATO_EVENT_NAMES` alias of `LEGACY_PLAYER_EVENT_NAMES`
 
+Source: `packages/contract/package.json`
+
+- Public package boundary is root-only via `exports["."]`.
+- Undocumented deep import subpaths are intentionally unsupported.
+
+Source: `apps/capacitor-demo/scripts/run-external-consumer-validation.mjs`
+
+- Packed/runtime proof executes `import('@ddgutierrezc/legato-contract')` and requires success.
+- Packed/runtime proof executes deep import attempts and requires export-map rejection (`ERR_PACKAGE_PATH_NOT_EXPORTED`).
+
 ## Capacitor package export map
 
 Source: `packages/capacitor/src/index.ts`

--- a/packages/capacitor/scripts/__tests__/package-ergonomics.test.mjs
+++ b/packages/capacitor/scripts/__tests__/package-ergonomics.test.mjs
@@ -4,7 +4,7 @@ import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
-import { validatePackageErgonomics } from '../assert-package-entries.mjs';
+import { validatePackageEntrypoints, validatePackageErgonomics } from '../assert-package-entries.mjs';
 
 const writeJson = (path, value) => writeFile(path, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
 
@@ -92,6 +92,35 @@ test('ergonomics validator fails when README is missing from files and package r
     const result = await validatePackageErgonomics({ packageRoot, profile: 'contract' });
     assert.equal(result.status, 'FAIL');
     assert.match(result.failures.join('\n'), /README\.md/i);
+  } finally {
+    await rm(packageRoot, { recursive: true, force: true });
+  }
+});
+
+test('entrypoint validator fails contract profile when deep subpath exports are declared', async () => {
+  const packageRoot = await createPackageRoot({
+    packageJson: {
+      name: '@ddgutierrezc/legato-contract',
+      description: 'Contract package for Legato.',
+      homepage: 'https://github.com/ddgutierrezc/legato#readme',
+      repository: { type: 'git', url: 'https://github.com/ddgutierrezc/legato.git' },
+      main: './dist/index.js',
+      types: './dist/index.d.ts',
+      exports: {
+        '.': { default: './dist/index.js', types: './dist/index.d.ts' },
+        './dist/state.js': './dist/state.js',
+      },
+      keywords: ['legato', 'contract'],
+      files: ['dist', 'README.md'],
+    },
+    readme: '# @ddgutierrezc/legato-contract\n\nLibrary-only package.\n',
+  });
+
+  try {
+    await writeFile(join(packageRoot, 'dist', 'state.js'), 'export const state = true;\n', 'utf8');
+    const result = await validatePackageEntrypoints({ packageRoot, profile: 'contract' });
+    assert.equal(result.status, 'FAIL');
+    assert.match(result.failures.join('\n'), /must not expose deep subpath exports/i);
   } finally {
     await rm(packageRoot, { recursive: true, force: true });
   }

--- a/packages/capacitor/scripts/assert-package-entries.mjs
+++ b/packages/capacitor/scripts/assert-package-entries.mjs
@@ -41,6 +41,11 @@ const readPackageJson = async (packageRoot) => {
   return JSON.parse(raw);
 };
 
+const isContractDeepExportKey = (key) => {
+  const normalized = String(key ?? '').trim();
+  return normalized.startsWith('./') && normalized !== './package.json';
+};
+
 const hasString = (value) => typeof value === 'string' && value.trim().length > 0;
 
 const normalizeKeyword = (value) => String(value ?? '').trim().toLowerCase();
@@ -170,6 +175,7 @@ export const validatePackageEntrypoints = async ({ packageRoot, requireDistPrefi
   const packageJson = await readPackageJson(resolvedPackageRoot);
   const failures = [];
   const entrypoints = collectDeclaredEntrypoints(packageJson);
+  const resolvedProfile = detectProfile({ profile, packageJson });
 
   if (entrypoints.length === 0) {
     failures.push('No publish-facing entrypoints declared (main/types/exports/bin are empty).');
@@ -189,6 +195,24 @@ export const validatePackageEntrypoints = async ({ packageRoot, requireDistPrefi
     const targetPath = resolve(resolvedPackageRoot, entry);
     if (!await pathExists(targetPath)) {
       failures.push(`Entrypoint target does not exist: ${entry}`);
+    }
+  }
+
+  if (resolvedProfile === 'contract') {
+    const exportsField = packageJson.exports;
+    if (!exportsField || typeof exportsField !== 'object' || Array.isArray(exportsField)) {
+      failures.push('Contract profile must define exports as an object with root-only "exports[\".\"]".');
+    } else {
+      const exportKeys = Object.keys(exportsField);
+      const hasRootExport = exportKeys.includes('.');
+      if (!hasRootExport) {
+        failures.push('Contract profile must define root-only "exports[\".\"]".');
+      }
+      for (const exportKey of exportKeys) {
+        if (isContractDeepExportKey(exportKey)) {
+          failures.push(`Contract profile must not expose deep subpath exports (found: exports["${exportKey}"]).`);
+        }
+      }
     }
   }
 

--- a/packages/contract/README.md
+++ b/packages/contract/README.md
@@ -22,6 +22,11 @@ Use this package when you need shared contract primitives only.
 import { LEGATO_EVENT_NAMES } from '@ddgutierrezc/legato-contract';
 ```
 
+Supported import contract:
+
+- ✅ Supported: root import from `@ddgutierrezc/legato-contract`
+- ❌ Unsupported: undocumented deep imports such as `@ddgutierrezc/legato-contract/dist/*`
+
 ## Public surface
 
 `packages/contract/src/index.ts` exports the following groups:
@@ -38,6 +43,7 @@ Maintainer verification map: [`../../docs/maintainers/package-documentation-foun
 
 - This package is library-only and does not ship a CLI.
 - If you need the `legato` command, install `@ddgutierrezc/legato-capacitor` instead.
+- Public exports are intentionally root-only via `packages/contract/package.json` (`exports["."]`).
 
 ## Runtime prerequisites
 

--- a/packages/contract/src/events.ts
+++ b/packages/contract/src/events.ts
@@ -1,8 +1,8 @@
-import type { LegatoError } from './errors';
-import type { PlaybackSnapshot } from './snapshot';
-import type { PlaybackState } from './state';
-import type { QueueSnapshot } from './queue';
-import type { Track } from './track';
+import type { LegatoError } from './errors.js';
+import type { PlaybackSnapshot } from './snapshot.js';
+import type { PlaybackState } from './state.js';
+import type { QueueSnapshot } from './queue.js';
+import type { Track } from './track.js';
 
 export const PLAYER_EVENT_NAMES = [
   'playback-state-changed',

--- a/packages/contract/src/index-esm-specifiers.test.mjs
+++ b/packages/contract/src/index-esm-specifiers.test.mjs
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const indexSourcePath = resolve(testDir, './index.ts');
+
+test('contract root barrel uses explicit .js relative specifiers for Node ESM runtime output', async () => {
+  const indexSource = await readFile(indexSourcePath, 'utf8');
+
+  const runtimeExportSpecifiers = [
+    './track.js',
+    './state.js',
+    './queue.js',
+    './snapshot.js',
+    './errors.js',
+    './events.js',
+    './capability.js',
+    './invariants.js',
+  ];
+
+  for (const specifier of runtimeExportSpecifiers) {
+    assert.match(indexSource, new RegExp(`from ['\"]${specifier.replace('.', '\\.')}['\"]`));
+  }
+});

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -1,8 +1,8 @@
-export * from './track';
-export * from './state';
-export * from './queue';
-export * from './snapshot';
-export * from './errors';
+export * from './track.js';
+export * from './state.js';
+export * from './queue.js';
+export * from './snapshot.js';
+export * from './errors.js';
 
 // Shared primitives across boundary surfaces.
 export type {
@@ -18,13 +18,13 @@ export type {
   MediaSessionEventPayloadMap,
   LegacyPlayerEventPayloadMap,
   LegatoEventPayloadMap,
-} from './events';
+} from './events.js';
 export {
   PLAYER_EVENT_NAMES,
   MEDIA_SESSION_EVENT_NAMES,
   LEGACY_PLAYER_EVENT_NAMES,
   LEGATO_EVENT_NAMES,
-} from './events';
+} from './events.js';
 
-export * from './capability';
-export * from './invariants';
+export * from './capability.js';
+export * from './invariants.js';

--- a/packages/contract/src/queue.ts
+++ b/packages/contract/src/queue.ts
@@ -1,4 +1,4 @@
-import type { Track } from './track';
+import type { Track } from './track.js';
 
 export interface QueueSnapshot {
   items: Track[];

--- a/packages/contract/src/snapshot.ts
+++ b/packages/contract/src/snapshot.ts
@@ -1,6 +1,6 @@
-import type { QueueSnapshot } from './queue';
-import type { PlaybackState } from './state';
-import type { Track } from './track';
+import type { QueueSnapshot } from './queue.js';
+import type { PlaybackState } from './state.js';
+import type { Track } from './track.js';
 
 export interface PlaybackSnapshot {
   state: PlaybackState;

--- a/packages/contract/tsconfig.json
+++ b/packages/contract/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2021",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "strict": true,
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
Closes #68

## Summary
- switch the contract package to NodeNext-compatible ESM emit with explicit internal `.js` specifiers
- remove the root-import mismatch exception from external validation and keep deep undocumented imports rejected
- persist the associated validator/docs/source-map updates needed to keep public usage truthful

## Changes
| File | Change |
|------|--------|
| `packages/contract/src/index.ts` | uses explicit `.js` re-export specifiers for Node ESM correctness |
| `packages/contract/src/events.ts`, `queue.ts`, `snapshot.ts` | align internal type imports with NodeNext `.js` semantics |
| `packages/contract/tsconfig.json` | moves contract package emit to `NodeNext` / `NodeNext` |
| `packages/contract/src/index-esm-specifiers.test.mjs` | adds direct guard for explicit `.js` root barrel specifiers |
| `apps/capacitor-demo/scripts/run-external-consumer-validation*.mjs` | removes root-import mismatch tolerance and validates real contract runtime behavior |
| `apps/capacitor-demo/scripts/run-npm-readiness*.mjs` | preserves readiness coverage for contract packaging/runtime checks |
| `packages/capacitor/scripts/assert-package-entries.mjs` and package ergonomics tests | keep strict root-only exports and deep-import rejection guarantees |
| `packages/contract/README.md`, `docs/maintainers/package-documentation-foundation-v1-source-map.md`, `apps/capacitor-demo/scripts/package-documentation-foundation-v1-docs.test.mjs` | keep documented package usage/source maps aligned with the fix |

## Test Plan
- [x] `node --test packages/contract/src/index-esm-specifiers.test.mjs apps/capacitor-demo/scripts/run-external-consumer-validation.test.mjs apps/capacitor-demo/scripts/run-npm-readiness.test.mjs packages/capacitor/scripts/__tests__/package-ergonomics.test.mjs`
- [x] Manual packed tarball check: root import succeeds and deep import rejects with `ERR_PACKAGE_PATH_NOT_EXPORTED`
- [x] No shell scripts changed

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Docs updated where public usage/source-map guidance changed
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers