### PR TITLE
docs(architecture): add multi-binding foundation artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Legato provides a contract package and a Capacitor integration package for continuous audio playback flows.
 
+## Which package should I install?
+
 ## Package decision matrix
 
 | If you need... | Install | Read first |

--- a/apps/capacitor-demo/scripts/external-consumer-template.test.mjs
+++ b/apps/capacitor-demo/scripts/external-consumer-template.test.mjs
@@ -30,7 +30,7 @@ test('external consumer template package uses standard Capacitor deps with no wo
 
 test('external consumer template compile surface imports legato capacitor and contract types', async () => {
   const source = await readFile(resolve(templateRoot, 'src/main.ts'), 'utf8');
-  assert.match(source, /from\s+'@legato\/capacitor'/i);
-  assert.match(source, /from\s+'@legato\/contract'/i);
+  assert.match(source, /from\s+'@ddgutierrezc\/legato-capacitor'/i);
+  assert.match(source, /from\s+'@ddgutierrezc\/legato-contract'/i);
   assert.match(source, /Legato/i);
 });

--- a/apps/capacitor-demo/scripts/multi-binding-architecture-foundation-v1-docs.test.mjs
+++ b/apps/capacitor-demo/scripts/multi-binding-architecture-foundation-v1-docs.test.mjs
@@ -1,0 +1,92 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '../../..');
+
+const capabilityMapPath = resolve(repoRoot, 'docs/architecture/multi-binding-capability-map.md');
+const guardrailsPath = resolve(repoRoot, 'docs/architecture/multi-binding-guardrails.md');
+const spikePath = resolve(repoRoot, 'docs/architecture/spikes/flutter-rn-adapter-spike.md');
+const architectureDocPath = resolve(repoRoot, 'arquitectura_cambio.md');
+
+const collectUnbackedClaims = (markdown) => markdown
+  .split('\n')
+  .map((line) => line.trim())
+  .filter((line) => line.startsWith('|'))
+  .filter((line) => !/^\|[-\s|]+\|$/.test(line))
+  .map((line) => line.split('|').slice(1, -1).map((cell) => cell.trim()))
+  .filter((cells) => cells.length >= 5)
+  .filter((cells) => /Reusable Core|Binding-Specific Adapter/i.test(cells[1] ?? ''))
+  .filter((cells) => {
+    const sourcePath = cells[3] ?? '';
+    return sourcePath === '' || sourcePath === '—' || /^tbd$/i.test(sourcePath);
+  });
+
+test('capability map keeps current-vs-future sections with source-backed reusable/binding matrix', async () => {
+  const capabilityMap = await readFile(capabilityMapPath, 'utf8');
+
+  assert.match(capabilityMap, /Current \(implemented\)/i);
+  assert.match(capabilityMap, /Future \(planned\)/i);
+  assert.match(capabilityMap, /Reusable Core/i);
+  assert.match(capabilityMap, /Binding-Specific Adapter/i);
+  assert.match(capabilityMap, /packages\/contract\/src\//i);
+  assert.match(capabilityMap, /native\/android\/core\//i);
+  assert.match(capabilityMap, /native\/ios\/LegatoCore\//i);
+  assert.match(capabilityMap, /packages\/capacitor\//i);
+  assert.match(capabilityMap, /apps\/capacitor-demo\//i);
+  assert.match(capabilityMap, /packages\/react-native\/\.gitkeep/i);
+  assert.match(capabilityMap, /packages\/flutter\/legato\/\.gitkeep/i);
+});
+
+test('reject unbacked claims: rows without source path evidence are non-compliant', async () => {
+  const capabilityMap = await readFile(capabilityMapPath, 'utf8');
+  assert.equal(collectUnbackedClaims(capabilityMap).length, 0);
+
+  const unbackedSample = `
+## Current (implemented)
+| Layer | Classification | State | Source path(s) | Evidence note |
+|---|---|---|---|---|
+| Missing source row | Reusable Core | Current |  | no evidence |
+`;
+
+  assert.equal(collectUnbackedClaims(unbackedSample).length, 1);
+});
+
+test('guardrails document pins do-not-touch release/runtime/host-wiring paths', async () => {
+  const guardrails = await readFile(guardrailsPath, 'utf8');
+
+  assert.match(guardrails, /do-not-touch/i);
+  assert.match(guardrails, /docs\/releases\/native-artifact-foundation-v1\.md/i);
+  assert.match(guardrails, /docs\/releases\/publication-pipeline-v2\.md/i);
+  assert.match(guardrails, /apps\/capacitor-demo\/ios\/App\/CapApp-SPM\/Package\.swift/i);
+  assert.match(guardrails, /packages\/capacitor\/android\//i);
+  assert.match(guardrails, /packages\/capacitor\/ios\//i);
+});
+
+test('architecture narrative cross-links map and guardrails with explicit v1 out-of-scope list', async () => {
+  const architectureDoc = await readFile(architectureDocPath, 'utf8');
+
+  assert.match(architectureDoc, /docs\/architecture\/multi-binding-capability-map\.md/i);
+  assert.match(architectureDoc, /docs\/architecture\/multi-binding-guardrails\.md/i);
+  assert.match(architectureDoc, /Out of scope in v1/i);
+  assert.match(architectureDoc, /no Flutter runtime adapter/i);
+  assert.match(architectureDoc, /no React Native runtime adapter/i);
+  assert.match(architectureDoc, /no release-pipeline rewiring/i);
+  assert.match(architectureDoc, /no native engine rewrite/i);
+});
+
+test('flutter/rn spike doc states entry criteria and conformance checklist without implementation promises', async () => {
+  const spikeDoc = await readFile(spikePath, 'utf8');
+
+  assert.match(spikeDoc, /entry criteria/i);
+  assert.match(spikeDoc, /success metrics/i);
+  assert.match(spikeDoc, /method parity/i);
+  assert.match(spikeDoc, /event parity/i);
+  assert.match(spikeDoc, /capability parity/i);
+  assert.match(spikeDoc, /error-code parity/i);
+  assert.match(spikeDoc, /packages\/contract\/src\/binding-adapter\.ts/i);
+  assert.match(spikeDoc, /does not implement Flutter or React Native runtime adapters in v1/i);
+});

--- a/apps/capacitor-demo/scripts/multi-binding-architecture-foundation-v1-types.test.mjs
+++ b/apps/capacitor-demo/scripts/multi-binding-architecture-foundation-v1-types.test.mjs
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '../../..');
+
+const bindingAdapterPath = resolve(repoRoot, 'packages/contract/src/binding-adapter.ts');
+const contractIndexPath = resolve(repoRoot, 'packages/contract/src/index.ts');
+const capacitorDefinitionsPath = resolve(repoRoot, 'packages/capacitor/src/definitions.ts');
+const capacitorSyncPath = resolve(repoRoot, 'packages/capacitor/src/sync.ts');
+const capacitorPluginPath = resolve(repoRoot, 'packages/capacitor/src/plugin.ts');
+const capacitorReadmePath = resolve(repoRoot, 'packages/capacitor/README.md');
+
+test('contract exposes transport-neutral binding adapter primitives', async () => {
+  const [bindingAdapter, contractIndex] = await Promise.all([
+    readFile(bindingAdapterPath, 'utf8'),
+    readFile(contractIndexPath, 'utf8'),
+  ]);
+
+  assert.match(bindingAdapter, /export interface BindingListenerHandle/i);
+  assert.match(bindingAdapter, /remove\(\): Promise<void> \| void/i);
+  assert.match(bindingAdapter, /export interface BindingAdapter/i);
+  assert.match(bindingAdapter, /addListener<\s*E extends LegatoEventName\s*>/i);
+  assert.match(bindingAdapter, /removeAllListeners\(\): Promise<void>/i);
+  assert.match(bindingAdapter, /BindingCapabilitiesSnapshot/i);
+  assert.match(contractIndex, /binding-adapter\.js/);
+});
+
+test('capacitor type boundary uses binding listener handle instead of capacitor transport handle', async () => {
+  const [definitionsSource, syncSource] = await Promise.all([
+    readFile(capacitorDefinitionsPath, 'utf8'),
+    readFile(capacitorSyncPath, 'utf8'),
+  ]);
+
+  assert.doesNotMatch(definitionsSource, /import type \{ PluginListenerHandle \} from '@capacitor\/core'/);
+  assert.match(definitionsSource, /BindingListenerHandle/);
+  assert.doesNotMatch(syncSource, /PluginListenerHandle/);
+  assert.match(syncSource, /BindingListenerHandle/);
+});
+
+test('capacitor runtime entrypoint keeps plugin id and first-adapter boundary note', async () => {
+  const [pluginSource, capacitorReadme] = await Promise.all([
+    readFile(capacitorPluginPath, 'utf8'),
+    readFile(capacitorReadmePath, 'utf8'),
+  ]);
+
+  assert.match(pluginSource, /registerPlugin<LegatoCapacitorPlugin>\('Legato'\)/);
+  assert.match(pluginSource, /export const audioPlayer/);
+  assert.match(pluginSource, /export const mediaSession/);
+  assert.match(pluginSource, /export const Legato/);
+
+  assert.match(capacitorReadme, /first concrete adapter/i);
+  assert.match(capacitorReadme, /only implemented binding/i);
+});

--- a/apps/capacitor-demo/scripts/release-ios-execution.mjs
+++ b/apps/capacitor-demo/scripts/release-ios-execution.mjs
@@ -2,6 +2,7 @@ import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { spawn } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { normalizeTargetSummary } from './release-control-summary-schema.mjs';
 
 const PASS = 'PASS';
@@ -11,7 +12,8 @@ const CONFIG_ERROR_EXIT_CODE = 2;
 const DEFAULT_RELEASE_ID = 'manual';
 const DEFAULT_ARTIFACTS_DIR = 'artifacts/ios-publication-v1';
 const DEFAULT_PUBLISH_ARTIFACTS_DIR = 'artifacts/ios-publication-v2';
-const DEFAULT_CONTRACT_PATH = '../../packages/capacitor/native-artifacts.json';
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_CONTRACT_PATH = resolve(SCRIPT_DIR, '../../../packages/capacitor/native-artifacts.json');
 const ALLOWED_PROOF_TYPES = new Set(['tag-release-url', 'commit-sha']);
 const PLACEHOLDER_VALUE_RE = /(\b(tbd|example|placeholder)\b|^<.+>$)/i;
 

--- a/apps/capacitor-demo/scripts/validate-native-release-gate.test.mjs
+++ b/apps/capacitor-demo/scripts/validate-native-release-gate.test.mjs
@@ -31,7 +31,11 @@ let package = Package(
 
 const pluginSwiftSource = `
 @objc(LegatoPlugin)
-public final class LegatoPlugin: CAPPlugin, CAPBridgedPlugin {}
+public final class LegatoPlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "LegatoPlugin"
+    public let jsName = "Legato"
+    public let pluginMethods: [CAPPluginMethod] = []
+}
 `;
 
 const capacitorConfig = `
@@ -69,6 +73,14 @@ let package = Package(
     name: "CapApp-SPM",
     dependencies: [
         .package(name: "DdgutierrezcLegatoCapacitor", path: "../../../node_modules/@ddgutierrezc/legato-capacitor")
+    ],
+    targets: [
+        .target(
+            name: "App",
+            dependencies: [
+                .product(name: "DdgutierrezcLegatoCapacitor", package: "DdgutierrezcLegatoCapacitor")
+            ]
+        )
     ]
 )
 `;

--- a/arquitectura_cambio.md
+++ b/arquitectura_cambio.md
@@ -1,0 +1,1112 @@
+# Legato — Descripción conceptual completa
+
+> Versión del documento: 1.0  
+> Estado del proyecto: En desarrollo activo  
+> Binding principal: Capacitor  
+> Distribución: Open source (`@ddgutierrezc/`)
+
+---
+
+## Índice
+
+1. [¿Qué es Legato?](#1-qué-es-legato)
+2. [Decisiones de diseño fundamentales](#2-decisiones-de-diseño-fundamentales)
+3. [Arquitectura general](#3-arquitectura-general)
+4. [Capa 0 — legato-contract](#4-capa-0--legato-contract)
+5. [Capa 1 — legato-capacitor](#5-capa-1--legato-capacitor)
+6. [Capa 2 — Bridge de Capacitor con Android](#6-capa-2--bridge-de-capacitor-con-android)
+7. [Capa 3 — Native Android Core](#7-capa-3--native-android-core)
+8. [Capa 3 — Native iOS Core](#8-capa-3--native-ios-core)
+9. [Demo harness y validación operativa](#9-demo-harness-y-validación-operativa)
+10. [Release y validation tooling](#10-release-y-validation-tooling)
+11. [Estrategia de testing](#11-estrategia-de-testing)
+12. [Estado actual y gaps](#12-estado-actual-y-gaps)
+13. [Roadmap de completitud](#13-roadmap-de-completitud)
+14. [Visión de largo plazo](#14-visión-de-largo-plazo)
+15. [Estado actual vs dirección multi-binding (foundation v1)](#15-estado-actual-vs-dirección-multi-binding-foundation-v1)
+
+---
+
+## 1. ¿Qué es Legato?
+
+Legato es un **plugin de audio de nivel producción para Capacitor**, diseñado como open source y orientado a casos de uso equivalentes a Spotify o YouTube Music. No es un reproductor básico — es una plataforma de playback/integración que expone una API TypeScript limpia sobre engines nativos reales (ExoPlayer en Android, AVQueuePlayer en iOS).
+
+El nombre refleja su filosofía: *legato* en música significa notas conectadas sin silencio entre ellas, lo cual describe exactamente el objetivo técnico — reproducción continua, sin cortes, con transiciones fluidas entre tracks.
+
+### Qué hace Legato
+
+- Reproduce audio desde URLs remotas o locales con soporte de streaming progresivo
+- Gestiona colas de reproducción con shuffle, repeat y crossfade
+- Muestra metadatos en lockscreen, notificaciones y sistema operativo
+- Responde a controles externos: lockscreen, AirPods, CarPlay, Android Auto
+- Maneja correctamente el foco de audio frente a llamadas entrantes y otras apps
+- Sobrevive al background en Android e iOS sin que el sistema operativo mate el proceso
+- Cachea audio progresivamente para reducir rebuffering en conexiones lentas
+
+### Lo que Legato NO es (hoy)
+
+- No es un SDK multi-framework terminado (Flutter y React Native son potencial arquitectónico, no realidad implementada)
+- No es un player engine fully production-complete en la capa nativa (los cores son seams avanzados, no motores cerrados)
+- No es un producto comercial — es open source, publicado bajo `@ddgutierrezc/`
+
+---
+
+## 2. Decisiones de diseño fundamentales
+
+Estas decisiones tomadas al inicio del proyecto determinan toda la arquitectura. Entenderlas evita cuestionarlas en el futuro sin contexto.
+
+### Contract-first
+
+El dominio de playback está definido en un paquete separado (`legato-contract`) que no tiene ninguna dependencia de runtime, plugin ni plataforma. Esto garantiza que los tipos, eventos y modelos son la fuente de verdad compartida entre TypeScript, el bridge de Capacitor y los engines nativos. Cualquier cambio en el dominio se propaga de forma controlada.
+
+### Monorepo como source of truth
+
+Todo el código vive en un solo repositorio (`legato` repo). Los paquetes se separan para distribución, no para dispersar la arquitectura. Esto permite releases coordinados, PRs atómicos y CI unificado sin el problema de compatibilidad entre versiones de repos distintos.
+
+### Wrappear libs nativas maduras, no reinventarlas
+
+Android usa ExoPlayer 3 (mantenido por Google, usado por YouTube). iOS usa AVQueuePlayer (framework oficial de Apple). Esta decisión no es un compromiso de performance — es la decisión correcta. El cuello de botella de un reproductor nunca es el player en sí: es el buffer, el cache y la gestión de la queue. Esas partes sí son implementación propia.
+
+### Plugin delega, engine ejecuta
+
+El plugin de Capacitor (`LegatoPlugin.kt`, `LegatoPlugin.swift`) no tiene lógica de negocio. Su único rol es traducir `PluginCall` → llamada al engine → `resolve/reject`. Toda la lógica de playback vive en `LegatoAndroidCore` y `LegatoCore` (iOS). Esto hace que el engine sea testeable de forma aislada, sin necesitar el runtime de Capacitor.
+
+### Inyección de dependencias en el engine
+
+Los engines nativos no instancian ExoPlayer ni AVPlayer directamente — los reciben a través de una interfaz (`AudioEngineProtocol` en Swift, `AudioPlayerEngine` en Kotlin). Esto permite mockear el player en tests unitarios y lograr ~80% de cobertura sin dispositivo físico ni emulador.
+
+### Separación de caminos de comunicación
+
+Capacitor tiene dos caminos de comunicación distintos y Legato los usa para cosas distintas:
+
+- **JS → nativo** (request/response): comandos del usuario como `play()`, `pause()`, `load()`, `seekTo()`. Resuelven como Promises.
+- **Nativo → JS** (eventos push): cambios de estado que el nativo inicia, como `stateChanged`, `positionChanged`, `error`, `audioFocusLost`. Llegan via `notifyListeners()` / `addListener()`.
+
+---
+
+## 3. Arquitectura general
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│         Consumer app (Ionic / Angular / React / Vue)        │
+│         Solo conoce la API TypeScript — nada nativo         │
+└────────────────────────────┬────────────────────────────────┘
+                             │
+┌────────────────────────────▼────────────────────────────────┐
+│              @ddgutierrezc/legato-capacitor                  │
+│   audioPlayer · mediaSession · Legato facade (compat)       │
+│              peerDep → legato-contract                       │
+└──────────────┬─────────────────────────────┬────────────────┘
+               │                             │
+               ▼                             ▼
+┌──────────────────────────┐   ┌─────────────────────────────┐
+│   @ddgutierrezc/          │   │  apps/capacitor-demo        │
+│   legato-contract         │   │  Demo + validation harness  │
+│   Tipos · eventos ·       │   │  Smoke flows · evidencia    │
+│   invariants · modelos    │   │  Valida packaging y bridges │
+└──────────────────────────┘   └─────────────────────────────┘
+               │
+┌──────────────▼──────────────────────────────────────────────┐
+│                  Capacitor bridge                            │
+│         MessageHandler interno — rutea PluginCalls          │
+└──────────┬──────────────────────────────┬───────────────────┘
+           │                              │
+┌──────────▼──────────┐      ┌────────────▼────────────────┐
+│  Android plugin     │      │  iOS plugin                 │
+│  LegatoPlugin.kt    │      │  LegatoPlugin.swift         │
+│  @CapacitorPlugin   │      │  CAPPlugin                  │
+└──────────┬──────────┘      └────────────┬────────────────┘
+           │                              │
+┌──────────▼──────────┐      ┌────────────▼────────────────┐
+│  native/android/    │      │  native/ios/LegatoCore      │
+│  core               │      │                             │
+│  LegatoAndroidCore  │      │  LegatoCore                 │
+│  ExoPlayer 3        │      │  AVQueuePlayer              │
+│  MediaSession compat│      │  AVAudioSession             │
+│  ForegroundService  │      │  MPNowPlayingInfoCenter     │
+│  AudioFocusManager  │      │  MPRemoteCommandCenter      │
+│  CacheDataSource    │      │  Interruption handling      │
+│  QueueManager       │      │  QueueManager               │
+└─────────────────────┘      └─────────────────────────────┘
+```
+
+### Flujo completo de un comando
+
+```
+audioPlayer.play()
+  → Capacitor serializa a JSON
+  → MessageHandler rutea a LegatoPlugin
+  → @PluginMethod fun play(call) { engine.play(); call.resolve() }
+  → LegatoAndroidCore.play()
+  → AudioFocusManager.request()
+  → ExoPlayer.play()
+  → ExoPlayer.Listener.onPlaybackStateChanged()
+  → emitter.emit("stateChanged", { state: "playing" })
+  → notifyListeners("stateChanged", data)
+  → addListener callback en JS
+```
+
+---
+
+## 4. Capa 0 — legato-contract
+
+**Paquete:** `@ddgutierrezc/legato-contract`  
+**Naturaleza:** Puro TypeScript, cero dependencias de runtime  
+**Rol:** Fuente de verdad del dominio de playback
+
+### Qué contiene
+
+#### Modelos de dominio
+
+```typescript
+// Track — unidad atómica de reproducción
+interface Track {
+  id: string
+  url: string
+  title: string
+  artist: string
+  album?: string
+  artworkUrl?: string
+  durationMs: number
+  headers?: Record<string, string>  // para streams autenticados
+}
+
+// PlayerState — estado observable del player
+interface PlayerState {
+  status: 'idle' | 'loading' | 'buffering' | 'ready' | 'playing' | 'paused' | 'ended' | 'error'
+  currentTrack: Track | null
+  positionMs: number
+  durationMs: number
+  bufferedMs: number
+  volume: number
+  playbackRate: number
+}
+
+// Queue — lista de reproducción con contexto
+interface PlaybackQueue {
+  tracks: Track[]
+  currentIndex: number
+  repeatMode: 'none' | 'one' | 'all'
+  shuffled: boolean
+  originalOrder: Track[]  // para des-shufflear
+}
+
+// Snapshot — estado serializable completo (para restore)
+interface PlaybackSnapshot {
+  queue: PlaybackQueue
+  state: PlayerState
+  timestamp: number
+}
+```
+
+#### Sistema de eventos
+
+```typescript
+type LegatoEvent =
+  | { type: 'stateChanged';       state: PlayerState }
+  | { type: 'positionChanged';    positionMs: number; durationMs: number }
+  | { type: 'trackChanged';       track: Track | null }
+  | { type: 'queueChanged';       queue: PlaybackQueue }
+  | { type: 'bufferingChanged';   isBuffering: boolean; bufferedMs: number }
+  | { type: 'volumeChanged';      volume: number }
+  | { type: 'error';              error: LegatoError }
+  | { type: 'audioFocusLost';     transient: boolean }
+  | { type: 'audioFocusGained' }
+  | { type: 'interruptionBegan' }                        // iOS
+  | { type: 'interruptionEnded';  shouldResume: boolean } // iOS
+```
+
+#### Errores tipados
+
+```typescript
+type LegatoError =
+  | { code: 'SOURCE_NOT_FOUND';    message: string; url: string }
+  | { code: 'NETWORK_ERROR';       message: string; retryable: boolean }
+  | { code: 'DECODE_ERROR';        message: string }
+  | { code: 'FOCUS_DENIED';        message: string }
+  | { code: 'BACKGROUND_KILLED';   message: string }
+  | { code: 'SOURCE_UNAVAILABLE';  message: string }
+  | { code: 'UNKNOWN';             message: string; raw?: unknown }
+```
+
+#### Invariants de dominio
+
+Reglas de negocio que se mantienen en toda la codebase:
+
+- `positionMs` siempre está entre `0` y `durationMs`
+- `currentIndex` siempre apunta a un track válido dentro de `tracks`, o es `-1` si la cola está vacía
+- `PlayerState.status === 'error'` implica que `LegatoError` está disponible
+- Un track no puede estar `playing` si `audioFocusLost` fue emitido sin un `audioFocusGained` posterior
+
+### Lo que el contract NO contiene
+
+- Ninguna importación de `@capacitor/core`
+- Ningún código nativo ni bridge
+- Ninguna lógica de runtime (reproducción, buffering, red)
+- Ninguna referencia a plataformas específicas
+
+---
+
+## 5. Capa 1 — legato-capacitor
+
+**Paquete:** `@ddgutierrezc/legato-capacitor`  
+**Naturaleza:** TypeScript + código nativo Android/iOS  
+**Rol:** Binding público real que consume el usuario final
+
+### Lo que expone
+
+#### audioPlayer
+
+API principal de control de reproducción:
+
+```typescript
+interface AudioPlayerPlugin {
+  // Carga y control
+  load(options: { url: string; startPositionMs?: number }): Promise<void>
+  play(): Promise<void>
+  pause(): Promise<void>
+  stop(): Promise<void>
+  seekTo(options: { positionMs: number }): Promise<void>
+
+  // Queue
+  setQueue(options: { tracks: Track[]; startIndex?: number }): Promise<void>
+  next(): Promise<void>
+  previous(): Promise<void>
+  addToQueue(options: { track: Track; position?: number }): Promise<void>
+  removeFromQueue(options: { index: number }): Promise<void>
+
+  // Estado
+  getState(): Promise<PlayerState>
+  getQueue(): Promise<PlaybackQueue>
+
+  // Configuración
+  setVolume(options: { volume: number }): Promise<void>
+  setPlaybackRate(options: { rate: number }): Promise<void>
+  setRepeatMode(options: { mode: 'none' | 'one' | 'all' }): Promise<void>
+  setShuffle(options: { enabled: boolean }): Promise<void>
+
+  // Listeners
+  addListener(event: string, handler: Function): Promise<PluginListenerHandle>
+  removeAllListeners(): Promise<void>
+}
+```
+
+#### mediaSession
+
+API para control de metadatos en el sistema operativo:
+
+```typescript
+interface MediaSessionPlugin {
+  setMetadata(options: {
+    title: string
+    artist: string
+    album?: string
+    artworkUrl?: string
+    durationMs?: number
+  }): Promise<void>
+
+  setPlaybackState(options: {
+    state: 'playing' | 'paused' | 'stopped'
+    positionMs?: number
+    playbackRate?: number
+  }): Promise<void>
+
+  setEnabledActions(options: {
+    actions: Array<'play' | 'pause' | 'next' | 'previous' | 'seek' | 'stop'>
+  }): Promise<void>
+}
+```
+
+#### Legato facade
+
+Facade de compatibilidad que unifica `audioPlayer` y `mediaSession` bajo una sola interfaz:
+
+```typescript
+class Legato {
+  static async play(track: Track): Promise<void>
+  static async pause(): Promise<void>
+  // ... wrapper sobre audioPlayer + mediaSession combinados
+}
+```
+
+> **Nota arquitectónica:** La facade existe para simplificar el caso de uso más común. Internamente delega 100% a `audioPlayer` y `mediaSession`. Está marcada para evaluación de deprecación en v2 si la API limpia gana suficiente adopción.
+
+### Dependencias del paquete
+
+```json
+{
+  "peerDependencies": {
+    "@capacitor/core": ">=5.0.0",
+    "@ddgutierrezc/legato-contract": "*"
+  }
+}
+```
+
+---
+
+## 6. Capa 2 — Bridge de Capacitor con Android
+
+El bridge es el mecanismo que conecta TypeScript con código Kotlin. Es gestionado completamente por Capacitor — Legato no escribe código de bridge propio.
+
+### Cómo funciona
+
+JavaScript en el WebView nunca toca código nativo directamente. Todo pasa por un canal de mensajes serializado a JSON que Capacitor gestiona internamente a través de su `MessageHandler`.
+
+**Camino 1 — JS llama a nativo (request/response):**
+
+```
+audioPlayer.play()
+  → Capacitor.Plugins.LegatoPlugin.call('play', {})
+  → JSON serializado al MessageHandler
+  → LegatoPlugin.kt @PluginMethod fun play(call: PluginCall)
+  → call.resolve() ó call.reject("código", excepción)
+  → Promise resuelta en TypeScript
+```
+
+**Camino 2 — Nativo avisa a JS (eventos push):**
+
+```
+ExoPlayer.Listener.onPlaybackStateChanged()
+  → engine llama a emitter.emit("stateChanged", data)
+  → plugin.notifyListeners("stateChanged", JSObject)
+  → todos los addListener('stateChanged') en JS reciben el evento
+```
+
+### Estructura del plugin Kotlin
+
+```kotlin
+@CapacitorPlugin(name = "LegatoPlugin")
+class LegatoPlugin : Plugin() {
+
+    private lateinit var engine: LegatoAndroidCore
+
+    // load() se llama una sola vez al registrar el plugin
+    override fun load() {
+        engine = LegatoAndroidCore(
+            context = context,
+            emitter = this  // el plugin implementa LegatoEventEmitter
+        )
+    }
+
+    @PluginMethod
+    fun play(call: PluginCall) {
+        try {
+            engine.play()
+            call.resolve()
+        } catch (e: Exception) {
+            call.reject("PLAY_FAILED", e)
+        }
+    }
+
+    @PluginMethod
+    fun load(call: PluginCall) {
+        val url = call.getString("url")
+            ?: return call.reject("MISSING_URL", "url is required")
+        val startMs = call.getLong("startPositionMs") ?: 0L
+        engine.load(url, startMs)
+        call.resolve()
+    }
+}
+```
+
+### Interfaz de emisión de eventos
+
+El engine no conoce el plugin directamente — se comunica a través de una interfaz. Esto desacopla el engine del runtime de Capacitor y lo hace testeable:
+
+```kotlin
+interface LegatoEventEmitter {
+    fun emit(event: String, data: JSObject)
+}
+
+// El plugin implementa la interfaz
+class LegatoPlugin : Plugin(), LegatoEventEmitter {
+    override fun emit(event: String, data: JSObject) {
+        notifyListeners(event, data)
+    }
+}
+```
+
+---
+
+## 7. Capa 3 — Native Android Core
+
+**Módulo:** `native/android/core`  
+**Clase principal:** `LegatoAndroidCore`  
+**Estado actual:** Runtime seam / MVP — estructura y boundaries definidos, no engine completo
+
+### Componentes del engine
+
+#### LegatoAndroidCore (orquestador)
+
+```kotlin
+class LegatoAndroidCore(
+    private val context: Context,
+    private val emitter: LegatoEventEmitter,
+    private val engine: AudioPlayerEngine = ExoPlayerEngine(context),
+    private val focusManager: AudioFocusManager = AudioFocusManager(context),
+    private val queueManager: QueueManager = QueueManager(),
+    private val cacheManager: CacheManager = CacheManager(context)
+) {
+    fun load(url: String, startPositionMs: Long) { ... }
+    fun play() { ... }
+    fun pause() { ... }
+    fun seekTo(positionMs: Long) { ... }
+    fun next() { ... }
+    fun previous() { ... }
+    fun setQueue(tracks: List<Track>, startIndex: Int) { ... }
+    fun release() { ... }
+}
+```
+
+#### AudioPlayerEngine (interfaz + implementación real)
+
+```kotlin
+// Interfaz — lo que el engine expone al core
+interface AudioPlayerEngine {
+    fun load(url: String, startPositionMs: Long)
+    fun play()
+    fun pause()
+    fun seekTo(positionMs: Long)
+    fun release()
+    val currentPositionMs: Long
+    val durationMs: Long
+    var listener: AudioEngineListener?
+}
+
+// Implementación real sobre ExoPlayer 3
+class ExoPlayerEngine(context: Context) : AudioPlayerEngine {
+    private val player = ExoPlayer.Builder(context).build()
+
+    override fun play() { player.play() }
+    override fun pause() { player.pause() }
+    override fun seekTo(positionMs: Long) { player.seekTo(positionMs) }
+
+    init {
+        player.addListener(object : Player.Listener {
+            override fun onPlaybackStateChanged(state: Int) {
+                listener?.onStateChanged(state.toLegatoState())
+            }
+            override fun onPlayerError(error: PlaybackException) {
+                listener?.onError(error.toLegatoError())
+            }
+        })
+    }
+}
+```
+
+#### AudioFocusManager
+
+Gestiona el foco de audio frente a llamadas entrantes y otras apps:
+
+```kotlin
+class AudioFocusManager(private val context: Context) {
+    private val audioManager = context.getSystemService(AudioManager::class.java)
+
+    fun request(): Boolean {
+        val result = audioManager.requestAudioFocus(
+            AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+                .setOnAudioFocusChangeListener { focusChange ->
+                    when (focusChange) {
+                        AudioManager.AUDIOFOCUS_LOSS           -> onFocusLost(transient = false)
+                        AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> onFocusLost(transient = true)
+                        AudioManager.AUDIOFOCUS_GAIN           -> onFocusGained()
+                    }
+                }.build()
+        )
+        return result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+    }
+
+    fun abandon() { audioManager.abandonAudioFocusRequest(...) }
+}
+```
+
+#### ForegroundService (obligatorio en Android 8+)
+
+Sin un `ForegroundService`, Android mata el proceso cuando la app va al background. El player debe vivir dentro del servicio, no en el plugin:
+
+```kotlin
+class LegatoPlaybackService : MediaLibraryService() {
+    private lateinit var mediaSession: MediaSession
+    private lateinit var player: ExoPlayer
+
+    override fun onCreate() {
+        super.onCreate()
+        player = ExoPlayer.Builder(this).build()
+        mediaSession = MediaSession.Builder(this, player).build()
+        // La notificación se crea automáticamente con DefaultMediaNotificationProvider
+    }
+
+    override fun onGetSession(controllerInfo: MediaSession.ControllerInfo) = mediaSession
+
+    override fun onDestroy() {
+        mediaSession.release()
+        player.release()
+        super.onDestroy()
+    }
+}
+```
+
+#### Cache progresivo
+
+Reduce rebuffering en conexiones lentas usando el sistema de cache de ExoPlayer:
+
+```kotlin
+class CacheManager(context: Context) {
+    private val cache = SimpleCache(
+        File(context.cacheDir, "legato_audio"),
+        LeastRecentlyUsedCacheEvictor(500 * 1024 * 1024), // 500 MB máximo
+        StandaloneDatabaseProvider(context)
+    )
+
+    fun buildDataSourceFactory(): CacheDataSource.Factory =
+        CacheDataSource.Factory()
+            .setCache(cache)
+            .setUpstreamDataSourceFactory(DefaultHttpDataSource.Factory())
+            .setCacheWriteDataSinkFactory(CacheDataSink.Factory().setCache(cache))
+}
+```
+
+#### Queue con gapless playback
+
+```kotlin
+class QueueManager {
+    private val concatenatingSource = ConcatenatingMediaSource()
+
+    fun setTracks(tracks: List<Track>, player: ExoPlayer) {
+        val mediaItems = tracks.map { track ->
+            MediaItem.Builder()
+                .setUri(track.url)
+                .setMediaMetadata(track.toMediaMetadata())
+                .build()
+        }
+        player.setMediaItems(mediaItems)
+        player.prepare()
+    }
+}
+```
+
+### Manifest requerido en la app del consumidor
+
+```xml
+<service
+    android:name="com.ddgutierrezc.legato.LegatoPlaybackService"
+    android:foregroundServiceType="mediaPlayback"
+    android:exported="true">
+    <intent-filter>
+        <action android:name="androidx.media3.session.MediaLibraryService"/>
+    </intent-filter>
+</service>
+
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
+```
+
+---
+
+## 8. Capa 3 — Native iOS Core
+
+**Módulo:** `native/ios/LegatoCore`  
+**Clase principal:** `LegatoCore`  
+**Estado actual:** Runtime seam / MVP — estructura y boundaries definidos, no engine completo
+
+### Componentes del engine
+
+#### LegatoCore (orquestador)
+
+```swift
+class LegatoCore {
+    private let engine: AudioEngineProtocol
+    private let emitter: LegatoEventEmitter
+    private let sessionManager: AudioSessionManager
+    private let nowPlayingManager: NowPlayingManager
+    private let remoteCommandManager: RemoteCommandManager
+
+    init(
+        engine: AudioEngineProtocol = AVPlayerEngine(),
+        emitter: LegatoEventEmitter,
+        sessionManager: AudioSessionManager = AudioSessionManager()
+    ) {
+        self.engine = engine
+        self.emitter = emitter
+        self.sessionManager = sessionManager
+        self.nowPlayingManager = NowPlayingManager()
+        self.remoteCommandManager = RemoteCommandManager()
+        setupRemoteCommands()
+    }
+}
+```
+
+#### AudioEngineProtocol (interfaz + implementación real)
+
+```swift
+protocol AudioEngineProtocol {
+    func load(url: URL, startPosition: TimeInterval)
+    func play()
+    func pause()
+    func seek(to position: TimeInterval)
+    func release()
+    var currentTime: TimeInterval { get }
+    var duration: TimeInterval { get }
+    var delegate: AudioEngineDelegate? { get set }
+}
+
+// Implementación real
+class AVPlayerEngine: AudioEngineProtocol {
+    private var player: AVQueuePlayer = AVQueuePlayer()
+    var delegate: AudioEngineDelegate?
+
+    func play()  { player.play() }
+    func pause() { player.pause() }
+
+    func seek(to position: TimeInterval) {
+        let time = CMTime(seconds: position, preferredTimescale: 1000)
+        player.seek(to: time)
+    }
+}
+```
+
+#### AudioSessionManager
+
+Configura AVAudioSession correctamente. Sin esto, el audio se pausa al bloquear la pantalla:
+
+```swift
+class AudioSessionManager {
+    func configure() throws {
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.playback, mode: .default, options: [.allowAirPlay, .allowBluetooth])
+        try session.setActive(true)
+
+        // Manejar interrupciones (llamadas, Siri, alarmas)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleInterruption),
+            name: AVAudioSession.interruptionNotification,
+            object: session
+        )
+    }
+
+    @objc private func handleInterruption(_ notification: Notification) {
+        guard let typeValue = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
+              let type = AVAudioSession.InterruptionType(rawValue: typeValue) else { return }
+
+        switch type {
+        case .began:
+            onInterruptionBegan?()
+        case .ended:
+            let shouldResume = (notification.userInfo?[AVAudioSessionInterruptionOptionKey] as? UInt)
+                .flatMap { AVAudioSession.InterruptionOptions(rawValue: $0) }
+                .map { $0.contains(.shouldResume) } ?? false
+            onInterruptionEnded?(shouldResume)
+        }
+    }
+}
+```
+
+#### NowPlayingManager
+
+Muestra metadatos en lockscreen, Control Center y CarPlay:
+
+```swift
+class NowPlayingManager {
+    func update(track: Track, position: TimeInterval, isPlaying: Bool) {
+        var info: [String: Any] = [
+            MPMediaItemPropertyTitle:            track.title,
+            MPMediaItemPropertyArtist:           track.artist,
+            MPMediaItemPropertyAlbumTitle:       track.album ?? "",
+            MPMediaItemPropertyPlaybackDuration: track.durationMs / 1000.0,
+            MPNowPlayingInfoPropertyElapsedPlaybackTime: position,
+            MPNowPlayingInfoPropertyPlaybackRate: isPlaying ? 1.0 : 0.0
+        ]
+
+        // Artwork asíncrono
+        if let artworkUrl = track.artworkUrl {
+            loadArtwork(from: artworkUrl) { image in
+                info[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(
+                    boundsSize: image.size
+                ) { _ in image }
+                MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+            }
+        }
+
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+    }
+}
+```
+
+#### RemoteCommandManager
+
+Conecta controles externos (lockscreen, AirPods, CarPlay, Apple Watch):
+
+```swift
+class RemoteCommandManager {
+    func setup(core: LegatoCore) {
+        let center = MPRemoteCommandCenter.shared()
+
+        center.playCommand.addTarget  { [weak core] _ in core?.play();     return .success }
+        center.pauseCommand.addTarget { [weak core] _ in core?.pause();    return .success }
+        center.nextTrackCommand.addTarget    { [weak core] _ in core?.next();      return .success }
+        center.previousTrackCommand.addTarget { [weak core] _ in core?.previous(); return .success }
+
+        center.changePlaybackPositionCommand.addTarget { [weak core] event in
+            if let e = event as? MPChangePlaybackPositionCommandEvent {
+                core?.seek(to: e.positionTime)
+            }
+            return .success
+        }
+    }
+}
+```
+
+### Info.plist requerido en la app del consumidor
+
+```xml
+<key>UIBackgroundModes</key>
+<array>
+    <string>audio</string>
+</array>
+```
+
+---
+
+## 9. Demo harness y validación operativa
+
+**App:** `apps/capacitor-demo`  
+**Rol:** No es un producto final — es una herramienta de validación operativa del proyecto
+
+### Qué valida
+
+- Smoke flows de playback básico (load, play, pause, seek)
+- Validación de bridges (comandos llegan al nativo y regresan correctamente)
+- Validación de packaging (el paquete npm publicado es consumible por una app limpia)
+- Validación de sync nativo (los plugins Android e iOS responden correctamente)
+- Captura de evidencia de comportamiento real
+
+### Smoke tests críticos que debe cubrir
+
+| Test | Descripción | Automatizable |
+|------|-------------|---------------|
+| Playback básico | load → play → pause → resume | Sí (Detox) |
+| Background survival | App al background → audio continúa | Manual |
+| Lockscreen controls | Play/pause desde notificación | Manual |
+| Llamada entrante | Audio pausa → llamada termina → reanuda | Manual |
+| Seek desde lockscreen | Barra de progreso en notificación funcional | Manual |
+| Queue con gapless | Transición entre tracks sin silencio | Sí (Detox) |
+| Error handling | URL inválida → evento `error` emitido | Sí (Detox) |
+
+### Lo que la demo NO debe ser
+
+- No debe tener lógica de producto real
+- No debe validar casos edge que son más apropiados para unit tests del engine
+- No debe ser el único mecanismo de validación (el unit testing del engine es más importante)
+
+---
+
+## 10. Release y validation tooling
+
+Legato tiene una capa seria de infraestructura alrededor del proceso de publicación. Esto es un activo real del proyecto, no overhead.
+
+### Componentes del tooling
+
+**release-control:** Orquesta el proceso completo de release — bump de versión, changelog, publicación a npm, tags de git.
+
+**npm readiness:** Verifica antes de publicar que el paquete tenga todo lo necesario: `main`, `types`, `exports`, archivos de declaración TypeScript, y que `package.json` esté bien formado.
+
+**external consumer validation:** Instala el paquete publicado en una app limpia (separada del monorepo) y verifica que el consumer flow funciona end-to-end sin dependencias del repo fuente.
+
+**native artifact validation:** Verifica que los módulos Android e iOS tienen los archivos correctos, que los podspec de iOS y los gradle scripts de Android son válidos, y que los plugins están correctamente registrados.
+
+**smoke collectors/validators:** Recolectan y validan evidencia de smoke tests — capturas de pantalla, logs de consola, resultados de Detox — y los agregan en un reporte de release.
+
+**docs/readiness drift guards:** Detectan cuando el código y la documentación se desincronizaron — por ejemplo, si se agrega un método al plugin pero no se documenta en el README.
+
+### Pipeline de CI recomendado
+
+```yaml
+# En cada PR:
+- lint + typecheck (legato-contract + legato-capacitor)
+- unit tests TypeScript (Jest)
+- unit tests Android (JUnit + Robolectric)
+- unit tests iOS (XCTest)
+
+# En cada merge a main:
+- todo lo anterior +
+- npm readiness check
+- native artifact validation
+- smoke tests en emulador Android (AVD)
+- smoke tests en iOS Simulator
+
+# En cada release:
+- todo lo anterior +
+- external consumer validation
+- docs drift guard
+- release-control (bump + publish)
+```
+
+---
+
+## 11. Estrategia de testing
+
+La estrategia de Legato está diseñada para alcanzar ~80% de cobertura sin necesitar un dispositivo físico ni tener el paquete instalado en una app real. El 20% restante requiere emulador o dispositivo y corresponde a comportamientos del sistema operativo que no son mockeables de forma confiable.
+
+### Por qué es posible el 80% sin dispositivo
+
+La razón es una sola decisión arquitectónica: **inyección de dependencias en el engine**. `LegatoAndroidCore` y `LegatoCore` no instancian `ExoPlayer` ni `AVPlayer` directamente — los reciben como parámetros a través de una interfaz. Esto permite sustituirlos con implementaciones fake en tests.
+
+### Nivel 1 — Contract + TypeScript (sin dispositivo)
+
+Testea con Jest/Vitest. El bridge de Capacitor se mockea completamente:
+
+```typescript
+// Mock del bridge — simula todo el runtime de Capacitor
+const mockBridge = {
+  calls: [],
+  listeners: new Map(),
+
+  call(method, args) {
+    this.calls.push({ method, args })
+    return Promise.resolve({ value: null })
+  },
+
+  addListener(event, cb) {
+    const existing = this.listeners.get(event) ?? []
+    this.listeners.set(event, [...existing, cb])
+    return { remove: () => {} }
+  },
+
+  emit(event, data) {  // simula evento push desde el nativo
+    this.listeners.get(event)?.forEach(cb => cb(data))
+  }
+}
+
+jest.mock('@capacitor/core', () => ({
+  registerPlugin: () => mockBridge
+}))
+```
+
+Qué se testea en este nivel:
+
+- Serialización correcta de llamadas al bridge (play, load, seekTo)
+- Propagación de eventos desde el mock al handler registrado
+- Lógica de la queue (shuffle, repeat, orden)
+- Validación de invariants del contrato
+- Manejo de errores tipados
+
+### Nivel 2 — Android engine con Robolectric (sin dispositivo)
+
+Robolectric corre el runtime de Android en la JVM. ExoPlayer se reemplaza con un fake:
+
+```kotlin
+// Engine fake para tests
+class FakeAudioEngine : AudioPlayerEngine {
+    var isPlaying = false
+    var loadedUrl: String? = null
+    var currentPositionMs: Long = 0L
+    var durationMs: Long = 0L
+    val loadCalls = mutableListOf<String>()
+
+    override fun load(url: String, startPositionMs: Long) {
+        loadedUrl = url
+        loadCalls.add(url)
+    }
+    override fun play()  { isPlaying = true }
+    override fun pause() { isPlaying = false }
+    override fun seekTo(positionMs: Long) { currentPositionMs = positionMs }
+    override fun release() {}
+}
+
+@RunWith(RobolectricTestRunner::class)
+class LegatoAndroidCoreTest {
+    @Test
+    fun `play emite stateChanged con estado playing`() {
+        val fakeEngine = FakeAudioEngine()
+        val fakeEmitter = FakeEmitter()
+        val core = LegatoAndroidCore(
+            context = ApplicationProvider.getApplicationContext(),
+            emitter = fakeEmitter,
+            engine = fakeEngine
+        )
+
+        core.play()
+
+        assertThat(fakeEmitter.events).contains(
+            EmittedEvent("stateChanged", mapOf("state" to "playing"))
+        )
+    }
+}
+```
+
+### Nivel 2 — iOS engine con XCTest (sin dispositivo)
+
+```swift
+class FakeAudioEngine: AudioEngineProtocol {
+    var isPlaying = false
+    var loadedURL: URL?
+    var currentTime: TimeInterval = 0
+    var duration: TimeInterval = 0
+    var delegate: AudioEngineDelegate?
+
+    func load(url: URL, startPosition: TimeInterval) { loadedURL = url }
+    func play()  { isPlaying = true }
+    func pause() { isPlaying = false }
+    func seek(to position: TimeInterval) { currentTime = position }
+    func release() {}
+}
+
+class LegatoCoreTests: XCTestCase {
+    func testPlayEmitsStateChanged() {
+        let fakeEngine = FakeAudioEngine()
+        let fakeEmitter = FakeEmitter()
+        let core = LegatoCore(engine: fakeEngine, emitter: fakeEmitter)
+
+        core.play()
+
+        XCTAssertTrue(fakeEmitter.events.contains { $0.name == "stateChanged" })
+    }
+}
+```
+
+### Nivel 3 — Integration tests (emulador/simulator en CI)
+
+Corren en GitHub Actions con Android Virtual Device (AVD) y iOS Simulator. No necesitan dispositivo físico pero sí un emulador real del OS. Validan:
+
+- Registro correcto del plugin en Capacitor
+- Flujo completo JS → bridge → plugin → engine → evento de retorno
+- Gapless playback entre dos tracks
+- Seek y posición correcta después del seek
+
+### El 20% que requiere dispositivo real
+
+Estos comportamientos dependen del OS real y no son mockeables de forma confiable:
+
+| Escenario | Por qué requiere dispositivo |
+|---|---|
+| Audio focus con llamada entrante real | AudioManager no responde igual en Robolectric |
+| Background survival en Android | El sistema de procesos reales no es simulable |
+| Lockscreen controls en iOS | MPNowPlayingInfoCenter necesita el framework real |
+| Interrupciones de AVAudioSession | El daemon de audio no existe completamente en Simulator |
+
+Estos se cubren como smoke tests manuales o automatizados con Detox en el `capacitor-demo`.
+
+---
+
+## 12. Estado actual y gaps
+
+### Completitud estimada por capa
+
+| Capa | Completitud | Estado |
+|------|-------------|--------|
+| legato-contract | 75% | Falta eventos de focus y buffering |
+| legato-capacitor | 64% | Facade ambigua, API incompleta |
+| native/android/core | 35% | Seam — falta ForegroundService, AudioFocus, Cache, gapless |
+| native/ios/LegatoCore | 35% | Seam — falta AVAudioSession, MPNowPlaying, RemoteCommands |
+| apps/capacitor-demo | 70% | Falta smoke tests de background survival |
+| Release + tooling | 90% | Bien maduro |
+| **Global** | **~55%** | Hacia el target de producción |
+
+### Gap más crítico
+
+Los native cores son el cuello de botella real del proyecto. Todo lo demás (tooling, packaging, contract) puede esperar. Sin engines completos, el tooling madura sobre vacío.
+
+La pregunta de validación del estado real: ¿`apps/capacitor-demo` puede reproducir audio de una URL, con controles de lockscreen funcionando, y sobrevivir ir al background? La respuesta determina si los seams son shells vacíos o motores parciales.
+
+---
+
+## 13. Roadmap de completitud
+
+### Fase 1 — Completar el contract (1 semana)
+
+Solo cambios en `legato-contract`. Sin tocar otras capas.
+
+- Agregar eventos faltantes: `bufferingChanged`, `audioFocusLost`, `audioFocusGained`, `interruptionBegan`, `interruptionEnded`
+- Agregar errores faltantes: `FOCUS_DENIED`, `BACKGROUND_KILLED`, `SOURCE_UNAVAILABLE`
+- Resolver la facade: definir si `Legato` es `@deprecated` (que delega a `audioPlayer`) o se promueve como API principal
+
+### Fase 2 — Android engine completo (2-3 semanas)
+
+Trabajo aditivo sobre el seam existente, en orden de prioridad:
+
+1. **ForegroundService** — bloqueante en Android 8+. Sin esto, el player muere en background.
+2. **AudioFocusManager** — reaccionar a llamadas entrantes y otras apps de audio.
+3. **CacheDataSource** — integrar `SimpleCache` de ExoPlayer para cache progresivo.
+4. **Queue con gapless** — `ConcatenatingMediaSource` para transición sin silencio entre tracks.
+
+### Fase 3 — iOS engine completo (2-3 semanas, paralelo a Fase 2)
+
+1. **AVAudioSession** configurado correctamente (`.playback`, no `.ambient`).
+2. **MPNowPlayingInfoCenter** — metadatos completos en lockscreen.
+3. **MPRemoteCommandCenter** — play, pause, next, previous, seek desde lockscreen/AirPods/CarPlay.
+4. **Manejo de interrupciones** — llamadas, Siri, alarmas.
+
+### Fase 4 — Ampliar demo harness (en paralelo)
+
+- Smoke test de background survival (app al background → audio continúa)
+- Smoke test de llamada entrante (pausa → llamada termina → reanuda)
+- Smoke test de seek desde lockscreen
+
+### Lo que NO tocar hasta completar Fases 1-3
+
+- Estructura del monorepo — correcta
+- Sistema de release y validación — correcto, solo extenderlo
+- Bridges de Capacitor — solo tocarlos cuando el engine cambie su interfaz
+- Packaging y distribución — ya funciona
+
+---
+
+## 14. Visión de largo plazo
+
+### Agnosticismo de framework como potencial arquitectónico
+
+Hoy Legato es Capacitor-first. La arquitectura está deliberadamente diseñada para que agregar Flutter o React Native en el futuro no requiera reescribir el dominio.
+
+El `legato-contract` ya es agnóstico de framework — define el dominio sin depender de ninguna plataforma. Los native engines (`LegatoAndroidCore`, `LegatoCore`) tampoco dependen de Capacitor — reciben el emitter como interfaz. Agregar un adapter de Flutter solo requiere:
+
+1. Crear `adapter-flutter` que registra un `MethodChannel` y traduce llamadas al emitter
+2. El engine nativo ya existe — solo cambia el bridge
+
+Esto es potencial arquitectónico real, no solo una aspiración.
+
+### Modelo de distribución futuro
+
+Si el proyecto crece en adopción, el monorepo permite evolucionar hacia un modelo tipo Capawesome — paquetes separados publicados desde el mismo repo, cada uno con su propio versionado pero coordinados por CI. Esto es posible sin cambiar la arquitectura fundamental.
+
+### Features de producción que vienen después del engine completo
+
+Una vez que los engines estén completos y los smoke tests pasen, el roadmap de features de producción incluye:
+
+- **Equalizer** — bandas de frecuencia y presets (requiere AudioFX en Android, AVAudioEngine en iOS)
+- **Crossfade** — transición con overlap configurable entre tracks
+- **Pitch control** — cambio de tono independiente de velocidad
+- **Offline support** — cache pre-cargado para reproducción sin red
+- **CarPlay / Android Auto** — UI nativa en el sistema de entretenimiento del auto
+- **Sleep timer** — pausa programada con fade out
+
+---
+
+## 15. Estado actual vs dirección multi-binding (foundation v1)
+
+### Estado actual (implementado hoy)
+
+- **Contract reusable real:** los tipos/eventos/errores/snapshots viven en `packages/contract/src/*`.
+- **Cores nativos reutilizables:** composición nativa en `native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidCoreComposition.kt` y `native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSCoreComposition.swift`.
+- **Binding runtime vigente:** solo existe binding operativo en `packages/capacitor/**`.
+- **Harness operativo vigente:** validación host/release actual se ejecuta con `apps/capacitor-demo/**`.
+
+### Dirección objetivo (planificada, no implementada en v1)
+
+- Definir un contrato adapter-agnostic en `packages/contract/src/binding-adapter.ts`.
+- Preparar el spike de bindings futuros sin implementar runtime en `packages/react-native/.gitkeep` y `packages/flutter/legato/.gitkeep`.
+- Mantener Capacitor como primer adapter concreto, sin cambiar su semántica runtime actual.
+
+### Referencias fundacionales de esta etapa
+
+- Capability map source-backed: [`docs/architecture/multi-binding-capability-map.md`](docs/architecture/multi-binding-capability-map.md)
+- Guardrails de alcance y estabilidad: [`docs/architecture/multi-binding-guardrails.md`](docs/architecture/multi-binding-guardrails.md)
+
+### Out of scope in v1
+
+- no Flutter runtime adapter
+- no React Native runtime adapter
+- no release-pipeline rewiring
+- no native engine rewrite
+
+*Documento generado como descripción conceptual completa de Legato v1.0 en su estado actual de desarrollo.*

--- a/docs/architecture/multi-binding-capability-map.md
+++ b/docs/architecture/multi-binding-capability-map.md
@@ -1,0 +1,32 @@
+# Multi-binding capability map (foundation v1)
+
+## Current (implemented)
+
+| Layer | Classification | State | Source path(s) | Evidence note |
+|---|---|---|---|---|
+| Domain contract (`events`, `errors`, `snapshot`, `capability`) | Reusable Core | Current | `packages/contract/src/events.ts`, `packages/contract/src/errors.ts`, `packages/contract/src/snapshot.ts`, `packages/contract/src/capability.ts` | Canonical shared vocabularies/types are already centralized in `@ddgutierrezc/legato-contract`. |
+| Android native composition | Reusable Core | Current | `native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidCoreComposition.kt` | Native composition seam exists independently of JS binding transport. |
+| iOS native composition | Reusable Core | Current | `native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSCoreComposition.swift` | Native composition seam exists independently of JS binding transport. |
+| Capacitor TS binding surface | Binding-Specific Adapter | Current | `packages/capacitor/src/definitions.ts`, `packages/capacitor/src/plugin.ts`, `packages/capacitor/src/events.ts`, `packages/capacitor/src/sync.ts` | Public TS API and adapter glue are Capacitor-specific runtime entrypoints today. |
+| Capacitor native bridge (Android + iOS plugin wrappers) | Binding-Specific Adapter | Current | `packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlugin.kt`, `packages/capacitor/ios/Sources/LegatoPlugin/LegatoPlugin.swift` | Current runtime transport is implemented through Capacitor plugin bridge files. |
+| Demo host harness and release evidence runner | Binding-Specific Adapter | Current | `apps/capacitor-demo/README.md`, `apps/capacitor-demo/scripts/*` | Operational smoke/release validation path is currently Capacitor-host based. |
+
+## Future (planned)
+
+| Layer | Classification | State | Source path(s) | Evidence note |
+|---|---|---|---|---|
+| Transport-neutral binding contract seam | Reusable Core | Future | `packages/contract/src/binding-adapter.ts` | Contract shape is defined to align adapters; runtime implementations beyond Capacitor are deferred. |
+| React Native binding package | Binding-Specific Adapter | Future | `packages/react-native/.gitkeep` | Package scaffold exists, but no runtime adapter implementation is present. |
+| Flutter binding package | Binding-Specific Adapter | Future | `packages/flutter/legato/.gitkeep` | Package scaffold exists, but no runtime adapter implementation is present. |
+
+## Reusable vs binding-specific matrix
+
+| Path | Classification | Current/Future | Why |
+|---|---|---|---|
+| `packages/contract/src/*` | Reusable Core | Current (+ foundation extension) | Shared domain contract for events/errors/snapshot/capabilities and adapter seam primitives. |
+| `native/android/core/**` | Reusable Core | Current | Android native composition is transport-independent. |
+| `native/ios/LegatoCore/**` | Reusable Core | Current | iOS native composition is transport-independent. |
+| `packages/capacitor/**` | Binding-Specific Adapter | Current | Active JS + native bridge adapter shipped to consumers today. |
+| `apps/capacitor-demo/**` | Binding-Specific Adapter | Current | Existing host validation harness coupled to Capacitor path. |
+| `packages/react-native/.gitkeep` | Binding-Specific Adapter | Future | Placeholder only for future adapter work. |
+| `packages/flutter/legato/.gitkeep` | Binding-Specific Adapter | Future | Placeholder only for future adapter work. |

--- a/docs/architecture/multi-binding-guardrails.md
+++ b/docs/architecture/multi-binding-guardrails.md
@@ -1,0 +1,30 @@
+# Multi-binding guardrails (foundation v1)
+
+## Do-not-touch protected paths
+
+This milestone is additive and must not rewire current release/runtime validation layers.
+
+| Protected path | Protection reason | Rule in v1 |
+|---|---|---|
+| `docs/releases/native-artifact-foundation-v1.md` | Release gate/source-of-truth for native artifact distribution policy | Do not edit as part of this change; use follow-up release changes only. |
+| `docs/releases/publication-pipeline-v2.md` | Current publication governance and evidence checklist spine | Do not edit as part of this change; preserve existing release workflow semantics. |
+| `apps/capacitor-demo/ios/App/CapApp-SPM/Package.swift` | Generated host wiring for demo iOS shell | Do not manually edit in this milestone. |
+| `packages/capacitor/android/**` | Active Android runtime bridge implementation | No runtime behavior rewrites in foundation v1. |
+| `packages/capacitor/ios/**` | Active iOS runtime bridge implementation | No runtime behavior rewrites in foundation v1. |
+| `native/android/core/**` | Native core engine/composition stability layer | Engine rewrite is out of scope. |
+| `native/ios/LegatoCore/**` | Native core engine/composition stability layer | Engine rewrite is out of scope. |
+
+## Scope enforcement
+
+Reject for this change:
+
+- runtime parity implementation for Flutter or React Native
+- native engine refactors unrelated to adapter contract foundation
+- release-pipeline rewiring or policy changes
+- generated host wiring modifications
+
+Accept for this change:
+
+- source-backed architecture docs clarifying reusable vs binding-specific layers
+- additive transport-neutral adapter contract type surface
+- Capacitor typing alignment that preserves current runtime behavior/API compatibility

--- a/docs/architecture/spikes/flutter-rn-adapter-spike.md
+++ b/docs/architecture/spikes/flutter-rn-adapter-spike.md
@@ -1,0 +1,42 @@
+# Flutter/RN adapter spike plan (post-foundation)
+
+## Purpose
+
+Define entry criteria and success metrics for future Flutter and React Native adapter spikes after foundation v1. This document is planning-only.
+
+This plan does not implement Flutter or React Native runtime adapters in v1.
+
+## Entry criteria
+
+- Binding contract baseline is available at `packages/contract/src/binding-adapter.ts`.
+- Current Capacitor adapter remains the only runtime implementation and stays release-safe.
+- Guardrails in `docs/architecture/multi-binding-guardrails.md` remain intact.
+- Capability map in `docs/architecture/multi-binding-capability-map.md` is accepted as source-backed baseline.
+
+## Assumptions
+
+- Canonical event/error/snapshot vocabulary continues to come from `packages/contract/src/events.ts`, `packages/contract/src/errors.ts`, and `packages/contract/src/snapshot.ts`.
+- Native core composition seams stay reusable (`native/android/core/**`, `native/ios/LegatoCore/**`).
+- Future bindings can introduce transport-specific glue without altering shared contract semantics.
+
+## Contract conformance checklist
+
+Reference contract: `packages/contract/src/binding-adapter.ts`.
+
+- [ ] Method parity: adapter exposes the same command/query lifecycle surface.
+- [ ] Event parity: adapter subscribes with canonical event names and payload typing.
+- [ ] Capability parity: adapter reports supported capabilities via contract projection.
+- [ ] Error-code parity: adapter error mapping aligns with canonical `LegatoError` code set.
+- [ ] Listener lifecycle parity: subscribe/unsubscribe/remove-all semantics are equivalent.
+
+## Success metrics
+
+- Spike artifacts identify binding-specific transport constraints without changing shared contract semantics.
+- Gap list is explicit per binding (`implemented`, `blocked`, `deferred`) and source-backed.
+- Follow-up runtime scope is decomposed into dedicated changes, not merged into foundation v1.
+
+## Non-goals
+
+- Shipping Flutter runtime adapter in this change.
+- Shipping React Native runtime adapter in this change.
+- Rewiring release governance or native engine internals.

--- a/packages/capacitor/README.md
+++ b/packages/capacitor/README.md
@@ -118,6 +118,12 @@ await sync.stop();
 - Choose `@ddgutierrezc/legato-contract` when you only need shared contracts/types.
 - Choose `@ddgutierrezc/legato-capacitor` when you need Capacitor plugin runtime integration.
 
+## Multi-binding boundary note (foundation v1)
+
+- Capacitor is the **first concrete adapter** over the shared binding contract.
+- Capacitor remains the **only implemented binding** in this change.
+- Flutter and React Native are planned follow-up spikes only; no runtime adapter implementation ships here.
+
 ## Maintainer operations
 
 Maintainer-heavy CLI/release/SPM operational details are documented in [`../../docs/maintainers/legato-capacitor-operator-guide.md`](../../docs/maintainers/legato-capacitor-operator-guide.md).

--- a/packages/capacitor/src/definitions.ts
+++ b/packages/capacitor/src/definitions.ts
@@ -1,5 +1,5 @@
-import type { PluginListenerHandle } from '@capacitor/core';
 import type {
+  Capability,
   LegatoEventName as ContractLegatoEventName,
   LegatoEventPayloadMap as ContractLegatoEventPayloadMap,
   LegatoError,
@@ -41,6 +41,14 @@ export type LegatoListener<E extends LegatoEventName> = (
   payload: LegatoEventPayloadMap[E],
 ) => void;
 
+export interface BindingListenerHandle {
+  remove(): Promise<void> | void;
+}
+
+export interface BindingCapabilitiesSnapshot {
+  supported: Capability[];
+}
+
 export interface AddOptions {
   tracks: Track[];
   startIndex?: number;
@@ -59,7 +67,7 @@ export interface SkipToOptions {
   index: number;
 }
 
-export interface AudioPlayerApi {
+export interface BindingAdapter {
   setup(): Promise<void>;
   add(options: AddOptions): Promise<PlaybackSnapshot>;
   remove(options: RemoveOptions): Promise<PlaybackSnapshot>;
@@ -77,10 +85,40 @@ export interface AudioPlayerApi {
   getCurrentTrack(): Promise<Track | null>;
   getQueue(): Promise<QueueSnapshot>;
   getSnapshot(): Promise<PlaybackSnapshot>;
+  getCapabilities(): Promise<BindingCapabilitiesSnapshot>;
+  addListener<E extends LegatoEventName>(
+    eventName: E,
+    listener: LegatoListener<E>,
+  ): Promise<BindingListenerHandle>;
+  removeAllListeners(): Promise<void>;
+}
+
+type BindingAdapterPlaybackSurface = Pick<
+  BindingAdapter,
+  | 'setup'
+  | 'add'
+  | 'remove'
+  | 'reset'
+  | 'play'
+  | 'pause'
+  | 'stop'
+  | 'seekTo'
+  | 'skipTo'
+  | 'skipToNext'
+  | 'skipToPrevious'
+  | 'getState'
+  | 'getPosition'
+  | 'getDuration'
+  | 'getCurrentTrack'
+  | 'getQueue'
+  | 'getSnapshot'
+>;
+
+export interface AudioPlayerApi extends BindingAdapterPlaybackSurface {
   addListener<E extends AudioPlayerEventName>(
     eventName: E,
     listener: AudioPlayerListener<E>,
-  ): Promise<PluginListenerHandle>;
+  ): Promise<BindingListenerHandle>;
   removeAllListeners(): Promise<void>;
 }
 
@@ -89,7 +127,7 @@ export interface MediaSessionApi {
   addListener<E extends MediaSessionEventName>(
     eventName: E,
     listener: MediaSessionListener<E>,
-  ): Promise<PluginListenerHandle>;
+  ): Promise<BindingListenerHandle>;
   removeAllListeners(): Promise<void>;
 }
 
@@ -99,6 +137,6 @@ export interface LegatoEventApi {
   addListener<E extends LegatoEventName>(
     eventName: E,
     listener: LegatoListener<E>,
-  ): Promise<PluginListenerHandle>;
+  ): Promise<BindingListenerHandle>;
   removeAllListeners(): Promise<void>;
 }

--- a/packages/capacitor/src/sync.ts
+++ b/packages/capacitor/src/sync.ts
@@ -1,5 +1,10 @@
-import type { PluginListenerHandle } from '@capacitor/core';
-import type { AudioPlayerApi, LegatoEventName, LegatoEventPayloadMap, PlaybackSnapshot } from './definitions';
+import type {
+  AudioPlayerApi,
+  BindingListenerHandle,
+  LegatoEventName,
+  LegatoEventPayloadMap,
+  PlaybackSnapshot,
+} from './definitions';
 import { AUDIO_PLAYER_EVENTS } from './events';
 import { Legato } from './plugin';
 
@@ -26,7 +31,7 @@ export interface AudioPlayerSyncOptions extends LegatoSyncOptions {
 
 export function createLegatoSync(options: LegatoSyncOptions = {}): LegatoSyncController {
   const client = options.client ?? Legato;
-  const handles: PluginListenerHandle[] = [];
+  const handles: BindingListenerHandle[] = [];
   let current: PlaybackSnapshot | null = null;
 
   const publishSnapshot = (snapshot: PlaybackSnapshot): PlaybackSnapshot => {

--- a/packages/contract/README.md
+++ b/packages/contract/README.md
@@ -36,6 +36,23 @@ Supported import contract:
 - Event payload types/maps
 - Event constants: `PLAYER_EVENT_NAMES`, `MEDIA_SESSION_EVENT_NAMES`, `LEGACY_PLAYER_EVENT_NAMES`, `LEGATO_EVENT_NAMES`
 - `capability`, `invariants`
+- `binding-adapter` (transport-neutral adapter contract primitives)
+
+## Binding adapter contract foundation (v1)
+
+`packages/contract/src/binding-adapter.ts` defines an adapter-agnostic surface for future bindings:
+
+- lifecycle/setup (`setup`)
+- playback command/query contract
+- typed event subscription + neutral listener handle (`BindingListenerHandle`)
+- capabilities projection (`BindingCapabilitiesSnapshot`)
+- typed adapter error envelope (`BindingAdapterError`)
+
+This is a **foundation contract only** for architecture alignment in v1.
+
+- It does not implement runtime adapters for Flutter or React Native.
+- It does not change current Capacitor runtime behavior.
+- It does not promise parity timelines for future bindings.
 
 Maintainer verification map: [`../../docs/maintainers/package-documentation-foundation-v1-source-map.md`](../../docs/maintainers/package-documentation-foundation-v1-source-map.md)
 

--- a/packages/contract/src/binding-adapter.ts
+++ b/packages/contract/src/binding-adapter.ts
@@ -1,0 +1,63 @@
+import type { Capability } from './capability.js';
+import type { LegatoError } from './errors.js';
+import type { LegatoEventName, LegatoEventPayloadMap } from './events.js';
+import type { QueueSnapshot } from './queue.js';
+import type { PlaybackSnapshot } from './snapshot.js';
+import type { PlaybackState } from './state.js';
+import type { Track } from './track.js';
+
+export interface BindingListenerHandle {
+  remove(): Promise<void> | void;
+}
+
+export interface BindingCapabilitiesSnapshot {
+  supported: Capability[];
+}
+
+export interface BindingAdapterError extends LegatoError {
+  source?: string;
+}
+
+export interface AddOptions {
+  tracks: Track[];
+  startIndex?: number;
+}
+
+export interface RemoveOptions {
+  id?: string;
+  index?: number;
+}
+
+export interface SeekToOptions {
+  position: number;
+}
+
+export interface SkipToOptions {
+  index: number;
+}
+
+export interface BindingAdapter {
+  setup(): Promise<void>;
+  add(options: AddOptions): Promise<PlaybackSnapshot>;
+  remove(options: RemoveOptions): Promise<PlaybackSnapshot>;
+  reset(): Promise<PlaybackSnapshot>;
+  play(): Promise<void>;
+  pause(): Promise<void>;
+  stop(): Promise<void>;
+  seekTo(options: SeekToOptions): Promise<void>;
+  skipTo(options: SkipToOptions): Promise<PlaybackSnapshot>;
+  skipToNext(): Promise<void>;
+  skipToPrevious(): Promise<void>;
+  getState(): Promise<PlaybackState>;
+  getPosition(): Promise<number>;
+  getDuration(): Promise<number | null>;
+  getCurrentTrack(): Promise<Track | null>;
+  getQueue(): Promise<QueueSnapshot>;
+  getSnapshot(): Promise<PlaybackSnapshot>;
+  getCapabilities(): Promise<BindingCapabilitiesSnapshot>;
+  addListener<E extends LegatoEventName>(
+    eventName: E,
+    listener: (payload: LegatoEventPayloadMap[E]) => void,
+  ): Promise<BindingListenerHandle>;
+  removeAllListeners(): Promise<void>;
+}

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -28,3 +28,4 @@ export {
 
 export * from './capability.js';
 export * from './invariants.js';
+export * from './binding-adapter.js';


### PR DESCRIPTION
Closes #75

## Summary
- add source-backed architecture artifacts that distinguish reusable vs binding-specific layers and document the current-vs-future multi-binding position
- introduce transport-neutral binding-adapter contract exports in `@ddgutierrezc/legato-contract` and align Capacitor typings without rewriting runtime behavior
- add docs/type drift guards and future Flutter/RN spike-prep docs while preserving the current release/runtime spine

## Changes
| File | Change |
|------|--------|
| `docs/architecture/multi-binding-capability-map.md` | adds a source-backed capability/layer map for current vs future multi-binding scope |
| `docs/architecture/multi-binding-guardrails.md` | documents protected runtime/release paths that must not be destabilized |
| `docs/architecture/spikes/flutter-rn-adapter-spike.md` | prepares future binding spikes without implementing them |
| `packages/contract/src/binding-adapter.ts` | introduces neutral adapter contract primitives |
| `packages/contract/src/index.ts` | exports binding-adapter primitives from the public contract package |
| `packages/capacitor/src/definitions.ts`, `src/sync.ts` | align Capacitor-side typing/docs with neutral listener semantics |
| `README.md`, `packages/contract/README.md`, `packages/capacitor/README.md`, `arquitectura_cambio.md` | update architecture/package docs to reflect current vs future state clearly |
| `apps/capacitor-demo/scripts/*multi-binding*` | add docs/type drift guards for the architecture foundation |
| `apps/capacitor-demo/scripts/external-consumer-template.test.mjs`, `release-ios-execution.mjs`, `validate-native-release-gate.test.mjs` | reconcile related tests/fixtures so the repo-wide Node baseline stays green |

## Test Plan
- [x] `node --test scripts/multi-binding-architecture-foundation-v1-docs.test.mjs scripts/multi-binding-architecture-foundation-v1-types.test.mjs`
- [x] `npm run test:npm:readiness`
- [x] `node --test` baseline is green in current repo state
- [x] No shell scripts changed

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Docs updated intentionally for architecture clarity
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers