### PR TITLE
docs(ios): polish package-specific host guidance

### DIFF
--- a/apps/capacitor-demo/README.md
+++ b/apps/capacitor-demo/README.md
@@ -188,6 +188,19 @@ Never hand-edit `ios/App/CapApp-SPM/Package.swift`; refresh via `npm run cap:syn
 
 See `ios/README.md` for the minimal iOS package-integration checklist before first iOS smoke.
 
+#### Post-sync iOS package verification checklist (required before smoke)
+
+This is a **post-sync iOS package verification checklist** and is **required before smoke** runs:
+
+1. Run `npm run cap:sync` before opening Xcode.
+2. Open `ios/App/App.xcodeproj`.
+3. Keep `CapApp-SPM` as the only generated package wiring source for the host target.
+4. Remove duplicate manual plugin/local package references if they appear.
+5. Avoid direct `LegatoCore` host linkage; keep it transitive through the plugin package.
+6. Verify `ios/App/App/capacitor.config.json` keeps `packageClassList` with `LegatoPlugin`.
+
+Out of scope: generic Apple signing/provisioning ownership and team/bundle management.
+
 ## Future iOS smoke path (first attempt)
 
 1. Ensure iOS host exists (`npm run cap:add:ios`, already done once in repo).

--- a/apps/capacitor-demo/ios/README.md
+++ b/apps/capacitor-demo/ios/README.md
@@ -15,13 +15,19 @@ npx cap add ios
 ## Wiring model (current)
 
 This host should rely on Capacitor CLI-generated SPM integration only (`App/CapApp-SPM/Package.swift`).
-Never hand-edit `App/CapApp-SPM/Package.swift`; regenerate it with `npm run cap:sync`.
+Do not hand-edit generated files (`apps/capacitor-demo/ios/App/CapApp-SPM/Package.swift`); regenerate them with `npm run cap:sync` (or `npx cap sync ios`).
 
-Before the first real iOS smoke attempt, do this in Xcode:
+## Ordered post-sync package checks
 
-1. Open `ios/App/App.xcodeproj`.
-2. Confirm target `App` links `CapApp-SPM` only (no extra manual local package reference to `../../../../packages/capacitor`).
-3. If present, remove direct `LegatoCore` target linkage; `LegatoCore` must remain transitive via the plugin package.
+After `npm run cap:sync`, run this package-only checklist in order:
+
+1. open `ios/App/App.xcodeproj`.
+2. Confirm `CapApp-SPM` remains the source of package wiring for target `App`.
+3. remove duplicate manual plugin/local package references (`../../../../packages/capacitor`) if they appear.
+4. avoid direct `LegatoCore` host linkage so the dependency stays transitive through the plugin package.
+5. Check `App/App/capacitor.config.json` and confirm `packageClassList` contains `LegatoPlugin`.
+
+Out of scope: generic Apple signing/team/provisioning ownership.
 
 ## Notes
 

--- a/apps/capacitor-demo/package.json
+++ b/apps/capacitor-demo/package.json
@@ -18,7 +18,7 @@
     "validate:npm:readiness": "node ./scripts/run-npm-readiness.mjs",
     "release:npm:policy": "node ./scripts/run-npm-release-policy.mjs",
     "release:npm:execute": "node ./scripts/release-npm-execution.mjs",
-    "test:npm:readiness": "node --test ./scripts/run-external-consumer-validation.test.mjs ./scripts/npm-release-readiness-workflow.test.mjs ./scripts/npm-tech-preview-checklist-docs.test.mjs ./scripts/package-documentation-foundation-v1-docs.test.mjs",
+    "test:npm:readiness": "node --test ./scripts/run-external-consumer-validation.test.mjs ./scripts/npm-release-readiness-workflow.test.mjs ./scripts/npm-tech-preview-checklist-docs.test.mjs ./scripts/package-documentation-foundation-v1-docs.test.mjs ./scripts/ios-host-polish-v1-docs.test.mjs",
     "test:release:confidence": "node --test ./scripts/release-control-workflow.test.mjs ./scripts/release-ios-execution.test.mjs ./scripts/aggregate-release-summary.test.mjs ./scripts/publication-pipeline-v2-docs.test.mjs ./scripts/validate-mixed-canary-head.test.mjs",
     "release:confidence:fresh-head:check": "node ./scripts/validate-mixed-canary-head.mjs --evidence-file ../../docs/releases/closure-evidence-canary-mixed-app-005.md",
     "release:control:contract:check": "node ./scripts/release-control-contract.mjs",

--- a/apps/capacitor-demo/scripts/ios-host-polish-v1-docs.test.mjs
+++ b/apps/capacitor-demo/scripts/ios-host-polish-v1-docs.test.mjs
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '../../..');
+
+const demoReadmePath = resolve(repoRoot, 'apps/capacitor-demo/README.md');
+const iosReadmePath = resolve(repoRoot, 'apps/capacitor-demo/ios/README.md');
+const operatorGuidePath = resolve(repoRoot, 'docs/maintainers/legato-capacitor-operator-guide.md');
+const demoPackageJsonPath = resolve(repoRoot, 'apps/capacitor-demo/package.json');
+
+test('operator guide documents ios host-polish scope, non-goals, and generated-file boundaries', async () => {
+  const operatorGuide = await readFile(operatorGuidePath, 'utf8');
+
+  assert.match(operatorGuide, /package-specific iOS integration\/onboarding\/guardrails only/i);
+  assert.match(operatorGuide, /no generic bundle-id ownership workflow/i);
+  assert.match(operatorGuide, /no signing\/provisioning automation/i);
+  assert.match(operatorGuide, /no provisioning-profile lifecycle ownership/i);
+  assert.match(operatorGuide, /apps\/capacitor-demo\/ios\/App\/CapApp-SPM\/Package\.swift/i);
+  assert.match(operatorGuide, /npm run cap:sync/i);
+});
+
+test('demo README requires post-sync ios package checks before smoke', async () => {
+  const demoReadme = await readFile(demoReadmePath, 'utf8');
+
+  assert.match(demoReadme, /post-sync iOS package verification checklist/i);
+  assert.match(demoReadme, /required before smoke/i);
+  assert.match(demoReadme, /npm run cap:sync/i);
+  assert.match(demoReadme, /ios\/App\/App\.xcodeproj/i);
+  assert.match(demoReadme, /CapApp-SPM/i);
+  assert.match(demoReadme, /LegatoCore/i);
+  assert.match(demoReadme, /packageClassList/i);
+  assert.match(demoReadme, /LegatoPlugin/i);
+  assert.match(demoReadme, /out of scope: generic Apple signing\/provisioning/i);
+});
+
+test('ios README keeps ordered package-only checks after sync', async () => {
+  const iosReadme = await readFile(iosReadmePath, 'utf8');
+
+  assert.match(iosReadme, /ordered post-sync package checks/i);
+  assert.match(iosReadme, /open `ios\/App\/App\.xcodeproj`/i);
+  assert.match(iosReadme, /CapApp-SPM.*source of package wiring/i);
+  assert.match(iosReadme, /remove duplicate manual plugin\/local package references/i);
+  assert.match(iosReadme, /avoid direct `LegatoCore` host linkage/i);
+  assert.match(iosReadme, /App\/App\/capacitor\.config\.json/i);
+  assert.match(iosReadme, /packageClassList.*LegatoPlugin/i);
+  assert.match(iosReadme, /do not hand-edit/i);
+  assert.match(iosReadme, /out of scope: generic Apple signing\/team\/provisioning ownership/i);
+});
+
+test('npm readiness docs suite includes ios host polish docs test', async () => {
+  const packageJson = await readFile(demoPackageJsonPath, 'utf8');
+  assert.match(packageJson, /ios-host-polish-v1-docs\.test\.mjs/);
+});

--- a/apps/capacitor-demo/scripts/validate-native-artifacts.mjs
+++ b/apps/capacitor-demo/scripts/validate-native-artifacts.mjs
@@ -12,8 +12,16 @@ const IOS_SPM_PRODUCT_MISMATCH_PATTERN = /product\s+'[^']+'\s+required\s+by\s+pa
 const IOS_SPM_MISSING_PRODUCT_PATTERN = /Missing\s+package\s+product/i;
 const IOS_PLUGIN_OBJC_PATTERN = /@objc\(LegatoPlugin\)/;
 const IOS_PLUGIN_BRIDGE_PATTERN = /class\s+LegatoPlugin\s*:\s*CAPPlugin,\s*CAPBridgedPlugin/;
+const IOS_PLUGIN_IDENTIFIER_PATTERN = /let\s+identifier\s*=\s*"LegatoPlugin"/;
+const IOS_PLUGIN_JS_NAME_PATTERN = /let\s+jsName\s*=\s*"Legato"/;
+const IOS_PLUGIN_METHODS_PATTERN = /let\s+pluginMethods\s*:\s*\[CAPPluginMethod\]\s*=\s*\[/;
 const CAP_APP_SPM_GENERATED_OWNERSHIP_PATTERN = /DO NOT MODIFY THIS FILE - managed by Capacitor CLI commands/;
 const CAP_APP_SPM_MANUAL_LEGATO_CORE_PATH_PATTERN = /\.package\(path:\s*"[^"]*LegatoCore[^"]*"\)/;
+const IOS_SYNC_REMEDIATION = 'Run `npm run cap:sync` (or `npx cap sync ios`) and re-run `npm run validate:native:artifacts`.';
+
+function withIosCategory(category, message) {
+  return `[${category}] ${message} ${IOS_SYNC_REMEDIATION}`;
+}
 
 const normalizeAbsolute = (value) => resolve(value).replaceAll('\\', '/');
 
@@ -236,14 +244,14 @@ export const validateNativeArtifacts = ({
   }
 
   if (pluginPackageSwift && IOS_LOCAL_PATH_DEPENDENCY_PATTERN.test(pluginPackageSwift)) {
-    failures.push('iOS local-path regression detected in Package.swift: remove `.package(path: ...)` and keep remote URL + exact pinning.');
+    failures.push(withIosCategory('package-wiring', 'iOS local-path regression detected in Package.swift: remove `.package(path: ...)` and keep remote URL + exact pinning.'));
   }
 
   if (pluginPackageSwift && !iosExactRemoteDependencyPattern.test(pluginPackageSwift)) {
     const expectedSnippet = expectedIosContract
       ? `.package(url: "${expectedIosContract.packageUrl}", exact: "${expectedIosContract.version}")`
       : '.package(url: "<ios.packageUrl>", exact: "<ios.version>")';
-    failures.push(`iOS remote Swift package dependency is missing: expected \`${expectedSnippet}\` in Package.swift.`);
+    failures.push(withIosCategory('package-wiring', `iOS remote Swift package dependency is missing: expected \`${expectedSnippet}\` in Package.swift.`));
   }
 
   if (expectedIosContract && pluginPackageSwift) {
@@ -252,48 +260,60 @@ export const validateNativeArtifacts = ({
     const expectedProductDependency = new RegExp(`\\.product\\(name:\\s*"${escapeRegExp(expectedIosContract.product)}",\\s*package:\\s*"(?:${packageAlternation})"\\)`);
     if (!expectedProductDependency.test(pluginPackageSwift)) {
       const primaryExpectedPackageIdentity = expectedPackageIdentities[0] ?? deriveSwiftPackageIdentity(expectedIosContract.packageUrl);
-      failures.push(`iOS product identity mismatch: expected .product(name: "${expectedIosContract.product}", package: "${primaryExpectedPackageIdentity}") in Package.swift.`);
+      failures.push(withIosCategory('package-wiring', `iOS product identity mismatch: expected .product(name: "${expectedIosContract.product}", package: "${primaryExpectedPackageIdentity}") in Package.swift.`));
     }
   }
 
   if (capAppSpmPackageSwift && !CAP_APP_SPM_GENERATED_OWNERSHIP_PATTERN.test(capAppSpmPackageSwift)) {
-    failures.push('CapApp-SPM integrity regression: expected generated ownership marker `DO NOT MODIFY THIS FILE - managed by Capacitor CLI commands`.');
+    failures.push(withIosCategory('generated-file-boundary', 'CapApp-SPM integrity regression: expected generated ownership marker `DO NOT MODIFY THIS FILE - managed by Capacitor CLI commands`.'));
   }
 
   if (capAppSpmPackageSwift && CAP_APP_SPM_MANUAL_LEGATO_CORE_PATH_PATTERN.test(capAppSpmPackageSwift)) {
-    failures.push('CapApp-SPM regression detected: remove manual local LegatoCore path wiring and keep generated package dependencies only.');
+    failures.push(withIosCategory('generated-file-boundary', 'CapApp-SPM regression detected: remove manual local LegatoCore path wiring and keep generated package dependencies only.'));
   }
 
   if (capAppSpmPackageSwift && !capAppSpmLegatoPackageName) {
-    failures.push('CapApp-SPM regression detected: expected generated Legato package dependency pointing to node_modules/@ddgutierrezc/legato-capacitor.');
+    failures.push(withIosCategory('package-wiring', 'CapApp-SPM regression detected: expected generated Legato package dependency pointing to node_modules/@ddgutierrezc/legato-capacitor.'));
   }
 
   if (capAppSpmPackageSwift && capAppSpmLegatoProductPattern && !capAppSpmLegatoProductPattern.test(capAppSpmPackageSwift)) {
-    failures.push(`CapApp-SPM regression detected: expected product dependency to mirror generated package name "${capAppSpmLegatoPackageName}".`);
+    failures.push(withIosCategory('package-wiring', `CapApp-SPM regression detected: expected product dependency to mirror generated package name "${capAppSpmLegatoPackageName}".`));
   }
 
   const iosProductMismatch = iosResolutionLog.match(IOS_SPM_PRODUCT_MISMATCH_PATTERN);
   if (iosProductMismatch) {
-    failures.push(`iOS SwiftPM resolver product mismatch: ${iosProductMismatch[0]}`);
+    failures.push(withIosCategory('package-wiring', `iOS SwiftPM resolver product mismatch: ${iosProductMismatch[0]}`));
   }
   const iosMissingProduct = iosResolutionLog.match(IOS_SPM_MISSING_PRODUCT_PATTERN);
   if (iosMissingProduct) {
-    failures.push(`iOS SwiftPM resolver missing product: ${iosMissingProduct[0]}`);
+    failures.push(withIosCategory('package-wiring', `iOS SwiftPM resolver missing product: ${iosMissingProduct[0]}`));
   }
 
   if (pluginSwiftSource && !IOS_PLUGIN_OBJC_PATTERN.test(pluginSwiftSource)) {
-    failures.push('iOS plugin discoverability regression: expected `@objc(LegatoPlugin)` in LegatoPlugin.swift.');
+    failures.push(withIosCategory('package-wiring', 'iOS plugin discoverability regression: expected `@objc(LegatoPlugin)` in LegatoPlugin.swift.'));
   }
 
   if (pluginSwiftSource && !IOS_PLUGIN_BRIDGE_PATTERN.test(pluginSwiftSource)) {
-    failures.push('iOS plugin discoverability regression: expected `LegatoPlugin: CAPPlugin, CAPBridgedPlugin` in LegatoPlugin.swift.');
+    failures.push(withIosCategory('package-wiring', 'iOS plugin discoverability regression: expected `LegatoPlugin: CAPPlugin, CAPBridgedPlugin` in LegatoPlugin.swift.'));
+  }
+
+  if (pluginSwiftSource && !IOS_PLUGIN_IDENTIFIER_PATTERN.test(pluginSwiftSource)) {
+    failures.push(withIosCategory('package-wiring', 'iOS plugin bridge contract regression: expected `identifier = "LegatoPlugin"` in LegatoPlugin.swift.'));
+  }
+
+  if (pluginSwiftSource && !IOS_PLUGIN_JS_NAME_PATTERN.test(pluginSwiftSource)) {
+    failures.push(withIosCategory('package-wiring', 'iOS plugin bridge contract regression: expected `jsName = "Legato"` in LegatoPlugin.swift.'));
+  }
+
+  if (pluginSwiftSource && !IOS_PLUGIN_METHODS_PATTERN.test(pluginSwiftSource)) {
+    failures.push(withIosCategory('package-wiring', 'iOS plugin bridge contract regression: expected `pluginMethods: [CAPPluginMethod]` registration in LegatoPlugin.swift.'));
   }
 
   const packageClassList = capacitorConfigJson ? parseCapacitorConfigPackageClassList(capacitorConfigJson) : [];
   if (packageClassList === null) {
-    failures.push('Failed to parse capacitor.config.json for packageClassList checks.');
+    failures.push(withIosCategory('package-wiring', 'Failed to parse capacitor.config.json for packageClassList checks.'));
   } else if (capacitorConfigJson && !packageClassList.includes('LegatoPlugin')) {
-    failures.push('iOS plugin discoverability regression: expected `"LegatoPlugin"` in capacitor.config.json packageClassList.');
+    failures.push(withIosCategory('package-wiring', 'iOS plugin discoverability regression: expected `"LegatoPlugin"` in capacitor.config.json packageClassList.'));
   }
 
   const status = failures.length === 0 ? PASS : FAIL;
@@ -313,6 +333,9 @@ export const validateNativeArtifacts = ({
       iosResolverProductMismatchDetected: Boolean(iosProductMismatch || iosMissingProduct),
       iosObjcPluginShapePresent: IOS_PLUGIN_OBJC_PATTERN.test(pluginSwiftSource),
       iosBridgedPluginShapePresent: IOS_PLUGIN_BRIDGE_PATTERN.test(pluginSwiftSource),
+      iosBridgedPluginIdentifierPresent: IOS_PLUGIN_IDENTIFIER_PATTERN.test(pluginSwiftSource),
+      iosBridgedPluginJsNamePresent: IOS_PLUGIN_JS_NAME_PATTERN.test(pluginSwiftSource),
+      iosBridgedPluginMethodsPresent: IOS_PLUGIN_METHODS_PATTERN.test(pluginSwiftSource),
       capacitorPackageClassListContainsLegatoPlugin: packageClassList === null ? false : packageClassList.includes('LegatoPlugin'),
     },
     failures,

--- a/apps/capacitor-demo/scripts/validate-native-artifacts.test.mjs
+++ b/apps/capacitor-demo/scripts/validate-native-artifacts.test.mjs
@@ -179,7 +179,19 @@ const capacitorConfigWithPluginClass = `
 
 const pluginSwiftDiscoverableShape = `
 @objc(LegatoPlugin)
-public final class LegatoPlugin: CAPPlugin, CAPBridgedPlugin {}
+public final class LegatoPlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "LegatoPlugin"
+    public let jsName = "Legato"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "setup", returnType: CAPPluginReturnPromise)
+    ]
+}
+`;
+
+const pluginSwiftMissingBridgeContract = `
+@objc(LegatoPlugin)
+public final class LegatoPlugin: CAPPlugin, CAPBridgedPlugin {
+}
 `;
 
 const unresolvedLog = `
@@ -445,6 +457,57 @@ test('validator accepts iOS product package identity based on contract packageNa
 
   assert.equal(result.status, 'PASS');
   assert.equal(result.failures.length, 0);
+});
+
+test('validator fails when bridged plugin identifier/jsName/pluginMethods contract is missing', () => {
+  const result = validateNativeArtifacts({
+    pluginBuildGradle: buildGradleArtifactOnly,
+    nativeArtifactsContractJson: nativeArtifactsContract,
+    androidSettingsGradle: androidSettingsWithoutNativeCore,
+    capAppSpmPackageSwift: capAppSpmGenerated,
+    pluginPackageSwift: packageSwiftArtifactOnly,
+    capacitorConfigJson: capacitorConfigWithPluginClass,
+    pluginSwiftSource: pluginSwiftMissingBridgeContract,
+  });
+
+  assert.equal(result.status, 'FAIL');
+  assert.match(result.failures.join('\n'), /identifier/i);
+  assert.match(result.failures.join('\n'), /jsName/i);
+  assert.match(result.failures.join('\n'), /pluginMethods/i);
+});
+
+test('validator reports generated-file boundary failures with sync remediation', () => {
+  const result = validateNativeArtifacts({
+    pluginBuildGradle: buildGradleArtifactOnly,
+    nativeArtifactsContractJson: nativeArtifactsContract,
+    androidSettingsGradle: androidSettingsWithoutNativeCore,
+    capAppSpmPackageSwift: capAppSpmWithoutGeneratedMarker,
+    pluginPackageSwift: packageSwiftArtifactOnly,
+    capacitorConfigJson: capacitorConfigWithPluginClass,
+    pluginSwiftSource: pluginSwiftDiscoverableShape,
+  });
+
+  assert.equal(result.status, 'FAIL');
+  assert.match(result.failures.join('\n'), /\[generated-file-boundary\]/i);
+  assert.match(result.failures.join('\n'), /npm run cap:sync/i);
+  assert.match(result.failures.join('\n'), /npm run validate:native:artifacts/i);
+});
+
+test('validator reports package-wiring drift failures with sync remediation', () => {
+  const result = validateNativeArtifacts({
+    pluginBuildGradle: buildGradleArtifactOnly,
+    nativeArtifactsContractJson: nativeArtifactsContract,
+    androidSettingsGradle: androidSettingsWithoutNativeCore,
+    capAppSpmPackageSwift: capAppSpmGenerated,
+    pluginPackageSwift: packageSwiftArtifactOnly.replace('.product(name: "LegatoCore", package: "LegatoCore")', '.product(name: "WrongCore", package: "LegatoCore")'),
+    capacitorConfigJson: capacitorConfigWithPluginClass,
+    pluginSwiftSource: pluginSwiftDiscoverableShape,
+  });
+
+  assert.equal(result.status, 'FAIL');
+  assert.match(result.failures.join('\n'), /\[package-wiring\]/i);
+  assert.match(result.failures.join('\n'), /npm run cap:sync/i);
+  assert.match(result.failures.join('\n'), /npm run validate:native:artifacts/i);
 });
 
 test('fixture mode path validator fails when host/plugin paths are coupled to monorepo app path', () => {

--- a/docs/maintainers/legato-capacitor-operator-guide.md
+++ b/docs/maintainers/legato-capacitor-operator-guide.md
@@ -15,9 +15,21 @@ Maintainer-only operational details for `@ddgutierrezc/legato-capacitor`.
 - Plugin target: `LegatoPlugin`.
 - Transitive native dependency: `LegatoCore` (remote Swift package URL + exact version in `Package.swift`).
 
+### iOS host polish v1 scope contract
+
+This maintainer contract covers **package-specific iOS integration/onboarding/guardrails only**.
+
+Explicit non-goals:
+
+- no generic bundle-ID ownership workflow
+- no signing/provisioning automation
+- no provisioning-profile lifecycle ownership
+
 Safety boundary:
 
-- Never hand-edit `ios/App/CapApp-SPM/Package.swift`; regenerate with `npx cap sync ios`.
+- Never hand-edit `apps/capacitor-demo/ios/App/CapApp-SPM/Package.swift`.
+- Regenerate generated iOS package wiring only through `npm run cap:sync` (or `npx cap sync ios`).
+- After sync, re-check generated surfaces (`CapApp-SPM/Package.swift`, `ios/App/App/capacitor.config.json`) before trusting host wiring state.
 
 ## Native setup CLI (repo-owned maintainer CLI)
 


### PR DESCRIPTION
Closes #70

## Summary
- clarify package-specific iOS setup guidance after `npx cap sync ios`
- make generated-file boundaries and post-sync/manual verification steps explicit
- align native-artifact validator expectations with the documented iOS host integration flow

## Changes
| File | Change |
|------|--------|
| `apps/capacitor-demo/README.md` | adds clearer package-specific iOS verification flow after sync |
| `apps/capacitor-demo/ios/README.md` | documents the ordered package-only iOS checks and generated-file boundaries |
| `docs/maintainers/legato-capacitor-operator-guide.md` | expands package-specific operator guidance and non-goals |
| `apps/capacitor-demo/scripts/validate-native-artifacts.mjs` | improves package-specific iOS validator categorization/remediation |
| `apps/capacitor-demo/scripts/validate-native-artifacts.test.mjs` | adds coverage for the new iOS host polish validator behavior |
| `apps/capacitor-demo/scripts/ios-host-polish-v1-docs.test.mjs` | adds docs drift guards for the new iOS guidance |
| `apps/capacitor-demo/package.json` | wires the docs guard into validation scripts |

## Test Plan
- [x] `node --test scripts/ios-host-polish-v1-docs.test.mjs scripts/validate-native-artifacts.test.mjs`
- [x] `npm run test:npm:readiness`
- [x] No shell scripts changed

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Docs updated intentionally for package-specific iOS guidance
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers