### PR TITLE
fix(android): harden runtime playback integrity

### DIFF
--- a/apps/capacitor-demo/index.html
+++ b/apps/capacitor-demo/index.html
@@ -285,7 +285,7 @@ errors=none</pre>
 
         <section class="card stack">
           <h2>Manual native controls</h2>
-          <p>Use these when validating background/lifecycle behavior step-by-step.</p>
+          <p>Use these when validating background/lifecycle/interruption behavior step-by-step.</p>
           <div class="actions">
             <button id="use-legato-surface" type="button">Manual target: Legato facade</button>
             <button id="use-audioplayer-surface" type="button">Manual target: audioPlayer namespace</button>
@@ -343,6 +343,7 @@ checks=none yet</pre>
             <li>Remote next/previous parity: run <code>Case: remote next/previous parity</code>; next and previous must round-trip queue index as prompted.</li>
             <li>Remote seek parity: run <code>Case: remote seek parity</code>; remote seek must produce a visible snapshot position jump.</li>
             <li>Boundary behavior parity: previous at first track restarts to 0, next at last track transitions to ended + playbackEnded event.</li>
+            <li>Interruption ingestion check: while playing, trigger focus-loss/noisy (headphones unplug/Bluetooth disconnect) and confirm snapshot moves to paused; keep <code>Recent events/progress</code> + <code>Raw operation log</code> for copyable evidence.</li>
             <li>Capability projection parity: canSkipNext/canSkipPrevious/canSeek summary must align with queue index + ended/empty states.</li>
             <li>Android lockscreen/notification position from real snapshot: on resume/seek, projected position should rebase near snapshot target (no transient 0 reset).</li>
             <li>iOS now-playing playbackRate fidelity: expect playbackRate=1.0 while playing and playbackRate=0.0 when paused/stopped/non-playing.</li>

--- a/apps/capacitor-demo/src/main.ts
+++ b/apps/capacitor-demo/src/main.ts
@@ -444,6 +444,7 @@ const updateParityInspector = (snapshot: PlaybackSnapshot): void => {
     `metadata signal: ${formatRequiredMetadataSignal(snapshot)}`,
     `artwork signal: ${artworkSignal}`,
     `observed sync events: ${summarizeObservedEventSignals()}`,
+    'interruption signal: while playing, trigger focus-loss or unplug headphones and verify snapshot reaches paused; use recent events + raw log for exact ordering.',
     'manual fidelity check: Android lockscreen/notification position rebases from real snapshot after resume/seek, and iOS now-playing playbackRate mirrors play/pause (1.0 vs 0.0).',
   ];
 
@@ -1203,6 +1204,7 @@ log('Legato parity harness ready.');
 log('platform:', platform);
 log('isNativePlatform:', isNative);
 log('Use smoke buttons for quick pass/fail, guided cases for scripted remote checks, and manual controls for deep debugging.');
+log('Interruption diagnostics: capture recent events + raw log while testing audio-focus loss/becoming-noisy to validate pause behavior.');
 renderBoundarySummary();
 
 smokeButton.addEventListener('click', () => {

--- a/native/android/core/README.md
+++ b/native/android/core/README.md
@@ -1,24 +1,27 @@
-# Legato Android Native Core (Runtime-Seam MVP)
+# Legato Android Native Core (Runtime + Integrity v1)
 
 This directory contains the Android native core and runtime integration seams for Legato.
 
 Current scope includes:
 - canonical queue/state/snapshot/event behavior,
-- manager scaffolding for session + remote command integration,
+- manager/runtime integration for session + remote command surfaces,
 - explicit runtime adapters/seams for playback/session/remote surfaces,
-- typed interruption + audio-focus policy contract surfaces (Milestone 1 groundwork only).
+- typed interruption + audio-focus policy surfaces wired through canonical interruption signals.
 
 Out of scope for this pass:
-- full Media3/ExoPlayer runtime binding,
-- complete Android AudioFocus/MediaSession lifecycle behavior,
-- production-grade background playback behavior.
+- process-death restoration/persistent queue recovery,
+- broad Android lifecycle/OEM matrix hardening,
+- cross-platform parity expansion beyond Android runtime integrity closure.
 
-The default runtime adapters are intentionally no-op/in-memory and exist to define stable integration boundaries.
+Deferred scope is tracked under follow-up milestones (`android-background-lifecycle-v1` and parity tracks) rather than this runtime-v1 integrity pass.
 
-## Milestone 1 contract note
+The module ships a real Media3 runtime path and also keeps default no-op adapters for explicit seam tests.
 
-Android session interruption/audio-focus surfaces in this module are contract seams only.
-They are intentionally no-op and DO NOT provide full Media3 audio-focus/background parity yet.
+## Runtime-v1 interruption contract
+
+- Focus loss (`AUDIOFOCUS_LOSS`, `AUDIOFOCUS_LOSS_TRANSIENT`, `AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK`) and becoming noisy signals pause playback with interruption pause origin.
+- Focus gain does **not** auto-resume playback in v1.
+- Service/app adapters ingest Android callbacks and forward canonical interruption signals to the session runtime.
 
 ## Gradle module bootstrap
 

--- a/native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidPlayerEngine.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidPlayerEngine.kt
@@ -153,6 +153,127 @@ class LegatoAndroidPlayerEngine(
         publishProgress(snapshotStore.getPlaybackSnapshot())
     }
 
+    suspend fun remove(index: Int): LegatoAndroidPlaybackSnapshot {
+        guardSetup()
+
+        return runCatching {
+            val queueSnapshot = queueManager.getQueueSnapshot()
+            require(index in queueSnapshot.items.indices) { "remove index out of bounds" }
+
+            val remainingItems = queueSnapshot.items.toMutableList().apply {
+                removeAt(index)
+            }
+
+            val previousSnapshot = snapshotStore.getPlaybackSnapshot()
+            val nextSnapshot = if (remainingItems.isEmpty()) {
+                if (!runRuntimeOperation {
+                    playbackRuntime.replaceQueue(emptyList(), null)
+                }) {
+                    return snapshotStore.getPlaybackSnapshot()
+                }
+
+                val clearedQueue = queueManager.replaceQueue(emptyList(), null)
+                pauseOrigin = LegatoAndroidPauseOrigin.USER
+                LegatoAndroidPlaybackSnapshot(
+                    state = LegatoAndroidPlaybackState.IDLE,
+                    currentTrack = null,
+                    currentIndex = null,
+                    positionMs = 0L,
+                    durationMs = null,
+                    bufferedPositionMs = null,
+                    queue = clearedQueue,
+                )
+            } else {
+                val targetIndex = resolvePostRemovalIndex(queueSnapshot.currentIndex, index, remainingItems.lastIndex)
+                if (!runRuntimeOperation {
+                    playbackRuntime.replaceQueue(remainingItems.map(::toRuntimeTrackSource), targetIndex)
+                }) {
+                    return snapshotStore.getPlaybackSnapshot()
+                }
+
+                val updatedQueue = queueManager.replaceQueue(remainingItems, targetIndex)
+                val runtimeSnapshot = playbackRuntime.snapshot()
+                val currentTrack = queueManager.getCurrentTrack()
+                val isSameTrack = currentTrack?.id == previousSnapshot.currentTrack?.id
+                val nextState = when {
+                    updatedQueue.items.isEmpty() -> LegatoAndroidPlaybackState.IDLE
+                    previousSnapshot.state == LegatoAndroidPlaybackState.IDLE -> LegatoAndroidPlaybackState.READY
+                    else -> previousSnapshot.state
+                }
+
+                LegatoAndroidPlaybackSnapshot(
+                    state = nextState,
+                    currentTrack = currentTrack,
+                    currentIndex = runtimeSnapshot.currentIndex ?: updatedQueue.currentIndex,
+                    positionMs = if (isSameTrack) previousSnapshot.positionMs else runtimeSnapshot.progress.positionMs,
+                    durationMs = runtimeSnapshot.progress.durationMs ?: currentTrack?.durationMs,
+                    bufferedPositionMs = if (isSameTrack) {
+                        previousSnapshot.bufferedPositionMs
+                    } else {
+                        runtimeSnapshot.progress.bufferedPositionMs
+                    },
+                    queue = updatedQueue,
+                )
+            }
+
+            snapshotStore.replacePlaybackSnapshot(nextSnapshot)
+            publishQueueAndTrack(nextSnapshot)
+            publishMetadata(nextSnapshot.currentTrack)
+            publishProgress(nextSnapshot)
+            if (nextSnapshot.state != previousSnapshot.state) {
+                publishState(nextSnapshot.state)
+            }
+
+            nextSnapshot
+        }.getOrElse { error ->
+            publishPlatformFailure(error)
+            snapshotStore.getPlaybackSnapshot()
+        }
+    }
+
+    suspend fun reset(): LegatoAndroidPlaybackSnapshot {
+        guardSetup()
+
+        return runCatching {
+            if (!runRuntimeOperation {
+                playbackRuntime.stop(resetPosition = true)
+            }) {
+                return snapshotStore.getPlaybackSnapshot()
+            }
+            if (!runRuntimeOperation {
+                playbackRuntime.replaceQueue(emptyList(), null)
+            }) {
+                return snapshotStore.getPlaybackSnapshot()
+            }
+
+            val previousSnapshot = snapshotStore.getPlaybackSnapshot()
+            val clearedQueue = queueManager.replaceQueue(emptyList(), null)
+            pauseOrigin = LegatoAndroidPauseOrigin.USER
+            val resetSnapshot = LegatoAndroidPlaybackSnapshot(
+                state = LegatoAndroidPlaybackState.IDLE,
+                currentTrack = null,
+                currentIndex = null,
+                positionMs = 0L,
+                durationMs = null,
+                bufferedPositionMs = null,
+                queue = clearedQueue,
+            )
+
+            snapshotStore.replacePlaybackSnapshot(resetSnapshot)
+            publishQueueAndTrack(resetSnapshot)
+            publishMetadata(null)
+            publishProgress(resetSnapshot)
+            if (previousSnapshot.state != resetSnapshot.state) {
+                publishState(resetSnapshot.state)
+            }
+
+            resetSnapshot
+        }.getOrElse { error ->
+            publishPlatformFailure(error)
+            snapshotStore.getPlaybackSnapshot()
+        }
+    }
+
     suspend fun seekTo(positionMs: Long) {
         guardSetup()
         executeSeekTo(positionMs)
@@ -187,6 +308,19 @@ class LegatoAndroidPlayerEngine(
             )
         }
         publishProgress(snapshotStore.getPlaybackSnapshot())
+    }
+
+    private fun resolvePostRemovalIndex(previousIndex: Int?, removedIndex: Int, lastIndex: Int): Int {
+        if (lastIndex < 0) {
+            return 0
+        }
+
+        return when (previousIndex) {
+            null -> 0
+            in (removedIndex + 1)..Int.MAX_VALUE -> (previousIndex - 1).coerceIn(0, lastIndex)
+            removedIndex -> removedIndex.coerceIn(0, lastIndex)
+            else -> previousIndex.coerceIn(0, lastIndex)
+        }
     }
 
     private fun executeSkipToNext() {

--- a/native/android/core/src/main/kotlin/io/legato/core/session/LegatoAndroidSessionRuntime.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/session/LegatoAndroidSessionRuntime.kt
@@ -64,7 +64,7 @@ class LegatoAndroidNoopSessionRuntime : LegatoAndroidSessionRuntime {
     private var interruptionListener: ((LegatoAndroidInterruptionSignal) -> Unit)? = null
 
     override fun configureSession() {
-        // Intentionally no-op. Media3/AudioFocus wiring is pending.
+        // Intentionally no-op. Use runtime-backed implementations when platform wiring is available.
     }
 
     override fun audioFocusPolicy(): LegatoAndroidAudioFocusPolicy =
@@ -75,7 +75,7 @@ class LegatoAndroidNoopSessionRuntime : LegatoAndroidSessionRuntime {
     }
 
     override fun onInterruption(signal: LegatoAndroidInterruptionSignal) {
-        // Intentionally no-op. Runtime callback handling is pending.
+        // Intentionally no-op. No listener projection in noop runtime.
     }
 
     override fun updatePlaybackState(state: LegatoAndroidPlaybackState) {
@@ -100,7 +100,7 @@ class LegatoAndroidAudioFocusSessionRuntime : LegatoAndroidSessionRuntime {
     private var interruptionListener: ((LegatoAndroidInterruptionSignal) -> Unit)? = null
 
     override fun configureSession() {
-        // Session wiring hooks are intentionally deferred to plugin/service integration batch.
+        // Configuration is owned by the Android adapter (service/app) boundary.
     }
 
     override fun audioFocusPolicy(): LegatoAndroidAudioFocusPolicy =
@@ -115,15 +115,15 @@ class LegatoAndroidAudioFocusSessionRuntime : LegatoAndroidSessionRuntime {
     }
 
     override fun updatePlaybackState(state: LegatoAndroidPlaybackState) {
-        // Runtime-backed media session publication is deferred.
+        // Publication is owned by service/media-session adapter.
     }
 
     override fun updateNowPlayingMetadata(metadata: LegatoAndroidNowPlayingMetadata?) {
-        // Runtime-backed metadata publication is deferred.
+        // Publication is owned by service/media-session adapter.
     }
 
     override fun updateProgress(progress: LegatoAndroidProgressUpdate) {
-        // Runtime-backed progress publication is deferred.
+        // Publication is owned by service/media-session adapter.
     }
 
     override fun releaseSession() {

--- a/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineInterruptionPolicyTest.kt
+++ b/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineInterruptionPolicyTest.kt
@@ -96,6 +96,54 @@ class LegatoAndroidPlayerEngineInterruptionPolicyTest {
     }
 
     @Test
+    fun `service-originated becoming noisy signal pauses playback with interruption origin`() = runBlocking {
+        val playbackRuntime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val engine = buildEngine(playbackRuntime, sessionRuntime)
+
+        engine.setup()
+        engine.load(
+            tracks = listOf(
+                LegatoAndroidTrack(
+                    id = "track-1",
+                    url = "https://example.com/audio.mp3",
+                ),
+            ),
+        )
+        engine.play()
+
+        sessionRuntime.emit(LegatoAndroidInterruptionSignal.BecomingNoisy)
+
+        assertEquals(LegatoAndroidPlaybackState.PAUSED, engine.getSnapshot().state)
+        assertEquals(LegatoAndroidPauseOrigin.INTERRUPTION, engine.getPauseOrigin())
+        assertEquals(LegatoAndroidServiceMode.RESUME_PENDING_INTERRUPTION, engine.getServiceMode())
+    }
+
+    @Test
+    fun `service-originated can-duck signal pauses playback and keeps interrupted mode`() = runBlocking {
+        val playbackRuntime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val engine = buildEngine(playbackRuntime, sessionRuntime)
+
+        engine.setup()
+        engine.load(
+            tracks = listOf(
+                LegatoAndroidTrack(
+                    id = "track-1",
+                    url = "https://example.com/audio.mp3",
+                ),
+            ),
+        )
+        engine.play()
+
+        sessionRuntime.emit(LegatoAndroidInterruptionSignal.AudioFocusLostTransientCanDuck)
+
+        assertEquals(LegatoAndroidPlaybackState.PAUSED, engine.getSnapshot().state)
+        assertEquals(LegatoAndroidPauseOrigin.INTERRUPTION, engine.getPauseOrigin())
+        assertEquals(LegatoAndroidServiceMode.RESUME_PENDING_INTERRUPTION, engine.getServiceMode())
+    }
+
+    @Test
     fun `runtime ended callback transitions state and emits playback-ended event`() = runBlocking {
         val playbackRuntime = RecordingPlaybackRuntime()
         val sessionRuntime = RecordingSessionRuntime()

--- a/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineQueueOwnershipTest.kt
+++ b/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineQueueOwnershipTest.kt
@@ -1,0 +1,199 @@
+package io.legato.core.core
+
+import io.legato.core.events.LegatoAndroidEventEmitter
+import io.legato.core.queue.LegatoAndroidQueueManager
+import io.legato.core.remote.LegatoAndroidRemoteCommandManager
+import io.legato.core.remote.LegatoAndroidRemoteCommandRuntime
+import io.legato.core.runtime.LegatoAndroidPlaybackRuntime
+import io.legato.core.runtime.LegatoAndroidPlaybackRuntimeListener
+import io.legato.core.runtime.LegatoAndroidRuntimeSnapshot
+import io.legato.core.runtime.LegatoAndroidRuntimeTrackSource
+import io.legato.core.session.LegatoAndroidAudioFocusGainHint
+import io.legato.core.session.LegatoAndroidAudioFocusPolicy
+import io.legato.core.session.LegatoAndroidInterruptionSignal
+import io.legato.core.session.LegatoAndroidSessionManager
+import io.legato.core.session.LegatoAndroidSessionRuntime
+import io.legato.core.snapshot.LegatoAndroidSnapshotStore
+import io.legato.core.state.LegatoAndroidStateMachine
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LegatoAndroidPlayerEngineQueueOwnershipTest {
+    @Test
+    fun `remove rebinds runtime queue and keeps canonical snapshot in sync`() = runBlocking {
+        val runtime = RecordingQueuePlaybackRuntime()
+        val engine = buildEngine(runtime)
+
+        engine.setup()
+        engine.load(
+            tracks = listOf(
+                LegatoAndroidTrack(id = "track-1", url = "https://example.com/1.mp3", durationMs = 111_000L),
+                LegatoAndroidTrack(id = "track-2", url = "https://example.com/2.mp3", durationMs = 222_000L),
+                LegatoAndroidTrack(id = "track-3", url = "https://example.com/3.mp3", durationMs = 333_000L),
+            ),
+            startIndex = 1,
+        )
+
+        engine.remove(index = 1)
+
+        assertEquals(listOf("track-1", "track-3"), runtime.lastQueueIds)
+        assertEquals(1, runtime.lastStartIndex)
+        val snapshot = engine.getSnapshot()
+        assertEquals(listOf("track-1", "track-3"), snapshot.queue.items.map { it.id })
+        assertEquals(1, snapshot.currentIndex)
+        assertEquals("track-3", snapshot.currentTrack?.id)
+    }
+
+    @Test
+    fun `remove shifts current index when deleting earlier queue item`() = runBlocking {
+        val runtime = RecordingQueuePlaybackRuntime()
+        val engine = buildEngine(runtime)
+
+        engine.setup()
+        engine.load(
+            tracks = listOf(
+                LegatoAndroidTrack(id = "track-1", url = "https://example.com/1.mp3"),
+                LegatoAndroidTrack(id = "track-2", url = "https://example.com/2.mp3"),
+                LegatoAndroidTrack(id = "track-3", url = "https://example.com/3.mp3"),
+            ),
+            startIndex = 2,
+        )
+
+        engine.remove(index = 0)
+
+        assertEquals(listOf("track-2", "track-3"), runtime.lastQueueIds)
+        assertEquals(1, runtime.lastStartIndex)
+        assertEquals(1, engine.getSnapshot().currentIndex)
+        assertEquals("track-3", engine.getSnapshot().currentTrack?.id)
+    }
+
+    @Test
+    fun `reset clears queue and projects service mode off`() = runBlocking {
+        val runtime = RecordingQueuePlaybackRuntime()
+        val engine = buildEngine(runtime)
+
+        engine.setup()
+        engine.load(
+            tracks = listOf(
+                LegatoAndroidTrack(id = "track-1", url = "https://example.com/1.mp3"),
+                LegatoAndroidTrack(id = "track-2", url = "https://example.com/2.mp3"),
+            ),
+        )
+        engine.play()
+
+        engine.reset()
+
+        val snapshot = engine.getSnapshot()
+        assertTrue(snapshot.queue.items.isEmpty())
+        assertEquals(null, snapshot.currentIndex)
+        assertEquals(LegatoAndroidPlaybackState.IDLE, snapshot.state)
+        assertEquals(LegatoAndroidServiceMode.OFF, engine.getServiceMode())
+    }
+
+    @Test
+    fun `reset from idle remains idempotent and keeps empty queue`() = runBlocking {
+        val runtime = RecordingQueuePlaybackRuntime()
+        val engine = buildEngine(runtime)
+
+        engine.setup()
+        engine.reset()
+
+        val snapshot = engine.getSnapshot()
+        assertTrue(snapshot.queue.items.isEmpty())
+        assertEquals(LegatoAndroidPlaybackState.IDLE, snapshot.state)
+    }
+
+    private fun buildEngine(playbackRuntime: RecordingQueuePlaybackRuntime): LegatoAndroidPlayerEngine {
+        val sessionRuntime = object : LegatoAndroidSessionRuntime {
+            override fun configureSession() = Unit
+
+            override fun audioFocusPolicy(): LegatoAndroidAudioFocusPolicy =
+                LegatoAndroidAudioFocusPolicy(
+                    gainHint = LegatoAndroidAudioFocusGainHint.AUDIOFOCUS_GAIN,
+                    pauseOnTransientLoss = true,
+                    duckOnTransientCanDuck = true,
+                    resumeAfterGainIfNotUserPaused = false,
+                )
+
+            override fun setInterruptionListener(listener: ((LegatoAndroidInterruptionSignal) -> Unit)?) = Unit
+
+            override fun onInterruption(signal: LegatoAndroidInterruptionSignal) = Unit
+
+            override fun updatePlaybackState(state: LegatoAndroidPlaybackState) = Unit
+
+            override fun updateNowPlayingMetadata(metadata: LegatoAndroidNowPlayingMetadata?) = Unit
+
+            override fun updateProgress(progress: LegatoAndroidProgressUpdate) = Unit
+
+            override fun releaseSession() = Unit
+        }
+
+        return LegatoAndroidPlayerEngine(
+            queueManager = LegatoAndroidQueueManager(),
+            eventEmitter = LegatoAndroidEventEmitter(),
+            snapshotStore = LegatoAndroidSnapshotStore(),
+            trackMapper = io.legato.core.mapping.LegatoAndroidTrackMapper(),
+            errorMapper = io.legato.core.errors.LegatoAndroidErrorMapper(),
+            stateMachine = LegatoAndroidStateMachine(),
+            sessionManager = LegatoAndroidSessionManager(sessionRuntime),
+            remoteCommandManager = LegatoAndroidRemoteCommandManager(object : LegatoAndroidRemoteCommandRuntime {
+                override fun bind(listener: (LegatoAndroidRemoteCommand) -> Unit) = Unit
+                override fun updatePlaybackState(state: LegatoAndroidPlaybackState) = Unit
+                override fun unbind() = Unit
+            }),
+            playbackRuntime = playbackRuntime,
+        )
+    }
+}
+
+private class RecordingQueuePlaybackRuntime : LegatoAndroidPlaybackRuntime {
+    private var listener: LegatoAndroidPlaybackRuntimeListener? = null
+    private var snapshot = LegatoAndroidRuntimeSnapshot()
+
+    var lastQueueIds: List<String> = emptyList()
+        private set
+
+    var lastStartIndex: Int? = null
+        private set
+
+    override fun configure() = Unit
+
+    override fun setListener(listener: LegatoAndroidPlaybackRuntimeListener?) {
+        this.listener = listener
+    }
+
+    override fun replaceQueue(items: List<LegatoAndroidRuntimeTrackSource>, startIndex: Int?) {
+        lastQueueIds = items.map { it.id }
+        lastStartIndex = startIndex
+        snapshot = snapshot.copy(
+            currentIndex = if (items.isEmpty()) null else (startIndex ?: 0),
+            progress = snapshot.progress.copy(positionMs = 0L, bufferedPositionMs = 0L),
+        )
+    }
+
+    override fun selectIndex(index: Int) {
+        snapshot = snapshot.copy(currentIndex = index)
+    }
+
+    override fun play() = Unit
+
+    override fun pause() = Unit
+
+    override fun stop(resetPosition: Boolean) {
+        if (resetPosition) {
+            snapshot = snapshot.copy(progress = snapshot.progress.copy(positionMs = 0L, bufferedPositionMs = 0L))
+        }
+    }
+
+    override fun seekTo(positionMs: Long) {
+        snapshot = snapshot.copy(progress = snapshot.progress.copy(positionMs = positionMs))
+    }
+
+    override fun snapshot(): LegatoAndroidRuntimeSnapshot = snapshot
+
+    override fun release() {
+        listener = null
+    }
+}

--- a/native/android/core/src/test/kotlin/io/legato/core/runtime/LegatoAndroidMedia3PlaybackRuntimeTest.kt
+++ b/native/android/core/src/test/kotlin/io/legato/core/runtime/LegatoAndroidMedia3PlaybackRuntimeTest.kt
@@ -102,6 +102,38 @@ class LegatoAndroidMedia3PlaybackRuntimeTest {
 
         assertEquals(listOf("prepare", "play"), playerCalls)
     }
+
+    @Test
+    fun `replace queue rebind clears progress and keeps provided start index`() {
+        val runtime = LegatoAndroidMedia3PlaybackRuntime()
+        runtime.dispatchProgress(positionMs = 9_500L, durationMs = 120_000L, bufferedPositionMs = 12_000L, currentIndex = 1)
+
+        runtime.replaceQueue(
+            items = listOf(
+                LegatoAndroidRuntimeTrackSource(id = "track-1", url = "https://example.com/1.mp3", headers = emptyMap(), type = null),
+                LegatoAndroidRuntimeTrackSource(id = "track-2", url = "https://example.com/2.mp3", headers = emptyMap(), type = null),
+            ),
+            startIndex = 1,
+        )
+
+        val snapshot = runtime.snapshot()
+        assertEquals(1, snapshot.currentIndex)
+        assertEquals(0L, snapshot.progress.positionMs)
+        assertEquals(0L, snapshot.progress.bufferedPositionMs)
+        assertEquals(null, snapshot.progress.durationMs)
+    }
+
+    @Test
+    fun `replace queue with empty items clears active index`() {
+        val runtime = LegatoAndroidMedia3PlaybackRuntime()
+        runtime.dispatchProgress(positionMs = 4_000L, durationMs = 60_000L, bufferedPositionMs = 8_000L, currentIndex = 0)
+
+        runtime.replaceQueue(items = emptyList(), startIndex = null)
+
+        val snapshot = runtime.snapshot()
+        assertEquals(null, snapshot.currentIndex)
+        assertEquals(0L, snapshot.progress.positionMs)
+    }
 }
 
 private class QueueingCommandExecutor : PlayerCommandExecutor {

--- a/packages/capacitor/README.md
+++ b/packages/capacitor/README.md
@@ -124,7 +124,8 @@ Maintainer-heavy CLI/release/SPM operational details are documented in [`../../d
 
 ## MVP limitations
 
-- Native runtime playback wiring (ExoPlayer/AVPlayer) is still pending in core.
-- This binding only bridges the current native core semantics/state/events.
-- Behavior is intentionally minimal and contract-first.
-- Android background playback/service wiring is groundwork-only in Milestone 1 (contract + stub service), not production parity.
+- Android runtime playback is implemented (Media3/ExoPlayer runtime + foreground service transport controls) for package-supported flows.
+- This binding bridges current native core semantics/state/events and keeps queue/state/event ownership aligned.
+- Interruption handling policy in runtime-v1 is explicit: focus loss/noisy pauses playback; focus gain does not auto-resume.
+- Non-goals for this milestone: process-death restore, broad lifecycle/OEM hardening, and cross-platform parity expansion.
+- Those deferred items move to follow-up milestones (`android-background-lifecycle-v1` and platform parity tracks), not runtime-v1.

--- a/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoAndroidPlaybackCoordinator.kt
+++ b/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoAndroidPlaybackCoordinator.kt
@@ -9,7 +9,9 @@ import io.legato.core.core.LegatoAndroidCoreDependencies
 import io.legato.core.core.LegatoAndroidCoreFactory
 import io.legato.core.core.LegatoAndroidNowPlayingMetadata
 import io.legato.core.core.LegatoAndroidPauseOrigin
+import io.legato.core.core.LegatoAndroidPlaybackSnapshot
 import io.legato.core.core.LegatoAndroidPlaybackState
+import io.legato.core.core.LegatoAndroidQueueSnapshot
 import io.legato.core.core.LegatoAndroidServiceMode
 import io.legato.core.core.LegatoAndroidTrack
 import io.legato.core.runtime.LegatoAndroidMedia3PlaybackRuntime
@@ -142,6 +144,134 @@ internal class LegatoAndroidPlaybackCoordinator(
         projectServiceMode()
         projectPlaybackState()
         projectNowPlayingMetadata()
+    }
+
+    fun remove(index: Int) {
+        val previousSnapshot = core.playerEngine.getSnapshot()
+        val queueSnapshot = core.queueManager.getQueueSnapshot()
+        require(index in queueSnapshot.items.indices) { "remove index out of bounds" }
+
+        val remainingItems = queueSnapshot.items.toMutableList().apply { removeAt(index) }
+        if (remainingItems.isEmpty()) {
+            core.playbackRuntime.replaceQueue(emptyList(), null)
+            core.queueManager.clear()
+            core.snapshotStore.replacePlaybackSnapshot(
+                LegatoAndroidPlaybackSnapshot(
+                    state = LegatoAndroidPlaybackState.IDLE,
+                    currentTrack = null,
+                    currentIndex = null,
+                    positionMs = 0L,
+                    durationMs = null,
+                    bufferedPositionMs = null,
+                    queue = LegatoAndroidQueueSnapshot(items = emptyList(), currentIndex = null),
+                ),
+            )
+        } else {
+            val targetIndex = resolvePostRemovalIndex(queueSnapshot.currentIndex, index, remainingItems.lastIndex)
+            val nextQueue = core.queueManager.replaceQueue(remainingItems, targetIndex)
+            core.playbackRuntime.replaceQueue(remainingItems.map(::toRuntimeTrackSource), targetIndex)
+            val runtimeSnapshot = core.playbackRuntime.snapshot()
+            val nextSnapshot = snapshotWithQueue(previousSnapshot, nextQueue, runtimeSnapshot.currentIndex)
+            core.snapshotStore.replacePlaybackSnapshot(nextSnapshot)
+        }
+
+        val next = core.snapshotStore.getPlaybackSnapshot()
+        publishQueueTrackProgress(next)
+        if (previousSnapshot.state != next.state) {
+            core.eventEmitter.emit(
+                name = io.legato.core.core.LegatoAndroidEventName.PLAYBACK_STATE_CHANGED,
+                payload = io.legato.core.core.LegatoAndroidEventPayload.PlaybackStateChanged(next.state),
+            )
+        }
+        projectServiceMode()
+        projectPlaybackState()
+        projectNowPlayingMetadata()
+    }
+
+    fun reset() {
+        core.playbackRuntime.stop(resetPosition = true)
+        core.playbackRuntime.replaceQueue(emptyList(), null)
+        core.queueManager.clear()
+        val snapshot = LegatoAndroidPlaybackSnapshot(
+            state = LegatoAndroidPlaybackState.IDLE,
+            currentTrack = null,
+            currentIndex = null,
+            positionMs = 0L,
+            durationMs = null,
+            bufferedPositionMs = null,
+            queue = LegatoAndroidQueueSnapshot(items = emptyList(), currentIndex = null),
+        )
+        core.snapshotStore.replacePlaybackSnapshot(snapshot)
+        publishQueueTrackProgress(snapshot)
+        core.eventEmitter.emit(
+            name = io.legato.core.core.LegatoAndroidEventName.PLAYBACK_STATE_CHANGED,
+            payload = io.legato.core.core.LegatoAndroidEventPayload.PlaybackStateChanged(snapshot.state),
+        )
+        projectServiceMode()
+        projectPlaybackState()
+        projectNowPlayingMetadata()
+    }
+
+    private fun publishQueueTrackProgress(snapshot: LegatoAndroidPlaybackSnapshot) {
+        core.eventEmitter.emit(
+            name = io.legato.core.core.LegatoAndroidEventName.PLAYBACK_QUEUE_CHANGED,
+            payload = io.legato.core.core.LegatoAndroidEventPayload.QueueChanged(snapshot.queue),
+        )
+        core.eventEmitter.emit(
+            name = io.legato.core.core.LegatoAndroidEventName.PLAYBACK_ACTIVE_TRACK_CHANGED,
+            payload = io.legato.core.core.LegatoAndroidEventPayload.ActiveTrackChanged(snapshot.currentTrack, snapshot.currentIndex),
+        )
+        core.eventEmitter.emit(
+            name = io.legato.core.core.LegatoAndroidEventName.PLAYBACK_PROGRESS,
+            payload = io.legato.core.core.LegatoAndroidEventPayload.PlaybackProgress(
+                positionMs = snapshot.positionMs,
+                durationMs = snapshot.durationMs,
+                bufferedPositionMs = snapshot.bufferedPositionMs,
+            ),
+        )
+    }
+
+    private fun resolvePostRemovalIndex(previousIndex: Int?, removedIndex: Int, lastIndex: Int): Int {
+        return when (previousIndex) {
+            null -> 0
+            in (removedIndex + 1)..Int.MAX_VALUE -> (previousIndex - 1).coerceIn(0, lastIndex)
+            removedIndex -> removedIndex.coerceIn(0, lastIndex)
+            else -> previousIndex.coerceIn(0, lastIndex)
+        }
+    }
+
+    private fun snapshotWithQueue(
+        previous: LegatoAndroidPlaybackSnapshot,
+        queue: LegatoAndroidQueueSnapshot,
+        runtimeCurrentIndex: Int?,
+    ): LegatoAndroidPlaybackSnapshot {
+        val fallbackIndex = if (queue.items.isNotEmpty()) 0 else null
+        val nextIndex = runtimeCurrentIndex ?: queue.currentIndex ?: fallbackIndex
+        val track = nextIndex?.let(queue.items::getOrNull)
+        val nextState = when {
+            queue.items.isEmpty() -> LegatoAndroidPlaybackState.IDLE
+            previous.state == LegatoAndroidPlaybackState.IDLE -> LegatoAndroidPlaybackState.READY
+            else -> previous.state
+        }
+
+        return LegatoAndroidPlaybackSnapshot(
+            state = nextState,
+            currentTrack = track,
+            currentIndex = nextIndex,
+            positionMs = if (track?.id == previous.currentTrack?.id) previous.positionMs else 0L,
+            durationMs = track?.durationMs,
+            bufferedPositionMs = if (track?.id == previous.currentTrack?.id) previous.bufferedPositionMs else 0L,
+            queue = queue,
+        )
+    }
+
+    private fun toRuntimeTrackSource(track: LegatoAndroidTrack): io.legato.core.runtime.LegatoAndroidRuntimeTrackSource {
+        return io.legato.core.runtime.LegatoAndroidRuntimeTrackSource(
+            id = track.id,
+            url = track.url,
+            headers = track.headers,
+            type = track.type,
+        )
     }
 
     fun addCoreEventListener(listener: (io.legato.core.core.LegatoAndroidEvent) -> Unit): Long =

--- a/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackService.kt
+++ b/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackService.kt
@@ -5,10 +5,14 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.media.AudioFocusRequest
+import android.media.AudioManager
 import android.media.MediaMetadata
 import android.media.session.MediaSession
 import android.media.session.PlaybackState
@@ -19,6 +23,7 @@ import io.legato.core.core.LegatoAndroidNowPlayingMetadata
 import io.legato.core.core.LegatoAndroidPlaybackState
 import io.legato.core.core.LegatoAndroidServiceMode
 import io.legato.core.queue.LegatoAndroidTransportCapabilitiesProjector
+import io.legato.core.session.LegatoAndroidInterruptionSignal
 import java.net.URL
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -46,6 +51,12 @@ class LegatoPlaybackService : Service() {
     private val artworkLoader: LegatoPlaybackArtworkLoader = DefaultLegatoPlaybackArtworkLoader
     private val artworkDiagnostics: LegatoPlaybackArtworkDiagnostics = AndroidLogcatArtworkDiagnostics
     private val artworkScope: CoroutineScope = CoroutineScope(SupervisorJob())
+    private var audioManager: AudioManager? = null
+    private var audioFocusListener: AudioManager.OnAudioFocusChangeListener? = null
+    private var audioFocusRequest: AudioFocusRequest? = null
+    private var hasAudioFocus: Boolean = false
+    private var noisyReceiver: BroadcastReceiver? = null
+    private var noisyReceiverRegistered: Boolean = false
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -92,6 +103,8 @@ class LegatoPlaybackService : Service() {
         syncMediaSessionPlaybackState(currentPlaybackState)
         publishNowPlayingSurfaces()
         refreshArtworkFor(currentNowPlayingMetadata)
+        setupInterruptionIngestion()
+        reconcileAudioFocusForState(currentPlaybackState)
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -121,6 +134,7 @@ class LegatoPlaybackService : Service() {
         activeArtworkJob?.cancel()
         activeArtworkJob = null
         artworkScope.cancel()
+        teardownInterruptionIngestion()
 
         mediaSession?.release()
         mediaSession = null
@@ -135,6 +149,7 @@ class LegatoPlaybackService : Service() {
     private fun onServiceModeChanged(mode: LegatoAndroidServiceMode) {
         currentMode = mode
         if (mode == LegatoAndroidServiceMode.OFF) {
+            abandonAudioFocusIfHeld()
             if (foregroundActive) {
                 stopForeground(STOP_FOREGROUND_REMOVE)
                 foregroundActive = false
@@ -150,6 +165,7 @@ class LegatoPlaybackService : Service() {
         currentPlaybackState = state
         syncMediaSessionPlaybackState(state)
         publishNowPlayingSurfaces()
+        reconcileAudioFocusForState(state)
     }
 
     private fun onNowPlayingMetadataChanged(metadata: LegatoAndroidNowPlayingMetadata?) {
@@ -161,6 +177,108 @@ class LegatoPlaybackService : Service() {
         }
         publishNowPlayingSurfaces()
         refreshArtworkFor(metadata)
+    }
+
+    private fun setupInterruptionIngestion() {
+        val manager = getSystemService(Context.AUDIO_SERVICE) as? AudioManager ?: return
+        audioManager = manager
+
+        val focusListener = AudioManager.OnAudioFocusChangeListener { focusChange ->
+            val signal = interruptionSignalFromAudioFocusChange(focusChange) ?: return@OnAudioFocusChangeListener
+            coordinator.core.mediaSessionBridge.onInterruption(signal)
+        }
+        audioFocusListener = focusListener
+        audioFocusRequest = buildAudioFocusRequest(focusListener)
+
+        if (noisyReceiver == null) {
+            noisyReceiver = object : BroadcastReceiver() {
+                override fun onReceive(context: Context?, intent: Intent?) {
+                    if (intent?.action == AudioManager.ACTION_AUDIO_BECOMING_NOISY) {
+                        coordinator.core.mediaSessionBridge.onInterruption(
+                            LegatoAndroidInterruptionSignal.BecomingNoisy,
+                        )
+                    }
+                }
+            }
+        }
+
+        if (!noisyReceiverRegistered) {
+            registerReceiver(noisyReceiver, IntentFilter(AudioManager.ACTION_AUDIO_BECOMING_NOISY))
+            noisyReceiverRegistered = true
+        }
+    }
+
+    private fun teardownInterruptionIngestion() {
+        abandonAudioFocusIfHeld()
+        if (noisyReceiverRegistered) {
+            runCatching { unregisterReceiver(noisyReceiver) }
+            noisyReceiverRegistered = false
+        }
+
+        noisyReceiver = null
+        audioFocusListener = null
+        audioFocusRequest = null
+        audioManager = null
+    }
+
+    private fun reconcileAudioFocusForState(state: LegatoAndroidPlaybackState) {
+        if (state == LegatoAndroidPlaybackState.PLAYING || state == LegatoAndroidPlaybackState.BUFFERING) {
+            requestAudioFocusIfNeeded()
+        } else {
+            abandonAudioFocusIfHeld()
+        }
+    }
+
+    private fun requestAudioFocusIfNeeded() {
+        if (hasAudioFocus) {
+            return
+        }
+
+        val manager = audioManager ?: return
+        val focusRequest = audioFocusRequest
+        val granted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && focusRequest != null) {
+            manager.requestAudioFocus(focusRequest) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+        } else {
+            @Suppress("DEPRECATION")
+            manager.requestAudioFocus(
+                audioFocusListener,
+                AudioManager.STREAM_MUSIC,
+                AudioManager.AUDIOFOCUS_GAIN,
+            ) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+        }
+        hasAudioFocus = granted
+    }
+
+    private fun abandonAudioFocusIfHeld() {
+        if (!hasAudioFocus) {
+            return
+        }
+
+        val manager = audioManager ?: return
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val focusRequest = audioFocusRequest
+            if (focusRequest != null) {
+                manager.abandonAudioFocusRequest(focusRequest)
+            }
+        } else {
+            @Suppress("DEPRECATION")
+            manager.abandonAudioFocus(audioFocusListener)
+        }
+        hasAudioFocus = false
+    }
+
+    private fun buildAudioFocusRequest(
+        listener: AudioManager.OnAudioFocusChangeListener,
+    ): AudioFocusRequest? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return null
+        }
+
+        return AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+            .setAcceptsDelayedFocusGain(false)
+            .setWillPauseWhenDucked(true)
+            .setOnAudioFocusChangeListener(listener)
+            .build()
     }
 
     private fun refreshArtworkFor(metadata: LegatoAndroidNowPlayingMetadata?) {
@@ -399,6 +517,16 @@ class LegatoPlaybackService : Service() {
         private const val REQUEST_CODE_TRANSPORT_BASE: Int = 1002
         private const val MAX_COMPACT_ACTIONS: Int = 3
         private const val MEDIA_SESSION_TAG: String = "legato.playback"
+    }
+}
+
+internal fun interruptionSignalFromAudioFocusChange(focusChange: Int): LegatoAndroidInterruptionSignal? {
+    return when (focusChange) {
+        AudioManager.AUDIOFOCUS_GAIN -> LegatoAndroidInterruptionSignal.AudioFocusGained
+        AudioManager.AUDIOFOCUS_LOSS -> LegatoAndroidInterruptionSignal.AudioFocusLost
+        AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> LegatoAndroidInterruptionSignal.AudioFocusLostTransient
+        AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> LegatoAndroidInterruptionSignal.AudioFocusLostTransientCanDuck
+        else -> null
     }
 }
 

--- a/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlugin.kt
+++ b/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlugin.kt
@@ -8,8 +8,6 @@ import com.getcapacitor.annotation.CapacitorPlugin
 import io.legato.core.core.LegatoAndroidEventName
 import io.legato.core.core.LegatoAndroidEventPayload
 import io.legato.core.core.LegatoAndroidPlaybackSnapshot
-import io.legato.core.core.LegatoAndroidPlaybackState
-import io.legato.core.core.LegatoAndroidQueueSnapshot
 import io.legato.core.core.LegatoAndroidErrorCode
 
 @CapacitorPlugin(name = "Legato")
@@ -57,77 +55,16 @@ class LegatoPlugin : Plugin() {
     fun remove(call: PluginCall) {
         runCatching {
             val index = resolveRemovalIndex(call)
-            val queue = core.queueManager.getQueueSnapshot()
-            val mutableItems = queue.items.toMutableList()
-
-            require(index in mutableItems.indices) { "remove index out of bounds" }
-            mutableItems.removeAt(index)
-
-            val previousSnapshot = core.snapshotStore.getPlaybackSnapshot()
-            if (mutableItems.isEmpty()) {
-                core.queueManager.clear()
-                core.snapshotStore.replacePlaybackSnapshot(
-                    LegatoAndroidPlaybackSnapshot(
-                        state = LegatoAndroidPlaybackState.IDLE,
-                        currentTrack = null,
-                        currentIndex = null,
-                        positionMs = 0L,
-                        durationMs = null,
-                        bufferedPositionMs = null,
-                        queue = LegatoAndroidQueueSnapshot(items = emptyList(), currentIndex = null),
-                    ),
-                )
-            } else {
-                val targetIndex = when (val previousIndex = queue.currentIndex) {
-                    null -> 0
-                    in (index + 1)..Int.MAX_VALUE -> previousIndex - 1
-                    index -> index.coerceAtMost(mutableItems.lastIndex)
-                    else -> previousIndex.coerceAtMost(mutableItems.lastIndex)
-                }
-
-                val nextQueue = core.queueManager.replaceQueue(mutableItems, targetIndex)
-                val nextSnapshot = snapshotWithQueue(previousSnapshot, nextQueue)
-                core.snapshotStore.replacePlaybackSnapshot(nextSnapshot)
-            }
-
-            val next = core.snapshotStore.getPlaybackSnapshot()
-            publishQueueTrackProgress(next)
-            if (previousSnapshot.state != next.state) {
-                core.eventEmitter.emit(
-                    name = LegatoAndroidEventName.PLAYBACK_STATE_CHANGED,
-                    payload = LegatoAndroidEventPayload.PlaybackStateChanged(next.state),
-                )
-            }
-
-            coordinator.projectServiceMode()
-
-            call.resolve(snapshotResult(next))
+            coordinator.remove(index)
+            call.resolve(snapshotResult(core.playerEngine.getSnapshot()))
         }.onFailure { reject(call, it) }
     }
 
     @PluginMethod
     fun reset(call: PluginCall) {
         runCatching {
-            core.queueManager.clear()
-            val snapshot = LegatoAndroidPlaybackSnapshot(
-                state = LegatoAndroidPlaybackState.IDLE,
-                currentTrack = null,
-                currentIndex = null,
-                positionMs = 0L,
-                durationMs = null,
-                bufferedPositionMs = null,
-                queue = LegatoAndroidQueueSnapshot(items = emptyList(), currentIndex = null),
-            )
-            core.snapshotStore.replacePlaybackSnapshot(snapshot)
-            publishQueueTrackProgress(snapshot)
-            core.eventEmitter.emit(
-                name = LegatoAndroidEventName.PLAYBACK_STATE_CHANGED,
-                payload = LegatoAndroidEventPayload.PlaybackStateChanged(snapshot.state),
-            )
-
-            coordinator.projectServiceMode()
-
-            call.resolve(snapshotResult(snapshot))
+            coordinator.reset()
+            call.resolve(snapshotResult(core.playerEngine.getSnapshot()))
         }.onFailure { reject(call, it) }
     }
 
@@ -233,25 +170,6 @@ class LegatoPlugin : Plugin() {
         call.resolve(snapshotResult(core.playerEngine.getSnapshot()))
     }
 
-    private fun publishQueueTrackProgress(snapshot: LegatoAndroidPlaybackSnapshot) {
-        core.eventEmitter.emit(
-            name = LegatoAndroidEventName.PLAYBACK_QUEUE_CHANGED,
-            payload = LegatoAndroidEventPayload.QueueChanged(snapshot.queue),
-        )
-        core.eventEmitter.emit(
-            name = LegatoAndroidEventName.PLAYBACK_ACTIVE_TRACK_CHANGED,
-            payload = LegatoAndroidEventPayload.ActiveTrackChanged(snapshot.currentTrack, snapshot.currentIndex),
-        )
-        core.eventEmitter.emit(
-            name = LegatoAndroidEventName.PLAYBACK_PROGRESS,
-            payload = LegatoAndroidEventPayload.PlaybackProgress(
-                positionMs = snapshot.positionMs,
-                durationMs = snapshot.durationMs,
-                bufferedPositionMs = snapshot.bufferedPositionMs,
-            ),
-        )
-    }
-
     private fun resolveRemovalIndex(call: PluginCall): Int {
         call.getInt("index")?.let { return it }
 
@@ -262,30 +180,6 @@ class LegatoPlugin : Plugin() {
         val resolved = queue.items.indexOfFirst { it.id == id }
         require(resolved >= 0) { "remove.id was not found in queue" }
         return resolved
-    }
-
-    private fun snapshotWithQueue(
-        previous: LegatoAndroidPlaybackSnapshot,
-        queue: LegatoAndroidQueueSnapshot,
-    ): LegatoAndroidPlaybackSnapshot {
-        val fallbackIndex = if (queue.items.isNotEmpty()) 0 else null
-        val nextIndex = queue.currentIndex ?: fallbackIndex
-        val track = nextIndex?.let(queue.items::getOrNull)
-        val nextState = when {
-            queue.items.isEmpty() -> LegatoAndroidPlaybackState.IDLE
-            previous.state == LegatoAndroidPlaybackState.IDLE -> LegatoAndroidPlaybackState.READY
-            else -> previous.state
-        }
-
-        return LegatoAndroidPlaybackSnapshot(
-            state = nextState,
-            currentTrack = track,
-            currentIndex = nextIndex,
-            positionMs = if (track?.id == previous.currentTrack?.id) previous.positionMs else 0L,
-            durationMs = track?.durationMs,
-            bufferedPositionMs = if (track?.id == previous.currentTrack?.id) previous.bufferedPositionMs else 0L,
-            queue = queue,
-        )
     }
 
     private fun snapshotResult(snapshot: LegatoAndroidPlaybackSnapshot): JSObject {

--- a/packages/capacitor/android/src/test/kotlin/io/legato/capacitor/LegatoAndroidPlaybackCoordinatorTest.kt
+++ b/packages/capacitor/android/src/test/kotlin/io/legato/capacitor/LegatoAndroidPlaybackCoordinatorTest.kt
@@ -319,6 +319,126 @@ class LegatoAndroidPlaybackCoordinatorTest {
         }
     }
 
+    @Test
+    fun `coordinator remove rebinds canonical queue through runtime`() = runBlocking {
+        val runtime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val coordinator = LegatoAndroidPlaybackCoordinator(
+            core = buildCore(runtime, sessionRuntime),
+            serviceRuntime = RecordingCoordinatorServiceRuntime(),
+        )
+
+        coordinator.setup()
+        coordinator.load(
+            listOf(
+                LegatoAndroidTrack(id = "track-1", url = "https://example.com/1.mp3"),
+                LegatoAndroidTrack(id = "track-2", url = "https://example.com/2.mp3"),
+                LegatoAndroidTrack(id = "track-3", url = "https://example.com/3.mp3"),
+            ),
+            startIndex = 1,
+        )
+
+        coordinator.remove(index = 1)
+
+        assertEquals(listOf("track-1", "track-3"), runtime.lastReplacedQueueIds)
+        assertEquals(2, runtime.replaceQueueCalls)
+        assertEquals("track-3", coordinator.core.playerEngine.getSnapshot().currentTrack?.id)
+    }
+
+    @Test
+    fun `coordinator remove shifts selected index when deleting item before active track`() = runBlocking {
+        val runtime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val coordinator = LegatoAndroidPlaybackCoordinator(
+            core = buildCore(runtime, sessionRuntime),
+            serviceRuntime = RecordingCoordinatorServiceRuntime(),
+        )
+
+        coordinator.setup()
+        coordinator.load(
+            listOf(
+                LegatoAndroidTrack(id = "track-1", url = "https://example.com/1.mp3"),
+                LegatoAndroidTrack(id = "track-2", url = "https://example.com/2.mp3"),
+                LegatoAndroidTrack(id = "track-3", url = "https://example.com/3.mp3"),
+            ),
+            startIndex = 2,
+        )
+
+        coordinator.remove(index = 0)
+
+        assertEquals(listOf("track-2", "track-3"), runtime.lastReplacedQueueIds)
+        assertEquals(1, coordinator.core.playerEngine.getSnapshot().currentIndex)
+    }
+
+    @Test
+    fun `coordinator reset clears queue and returns idle snapshot`() = runBlocking {
+        val runtime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val coordinator = LegatoAndroidPlaybackCoordinator(
+            core = buildCore(runtime, sessionRuntime),
+            serviceRuntime = RecordingCoordinatorServiceRuntime(),
+        )
+
+        coordinator.setup()
+        coordinator.load(
+            listOf(
+                LegatoAndroidTrack(id = "track-1", url = "https://example.com/1.mp3"),
+                LegatoAndroidTrack(id = "track-2", url = "https://example.com/2.mp3"),
+            ),
+        )
+
+        coordinator.reset()
+
+        val snapshot = coordinator.core.playerEngine.getSnapshot()
+        assertTrue(snapshot.queue.items.isEmpty())
+        assertEquals(null, snapshot.currentIndex)
+        assertEquals(LegatoAndroidPlaybackState.IDLE, snapshot.state)
+    }
+
+    @Test
+    fun `coordinator reset keeps idle state when queue already empty`() = runBlocking {
+        val runtime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val coordinator = LegatoAndroidPlaybackCoordinator(
+            core = buildCore(runtime, sessionRuntime),
+            serviceRuntime = RecordingCoordinatorServiceRuntime(),
+        )
+
+        coordinator.setup()
+        coordinator.reset()
+
+        val snapshot = coordinator.core.playerEngine.getSnapshot()
+        assertTrue(snapshot.queue.items.isEmpty())
+        assertEquals(LegatoAndroidPlaybackState.IDLE, snapshot.state)
+    }
+
+    @Test
+    fun `coordinator interruption projection stays coherent after canonical remove transition`() = runBlocking {
+        val runtime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val coordinator = LegatoAndroidPlaybackCoordinator(
+            core = buildCore(runtime, sessionRuntime),
+            serviceRuntime = RecordingCoordinatorServiceRuntime(),
+        )
+
+        coordinator.setup()
+        coordinator.load(
+            listOf(
+                LegatoAndroidTrack(id = "track-1", url = "https://example.com/1.mp3"),
+                LegatoAndroidTrack(id = "track-2", url = "https://example.com/2.mp3"),
+            ),
+            startIndex = 1,
+        )
+        coordinator.play()
+        coordinator.remove(index = 0)
+
+        sessionRuntime.emit(LegatoAndroidInterruptionSignal.AudioFocusLost)
+
+        assertEquals(LegatoAndroidPlaybackState.PAUSED, coordinator.currentPlaybackState())
+        assertEquals(LegatoAndroidServiceMode.RESUME_PENDING_INTERRUPTION, coordinator.currentServiceMode())
+        assertEquals(LegatoAndroidPauseOrigin.INTERRUPTION, coordinator.currentPauseOrigin())
+    }
+
     private fun buildCore(
         runtime: RecordingPlaybackRuntime,
         sessionRuntime: RecordingSessionRuntime,

--- a/packages/capacitor/android/src/test/kotlin/io/legato/capacitor/LegatoPlaybackServiceBootstrapTest.kt
+++ b/packages/capacitor/android/src/test/kotlin/io/legato/capacitor/LegatoPlaybackServiceBootstrapTest.kt
@@ -2,6 +2,7 @@ package io.legato.capacitor
 
 import io.legato.core.core.LegatoAndroidNowPlayingMetadata
 import io.legato.core.core.LegatoAndroidPlaybackState
+import io.legato.core.session.LegatoAndroidInterruptionSignal
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -249,5 +250,31 @@ class LegatoPlaybackServiceBootstrapTest {
         assertSame(provided, observed)
         assertFalse(observed === null)
         assertSame(expectedCoordinator, resolved)
+    }
+
+    @Test
+    fun `audio focus change mapping converts Android constants into canonical interruption signals`() {
+        assertEquals(
+            LegatoAndroidInterruptionSignal.AudioFocusGained,
+            interruptionSignalFromAudioFocusChange(android.media.AudioManager.AUDIOFOCUS_GAIN),
+        )
+        assertEquals(
+            LegatoAndroidInterruptionSignal.AudioFocusLost,
+            interruptionSignalFromAudioFocusChange(android.media.AudioManager.AUDIOFOCUS_LOSS),
+        )
+        assertEquals(
+            LegatoAndroidInterruptionSignal.AudioFocusLostTransient,
+            interruptionSignalFromAudioFocusChange(android.media.AudioManager.AUDIOFOCUS_LOSS_TRANSIENT),
+        )
+        assertEquals(
+            LegatoAndroidInterruptionSignal.AudioFocusLostTransientCanDuck,
+            interruptionSignalFromAudioFocusChange(android.media.AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK),
+        )
+    }
+
+    @Test
+    fun `audio focus change mapping ignores unsupported platform constants`() {
+        assertNull(interruptionSignalFromAudioFocusChange(Int.MAX_VALUE))
+        assertNull(interruptionSignalFromAudioFocusChange(123_456))
     }
 }

--- a/specs/task-breakdown-v0.md
+++ b/specs/task-breakdown-v0.md
@@ -13,19 +13,19 @@
 ## Phase 2
 - [x] Add Android native core skeleton package layout and placeholder APIs.
 - [x] Add iOS native core skeleton source layout and placeholder APIs.
-- [x] Keep native implementations as TODO-only (no ExoPlayer/AVPlayer wiring).
+- [x] Establish initial native runtime seam baseline for v0 (later superseded by Android runtime playback implementation/integrity hardening milestones).
 
 ## Phase 3
 - [x] Replace map/dictionary payload placeholders with typed native DTOs (Android + iOS).
 - [x] Implement canonical playback state machine transitions in native cores.
 - [x] Implement in-memory snapshot store behavior with v0-aligned empty/default snapshot.
 - [x] Implement minimal queue manager semantics (replace/add/clear/current/next/previous).
-- [x] Update player engine signatures to typed DTOs while keeping runtime playback wiring as TODO.
+- [x] Update player engine signatures to typed DTOs from the original v0 seam baseline (runtime playback later implemented on Android).
 
 ## Phase 4
 - [x] Add Android session/remote manager scaffolding with typed command/metadata seams.
 - [x] Add iOS session/now playing/remote manager scaffolding with typed command/metadata seams.
-- [x] Wire player engines to session/remote/metadata/progress seam points without real ExoPlayer/AVPlayer integration.
+- [x] Wire player engines to session/remote/metadata/progress seams; Android now runs real Media3 runtime playback, while iOS runtime parity remains deferred.
 
 ## Phase 4.1
 - [x] Add native composition roots/factories for Android and iOS core assembly.
@@ -35,9 +35,11 @@
 - [x] Add Android playback runtime adapter seam and wire player engine transport operations through it.
 - [x] Add iOS playback runtime adapter seam and wire player engine transport operations through it.
 - [x] Add Android/iOS session + remote + now playing runtime adapter seams with default no-op backends.
-- [x] Update native readmes/spec notes to clarify what is integrated vs still pending for first real playback.
+- [x] Update native readmes/spec notes to clarify integrated runtime scope and deferred follow-up milestones.
 
 ## Deferred
-- [ ] Native core implementation (real Media3/AVPlayer wiring and runtime behavior on device).
+- [ ] Android process-death queue/session restoration hardening (`android-background-lifecycle-v1`).
+- [ ] Broad Android background lifecycle + OEM matrix parity hardening (`android-background-lifecycle-v1` follow-ups).
+- [ ] iOS runtime parity closure and cross-platform behavior convergence (parity milestone tracks).
 - [ ] Framework binding implementations.
 - [ ] CI/tooling automation.


### PR DESCRIPTION
Closes #72

## Summary
- harden canonical Android runtime ownership so plugin queue mutations route through the coordinator/runtime path instead of direct shortcuts
- wire interruption/audio-focus ingestion through the Android runtime/service path and strengthen integration tests around existing playback behavior
- update stale Android runtime docs so they reflect the current Media3-backed runtime reality without over-claiming broader lifecycle parity

## Changes
| File | Change |
|------|--------|
| `native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidPlayerEngine.kt` | adds canonical queue ownership helpers for runtime integrity |
| `native/android/core/src/main/kotlin/io/legato/core/session/LegatoAndroidSessionRuntime.kt` | clarifies canonical interruption ingestion path |
| `native/android/core/src/test/kotlin/io/legato/core/core/*` | adds ownership/interruption-focused runtime tests |
| `native/android/core/src/test/kotlin/io/legato/core/runtime/LegatoAndroidMedia3PlaybackRuntimeTest.kt` | strengthens Media3 runtime coverage |
| `packages/capacitor/android/src/main/java/io/legato/capacitor/*` | routes plugin/coordinator/service behavior through the hardened runtime path |
| `packages/capacitor/android/src/test/kotlin/io/legato/capacitor/*` | expands adapter/service bootstrap tests |
| `apps/capacitor-demo/index.html`, `apps/capacitor-demo/src/main.ts` | keeps smoke/runtime evidence aligned with Android runtime integrity work |
| `packages/capacitor/README.md`, `native/android/core/README.md`, `specs/task-breakdown-v0.md` | remove stale runtime-pending wording and document deferred non-goals accurately |

## Test Plan
- [x] `bash ./gradlew :legato-capacitor:testDebugUnitTest --tests "io.legato.capacitor.LegatoAndroidPlaybackCoordinatorTest" --tests "io.legato.capacitor.LegatoPlaybackServiceBootstrapTest"` from `apps/capacitor-demo/android`
- [x] `gradle testDebugUnitTest --tests "io.legato.core.core.LegatoAndroidPlayerEngineInterruptionPolicyTest" --tests "io.legato.core.core.LegatoAndroidPlayerEngineQueueOwnershipTest" --tests "io.legato.core.runtime.LegatoAndroidMedia3PlaybackRuntimeTest"` from `native/android/core`
- [x] `node --test src/smoke-automation.test.mjs` from `apps/capacitor-demo`

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Docs updated where public/runtime wording changed
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers