### PR TITLE
chore(repo): persist open-source repository setup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Default owner coverage
+* @ddgutierrezc
+
+# Workflows and release automation
+.github/workflows/* @ddgutierrezc

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,22 @@
+name: Bug report
+description: Report something that is broken.
+title: "bug: "
+labels: ["type:bug", "status:needs-review"]
+body:
+  - type: markdown
+    attributes:
+      value: "Please include reproducible steps and expected behavior."
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      placeholder: What happened?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction steps
+      placeholder: Step by step
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+
+# OSS_CONTACT_LINKS:START
+contact_links:
+  - name: Security policy
+    url: https://github.com/ddgutierrezc/legato/blob/main/SECURITY.md
+    about: Read security disclosure guidance before reporting vulnerabilities.
+  - name: Maintainers scope notes
+    url: https://github.com/ddgutierrezc/legato/tree/main/docs/maintainers
+    about: Maintainer process, release constraints, and scope boundaries.
+# OSS_CONTACT_LINKS:END

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,22 @@
+name: Feature request
+description: Propose an improvement.
+title: "feature: "
+labels: ["type:feature", "status:needs-review"]
+body:
+  - type: markdown
+    attributes:
+      value: "Please describe the user need and expected outcomes."
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / opportunity
+      placeholder: What should improve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      placeholder: What are you proposing?
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Summary
+
+- Explain WHY this change is needed.
+
+## Linked issue
+
+Resolves #<issue-number>
+
+## Validation
+
+- [ ] Relevant tests/checks were run
+- [ ] No unrelated workflows were changed
+
+## Policy checks
+
+- [ ] Exactly one `type:*` label added
+- [ ] Approved issue linked when required (`status:approved`)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+
+# OSS_DEPENDABOT:START
+updates:
+  - package-ecosystem: "npm"
+    directory: "/apps/capacitor-demo"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/packages/capacitor"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/packages/contract"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+# OSS_DEPENDABOT:END

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,37 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness.
+- Being respectful of differing opinions and experiences.
+- Giving and gracefully accepting constructive feedback.
+
+Examples of unacceptable behavior include harassment, insulting comments,
+public or private attacks, and other conduct inappropriate in a professional setting.
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing standards and
+may remove or edit comments, commits, code, issues, and other contributions.
+
+## Scope
+
+This Code of Conduct applies within all project spaces and when an individual
+is officially representing the project in public spaces.
+
+## Enforcement
+
+Report incidents to maintainers via security channels documented in `SECURITY.md`.
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1:
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing to legato
+
+Thanks for contributing.
+
+## Before opening a PR
+
+1. Open or link an issue first.
+2. For implementation PRs, issue status must be `approved`.
+3. Use a branch name in the form `type/description` (lowercase `a-z0-9._-`).
+4. Use conventional commits.
+
+## Pull request checklist
+
+- Include `Closes #<issue>` / `Fixes #<issue>` / `Resolves #<issue>` in PR body.
+- Add exactly one `type:*` label (`type:feature`, `type:bug`, `type:docs`, `type:chore`).
+- Keep release workflows untouched unless your issue explicitly targets release automation.
+- Run relevant validation checks locally before asking for review.
+
+## Scope discipline
+
+Legato uses focused scope and contracts for release and runtime safety. Keep changes minimal and evidence-driven.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Legato contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -41,3 +41,11 @@ Maintainer-only scope and operational boundaries are documented in [`docs/mainta
 ## Contributing
 
 If you update README/package docs, also run docs drift checks from `apps/capacitor-demo`.
+
+<!-- OSS_LINKS:START -->
+## Community
+
+- [Contributing](./CONTRIBUTING.md)
+- [Code of Conduct](./CODE_OF_CONDUCT.md)
+- [Security Policy](./SECURITY.md)
+<!-- OSS_LINKS:END -->

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report suspected vulnerabilities privately via GitHub Security Advisories:
+
+- https://github.com/ddgutierrezc/legato/security/advisories/new
+
+If advisories are unavailable for your access level, open a private report with maintainers and avoid public disclosure until triage is complete.
+
+## Response Expectations
+
+- Initial triage acknowledgment: within 7 days.
+- Mitigation or remediation plan: provided after triage.
+
+## Supported Versions
+
+This repository currently focuses on the latest published package versions.

--- a/tooling/open-source-repository-setup/README.md
+++ b/tooling/open-source-repository-setup/README.md
@@ -1,0 +1,28 @@
+# Open Source Repository Setup Tooling
+
+This tooling applies an inspect → plan → apply workflow with non-destructive defaults.
+
+## Commands
+
+From repository root:
+
+```bash
+node tooling/open-source-repository-setup/inspect.mjs
+node tooling/open-source-repository-setup/apply.mjs plan
+node tooling/open-source-repository-setup/apply.mjs apply-files-only
+node tooling/open-source-repository-setup/apply.mjs apply
+node tooling/open-source-repository-setup/validate.mjs
+```
+
+## Behavior
+
+- `inspect`: read-only snapshot into `out/inspection.json`.
+- `plan`: classifies targets as `missing`, `present-compatible`, `present-divergent`, `permission-blocked`.
+- `apply-files-only`: writes only local file ops; divergent files are preserved and documented under `out/suggestions/`.
+- `apply`: includes API operation execution path, currently dry-run for permission-safe baseline.
+- `validate`: emits `out/validation.json`, `out/summary.md`, and `out/final-state.json`.
+
+## Rollback
+
+1. Revert changed files from the current branch.
+2. Restore API settings manually using the blocker list and repository settings UI.

--- a/tooling/open-source-repository-setup/__tests__/inspect-validate.test.mjs
+++ b/tooling/open-source-repository-setup/__tests__/inspect-validate.test.mjs
@@ -1,0 +1,104 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { validatePreflight, inspectLocalState } from '../inspect.mjs';
+import { validateRequirements, summarizeValidation } from '../validate.mjs';
+
+test('validatePreflight degrades when gh auth fails', async () => {
+  const result = await validatePreflight({
+    ghAuthStatus: async () => ({ ok: false, reason: 'not-authenticated' }),
+    getDefaultBranch: async () => 'main',
+    hasAdminAccess: async () => false,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.blockers.some((entry) => entry.code === 'GH_AUTH_MISSING'), true);
+});
+
+test('inspectLocalState marks missing OSS files', async () => {
+  const snapshot = await inspectLocalState({
+    repoRoot: '/repo',
+    fileExists: async (path) => path.endsWith('README.md'),
+  });
+
+  const security = snapshot.files.find((entry) => entry.path === 'SECURITY.md');
+  const readme = snapshot.files.find((entry) => entry.path === 'README.md');
+  assert.equal(readme.status, 'present-compatible');
+  assert.equal(security.status, 'missing');
+});
+
+test('validateRequirements produces pass fail and blocked statuses', () => {
+  const result = validateRequirements({
+    plan: {
+      fileOps: [
+        { path: 'CONTRIBUTING.md', status: 'missing', action: 'create' },
+        { path: 'README.md', status: 'present-compatible', action: 'skip' },
+      ],
+      apiOps: [{ id: 'branch-protection', status: 'permission-blocked' }],
+      blockers: [{ code: 'GH_ADMIN_REQUIRED', scope: 'branch-protection' }],
+    },
+    applyResult: {
+      applied: [{ path: 'CONTRIBUTING.md' }],
+      skipped: [{ path: 'README.md', reason: 'present-compatible' }],
+      blocked: [{ id: 'branch-protection' }],
+    },
+  });
+
+  assert.equal(result.requirements['Current-State-Aware Initialization'].status, 'pass');
+  assert.equal(result.requirements['Merge and Branch Protection Policy'].status, 'blocked');
+});
+
+test('summarizeValidation includes unresolved blockers', () => {
+  const summary = summarizeValidation({
+    validation: {
+      requirements: {
+        one: { status: 'pass' },
+        two: { status: 'blocked' },
+      },
+      blockers: [{ code: 'GH_ADMIN_REQUIRED', scope: 'rulesets' }],
+    },
+  });
+
+  assert.match(summary, /blocked: 1/i);
+  assert.match(summary, /GH_ADMIN_REQUIRED/);
+});
+
+test('validateRequirements fails non-overwrite safety when divergent conflict is not preserved with suggestion', () => {
+  const result = validateRequirements({
+    plan: {
+      fileOps: [
+        { path: '.github/PULL_REQUEST_TEMPLATE.md', status: 'present-divergent', strategy: 'create-if-missing' },
+      ],
+      apiOps: [],
+      blockers: [],
+    },
+    applyResult: {
+      applied: [],
+      skipped: [],
+      blocked: [],
+      suggestions: [],
+    },
+  });
+
+  assert.equal(result.requirements['Non-Overwrite Safety'].status, 'fail');
+});
+
+test('validateRequirements passes non-overwrite safety when divergent conflict is skipped and suggested', () => {
+  const result = validateRequirements({
+    plan: {
+      fileOps: [
+        { path: '.github/PULL_REQUEST_TEMPLATE.md', status: 'present-divergent', strategy: 'create-if-missing' },
+      ],
+      apiOps: [],
+      blockers: [],
+    },
+    applyResult: {
+      applied: [],
+      skipped: [{ path: '.github/PULL_REQUEST_TEMPLATE.md', reason: 'present-divergent' }],
+      blocked: [],
+      suggestions: [{ path: '.github/PULL_REQUEST_TEMPLATE.md' }],
+    },
+  });
+
+  assert.equal(result.requirements['Non-Overwrite Safety'].status, 'pass');
+});

--- a/tooling/open-source-repository-setup/__tests__/planner.test.mjs
+++ b/tooling/open-source-repository-setup/__tests__/planner.test.mjs
@@ -1,0 +1,196 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+
+import {
+  buildPlan,
+  applyFilePlan,
+  ensureManagedBlock,
+  reconcileDependabot,
+  buildApiPlan,
+  classifyPermission,
+} from '../apply.mjs';
+
+test('buildPlan classifies missing and divergent files', async () => {
+  const scratch = await mkdtemp(resolve(tmpdir(), 'oss-setup-plan-'));
+  try {
+    const plan = await buildPlan({
+      repoRoot: scratch,
+      targets: [
+        { path: 'CONTRIBUTING.md', template: 'contributing.md', strategy: 'create-if-missing' },
+        { path: 'README.md', template: 'readme.md', strategy: 'managed-block', marker: 'OSS_LINKS' },
+      ],
+      templateLoader: async () => 'template-content',
+      fileReader: async (path) => {
+        if (path.endsWith('README.md')) {
+          return '# existing-readme\n';
+        }
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      },
+    });
+
+    const contributing = plan.fileOps.find((entry) => entry.path === 'CONTRIBUTING.md');
+    const readme = plan.fileOps.find((entry) => entry.path === 'README.md');
+
+    assert.equal(contributing.status, 'missing');
+    assert.equal(readme.status, 'present-divergent');
+  } finally {
+    await rm(scratch, { recursive: true, force: true });
+  }
+});
+
+test('applyFilePlan creates only missing files and emits suggestions', async () => {
+  const scratch = await mkdtemp(resolve(tmpdir(), 'oss-setup-apply-'));
+  try {
+    const result = await applyFilePlan({
+      repoRoot: scratch,
+      plan: {
+        fileOps: [
+          {
+            path: 'SECURITY.md',
+            status: 'missing',
+            desired: 'security-policy',
+            strategy: 'create-if-missing',
+          },
+          {
+            path: 'README.md',
+            status: 'present-divergent',
+            desired: 'new-readme',
+            existing: '# existing',
+            strategy: 'create-if-missing',
+          },
+        ],
+      },
+    });
+
+    assert.equal(result.applied.length, 1);
+    assert.equal(result.suggestions.length, 1);
+
+    const security = await readFile(resolve(scratch, 'SECURITY.md'), 'utf8');
+    assert.equal(security, 'security-policy');
+
+    const suggestion = await readFile(resolve(scratch, 'tooling/open-source-repository-setup/out/suggestions/README.md.patch.md'), 'utf8');
+    assert.match(suggestion, /present-divergent/i);
+  } finally {
+    await rm(scratch, { recursive: true, force: true });
+  }
+});
+
+test('ensureManagedBlock updates managed section without replacing user content', () => {
+  const current = '# title\n\ncustom intro\n\n<!-- OSS_LINKS:START -->\nold block\n<!-- OSS_LINKS:END -->\n';
+  const updated = ensureManagedBlock({
+    current,
+    marker: 'OSS_LINKS',
+    content: '- [Contributing](./CONTRIBUTING.md)',
+  });
+
+  assert.match(updated, /custom intro/);
+  assert.match(updated, /Contributing/);
+  assert.doesNotMatch(updated, /old block/);
+});
+
+test('ensureManagedBlock supports hash markers for YAML files', () => {
+  const current = 'version: 2\n# OSS_DEPENDABOT:START\nold\n# OSS_DEPENDABOT:END\n';
+  const updated = ensureManagedBlock({
+    current,
+    marker: 'OSS_DEPENDABOT',
+    content: 'updates:\n  - package-ecosystem: "npm"',
+    commentStyle: 'hash',
+  });
+
+  assert.match(updated, /# OSS_DEPENDABOT:START/);
+  assert.match(updated, /package-ecosystem/);
+  assert.doesNotMatch(updated, /\nold\n/);
+});
+
+test('reconcileDependabot adds missing target path while preserving cadence', () => {
+  const current = [
+    'version: 2',
+    'updates:',
+    '  - package-ecosystem: npm',
+    '    directory: "/apps/capacitor-demo"',
+    '    schedule:',
+    '      interval: weekly',
+  ].join('\n');
+
+  const next = reconcileDependabot({
+    current,
+    requiredEntries: [
+      { ecosystem: 'npm', directory: '/apps/capacitor-demo' },
+      { ecosystem: 'npm', directory: '/packages/capacitor' },
+    ],
+  });
+
+  assert.match(next, /interval: weekly/);
+  assert.match(next, /directory: "\/packages\/capacitor"/);
+});
+
+test('buildApiPlan marks blocked operations when admin scope missing', () => {
+  const plan = buildApiPlan({
+    desired: {
+      repo: { allow_auto_merge: true },
+      labels: [{ name: 'status:needs-review', color: 'd4c5f9', description: 'Needs reviewer triage' }],
+      topics: ['legato', 'capacitor'],
+      branchProtection: { requiredApprovingReviewCount: 1 },
+    },
+    current: {
+      repo: { allow_auto_merge: false },
+      labels: [],
+      topics: [],
+      branchProtection: null,
+      permissions: { admin: false },
+    },
+  });
+
+  assert.equal(plan.apiOps.every((entry) => entry.status === 'permission-blocked'), true);
+});
+
+test('buildApiPlan plans branch protection reconcile when admin is available and policy drift exists', () => {
+  const desiredBranchProtection = {
+    branch: 'main',
+    required_status_checks: { strict: true, contexts: ['npm-readiness'] },
+    enforce_admins: false,
+    required_pull_request_reviews: {
+      required_approving_review_count: 1,
+      dismiss_stale_reviews: false,
+      require_code_owner_reviews: false,
+    },
+  };
+
+  const plan = buildApiPlan({
+    desired: {
+      repo: {},
+      labels: [],
+      topics: [],
+      branchProtection: desiredBranchProtection,
+    },
+    current: {
+      repo: {},
+      labels: [],
+      topics: [],
+      branchProtection: {
+        branch: 'main',
+        required_status_checks: { strict: false, contexts: [] },
+        enforce_admins: false,
+        required_pull_request_reviews: {
+          required_approving_review_count: 0,
+          dismiss_stale_reviews: false,
+          require_code_owner_reviews: false,
+        },
+      },
+      permissions: { admin: true },
+    },
+  });
+
+  const branchProtection = plan.apiOps.find((entry) => entry.id === 'branch-protection');
+  assert.ok(branchProtection, 'expected branch-protection op when drift exists');
+  assert.equal(branchProtection.status, 'missing');
+  assert.deepEqual(branchProtection.payload, desiredBranchProtection);
+});
+
+test('classifyPermission returns blocked when operation needs admin', () => {
+  assert.equal(classifyPermission({ needsAdmin: true, hasAdmin: false }), 'permission-blocked');
+  assert.equal(classifyPermission({ needsAdmin: false, hasAdmin: false }), 'missing');
+});

--- a/tooling/open-source-repository-setup/__tests__/workflows-preserved.test.mjs
+++ b/tooling/open-source-repository-setup/__tests__/workflows-preserved.test.mjs
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { resolve } from 'node:path';
+
+import { inspectWorkflowInventory } from '../inspect.mjs';
+
+const repoRoot = resolve(import.meta.dirname, '../../..');
+
+test('release workflows remain untouched by OSS setup tooling run', async () => {
+  const before = await inspectWorkflowInventory({ repoRoot });
+
+  const expected = [
+    '.github/workflows/release-control.yml',
+    '.github/workflows/release-npm.yml',
+    '.github/workflows/release-android.yml',
+  ];
+
+  for (const workflow of expected) {
+    const entry = before.find((item) => item.path === workflow);
+    assert.ok(entry, `expected workflow missing from inventory: ${workflow}`);
+    const content = await readFile(resolve(repoRoot, workflow), 'utf8');
+    const hash = createHash('sha256').update(content).digest('hex');
+    assert.equal(entry.sha256, hash);
+  }
+});

--- a/tooling/open-source-repository-setup/apply.mjs
+++ b/tooling/open-source-repository-setup/apply.mjs
@@ -1,0 +1,401 @@
+import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { resolve, dirname } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { tmpdir } from 'node:os';
+
+const execFileAsync = promisify(execFile);
+
+export function classifyPermission({ needsAdmin, hasAdmin }) {
+  if (needsAdmin && !hasAdmin) {
+    return 'permission-blocked';
+  }
+  return 'missing';
+}
+
+function markerTokens(marker, commentStyle = 'html') {
+  if (commentStyle === 'hash') {
+    return {
+      start: `# ${marker}:START`,
+      end: `# ${marker}:END`,
+    };
+  }
+  return {
+    start: `<!-- ${marker}:START -->`,
+    end: `<!-- ${marker}:END -->`,
+  };
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function ensureManagedBlock({ current, marker, content, commentStyle = 'html' }) {
+  const { start, end } = markerTokens(marker, commentStyle);
+  const managed = `${start}\n${content}\n${end}`;
+  const variants = [markerTokens(marker, 'html'), markerTokens(marker, 'hash')];
+
+  let sanitized = current;
+  for (const variant of variants) {
+    const pattern = new RegExp(`${escapeRegex(variant.start)}[\\s\\S]*?${escapeRegex(variant.end)}\\n?`, 'gm');
+    sanitized = sanitized.replace(pattern, '').trimEnd();
+    const orphanStart = new RegExp(`^${escapeRegex(variant.start)}\\s*$`, 'gm');
+    const orphanEnd = new RegExp(`^${escapeRegex(variant.end)}\\s*$`, 'gm');
+    sanitized = sanitized.replace(orphanStart, '').replace(orphanEnd, '').trimEnd();
+  }
+
+  if (sanitized.length === 0) {
+    return `${managed}\n`;
+  }
+
+  return `${sanitized}\n\n${managed}\n`;
+}
+
+function buildSuggestion({ path, existing, desired, reason }) {
+  return [
+    `# Suggestion for ${path}`,
+    `reason: ${reason}`,
+    '--- existing ---',
+    existing ?? '',
+    '--- desired ---',
+    desired ?? '',
+    '',
+  ].join('\n');
+}
+
+export function reconcileDependabot({ current, requiredEntries }) {
+  const lines = current.split('\n');
+  const hasUpdates = lines.some((line) => line.trim() === 'updates:');
+  const output = [...lines];
+
+  if (!hasUpdates) {
+    output.push('updates:');
+  }
+
+  for (const entry of requiredEntries) {
+    const token = `directory: "${entry.directory}"`;
+    if (output.some((line) => line.includes(token))) {
+      continue;
+    }
+    output.push(`  - package-ecosystem: "${entry.ecosystem}"`);
+    output.push(`    directory: "${entry.directory}"`);
+    output.push('    schedule:');
+    output.push('      interval: weekly');
+  }
+
+  return output.join('\n').replace(/\n{3,}/g, '\n\n');
+}
+
+async function fileExists(path) {
+  try {
+    await readFile(path, 'utf8');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function defaultTemplateLoader({ repoRoot, template }) {
+  return readFile(resolve(repoRoot, 'tooling/open-source-repository-setup/templates', template), 'utf8');
+}
+
+export async function buildPlan({ repoRoot, targets, templateLoader = defaultTemplateLoader, fileReader = readFile }) {
+  const fileOps = [];
+
+  for (const target of targets) {
+    const absolute = resolve(repoRoot, target.path);
+    const desired = await templateLoader({ repoRoot, template: target.template });
+
+    let existing = null;
+    try {
+      existing = await fileReader(absolute, 'utf8');
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        throw error;
+      }
+    }
+
+    if (target.strategy === 'managed-block') {
+      if (existing == null) {
+        const seed = target.base ?? '';
+        const managedContent = ensureManagedBlock({
+          current: seed,
+          marker: target.marker,
+          content: desired.trim(),
+          commentStyle: target.commentStyle,
+        });
+        fileOps.push({ path: target.path, strategy: target.strategy, marker: target.marker, commentStyle: target.commentStyle, status: 'missing', desired: managedContent });
+        continue;
+      }
+
+      const managedContent = ensureManagedBlock({
+        current: existing,
+        marker: target.marker,
+        content: desired.trim(),
+        commentStyle: target.commentStyle,
+      });
+      if (managedContent === existing) {
+        fileOps.push({ path: target.path, strategy: target.strategy, marker: target.marker, commentStyle: target.commentStyle, status: 'present-compatible', existing, desired: managedContent });
+      } else {
+        fileOps.push({ path: target.path, strategy: target.strategy, marker: target.marker, commentStyle: target.commentStyle, status: 'present-divergent', existing, desired: managedContent });
+      }
+      continue;
+    }
+
+    if (existing == null) {
+      fileOps.push({ path: target.path, strategy: target.strategy, marker: target.marker, commentStyle: target.commentStyle, status: 'missing', desired });
+      continue;
+    }
+
+    if (existing === desired) {
+      fileOps.push({ path: target.path, strategy: target.strategy, status: 'present-compatible', existing, desired });
+    } else {
+      fileOps.push({ path: target.path, strategy: target.strategy, status: 'present-divergent', existing, desired });
+    }
+  }
+
+  return { fileOps, apiOps: [], blockers: [] };
+}
+
+export function buildApiPlan({ desired, current }) {
+  const hasAdmin = Boolean(current.permissions?.admin);
+  const apiOps = [];
+
+  const pickDesiredShape = (source, shape) => {
+    if (Array.isArray(shape)) {
+      return Array.isArray(source) ? source : [];
+    }
+    if (shape && typeof shape === 'object') {
+      const out = {};
+      for (const key of Object.keys(shape)) {
+        out[key] = pickDesiredShape(source?.[key], shape[key]);
+      }
+      return out;
+    }
+    return source;
+  };
+
+  const comparableCurrentRepo = pickDesiredShape(current.repo ?? {}, desired.repo ?? {});
+
+  if (JSON.stringify(comparableCurrentRepo) !== JSON.stringify(desired.repo ?? {})) {
+    apiOps.push({
+      id: 'repo-settings',
+      method: 'PATCH',
+      endpoint: '/repos/{owner}/{repo}',
+      status: classifyPermission({ needsAdmin: true, hasAdmin }),
+      payload: desired.repo,
+    });
+  }
+
+  const currentTopics = [...(current.topics ?? [])].sort();
+  const desiredTopics = [...(desired.topics ?? [])].sort();
+  if (JSON.stringify(currentTopics) !== JSON.stringify(desiredTopics)) {
+    apiOps.push({
+      id: 'repo-topics',
+      method: 'PUT',
+      endpoint: '/repos/{owner}/{repo}/topics',
+      status: classifyPermission({ needsAdmin: true, hasAdmin }),
+      payload: { names: desiredTopics },
+    });
+  }
+
+  for (const label of desired.labels ?? []) {
+    const exists = (current.labels ?? []).some((entry) => entry.name === label.name);
+    if (!exists) {
+      apiOps.push({
+        id: `label:${label.name}`,
+        method: 'POST',
+        endpoint: '/repos/{owner}/{repo}/labels',
+        status: classifyPermission({ needsAdmin: true, hasAdmin }),
+        payload: label,
+      });
+    }
+  }
+
+  const comparableBranchProtection = pickDesiredShape(current.branchProtection ?? {}, desired.branchProtection ?? {});
+  if (desired.branchProtection && JSON.stringify(comparableBranchProtection) !== JSON.stringify(desired.branchProtection)) {
+    apiOps.push({
+      id: 'branch-protection',
+      method: 'PUT',
+      endpoint: `/repos/{owner}/{repo}/branches/${desired.branchProtection.branch}/protection`,
+      status: classifyPermission({ needsAdmin: true, hasAdmin }),
+      payload: desired.branchProtection,
+    });
+  }
+
+  return { apiOps, blockers: apiOps.filter((entry) => entry.status === 'permission-blocked') };
+}
+
+export async function applyFilePlan({ repoRoot, plan }) {
+  const suggestionsDir = resolve(repoRoot, 'tooling/open-source-repository-setup/out/suggestions');
+  await mkdir(suggestionsDir, { recursive: true });
+
+  const result = { applied: [], skipped: [], blocked: [], suggestions: [] };
+
+  for (const operation of plan.fileOps) {
+    const absolute = resolve(repoRoot, operation.path);
+    await mkdir(dirname(absolute), { recursive: true });
+
+    if (operation.status === 'missing') {
+      await writeFile(absolute, operation.desired, 'utf8');
+      result.applied.push({ path: operation.path, action: 'created' });
+      continue;
+    }
+
+    if (operation.status === 'present-compatible') {
+      result.skipped.push({ path: operation.path, reason: operation.status });
+      continue;
+    }
+
+    if (operation.strategy === 'managed-block') {
+      await writeFile(absolute, operation.desired, 'utf8');
+      result.applied.push({ path: operation.path, action: 'managed-block-updated' });
+      continue;
+    }
+
+    const suggestionPath = resolve(suggestionsDir, `${operation.path.replaceAll('/', '__')}.patch.md`);
+    await mkdir(dirname(suggestionPath), { recursive: true });
+    await writeFile(
+      suggestionPath,
+      buildSuggestion({ path: operation.path, existing: operation.existing, desired: operation.desired, reason: operation.status }),
+      'utf8',
+    );
+    result.suggestions.push({ path: operation.path, suggestionPath: suggestionPath.replace(`${repoRoot}/`, '') });
+    result.skipped.push({ path: operation.path, reason: operation.status });
+  }
+
+  return result;
+}
+
+async function runGhApi({ method, endpoint, payload }) {
+  const args = ['api', endpoint, '-X', method];
+  let tempDir = null;
+  let payloadPath = null;
+  if (payload) {
+    tempDir = await mkdtemp(resolve(tmpdir(), 'oss-setup-gh-'));
+    payloadPath = resolve(tempDir, 'payload.json');
+    await writeFile(payloadPath, JSON.stringify(payload), 'utf8');
+    args.push('--input', payloadPath);
+  }
+  try {
+    await execFileAsync('gh', args, { encoding: 'utf8' });
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: String(error.message ?? error) };
+  } finally {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  }
+}
+
+export async function applyApiPlan({ repo, apiPlan, dryRun = true }) {
+  const [owner, name] = repo.split('/');
+  const applied = [];
+  const blocked = [];
+  const skipped = [];
+
+  for (const operation of apiPlan.apiOps) {
+    if (operation.status === 'permission-blocked') {
+      blocked.push({ id: operation.id, reason: 'permission-blocked' });
+      continue;
+    }
+
+    if (dryRun) {
+      skipped.push({ id: operation.id, reason: 'dry-run' });
+      continue;
+    }
+
+    const endpoint = operation.endpoint.replace('{owner}', owner).replace('{repo}', name);
+    const res = await runGhApi({ method: operation.method, endpoint, payload: operation.payload });
+    if (res.ok) {
+      applied.push({ id: operation.id });
+    } else {
+      blocked.push({ id: operation.id, reason: res.error });
+    }
+  }
+
+  return { applied, blocked, skipped };
+}
+
+async function loadManifest(repoRoot) {
+  const content = await readFile(resolve(repoRoot, 'tooling/open-source-repository-setup/manifest.json'), 'utf8');
+  return JSON.parse(content);
+}
+
+async function loadInspection(repoRoot) {
+  const content = await readFile(resolve(repoRoot, 'tooling/open-source-repository-setup/out/inspection.json'), 'utf8');
+  return JSON.parse(content);
+}
+
+async function writeJson(path, value) {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+async function main() {
+  const command = process.argv[2] ?? 'plan';
+  const applyApi = process.argv.includes('--apply-api');
+  const repoRoot = resolve(process.cwd());
+  const outDir = resolve(repoRoot, 'tooling/open-source-repository-setup/out');
+  const manifest = await loadManifest(repoRoot);
+  const inspection = await loadInspection(repoRoot);
+
+  const filePlan = await buildPlan({ repoRoot, targets: manifest.files });
+
+  const dependabotOp = filePlan.fileOps.find((op) => op.path === '.github/dependabot.yml');
+  if (dependabotOp) {
+    dependabotOp.desired = reconcileDependabot({
+      current: dependabotOp.desired,
+      requiredEntries: manifest.dependabotTargets,
+    });
+  }
+
+  const apiPlan = buildApiPlan({
+    desired: {
+      repo: manifest.github.repo,
+      topics: manifest.github.topics,
+      labels: manifest.github.requiredLabels,
+      branchProtection: manifest.github.branchProtection,
+    },
+    current: {
+      repo: inspection.github.repoSettings ?? {},
+      labels: inspection.github.labels,
+      topics: inspection.github.topics ?? [],
+      branchProtection: inspection.github.branchProtection,
+      permissions: inspection.permissions,
+    },
+  });
+
+  const plan = {
+    generatedAt: new Date().toISOString(),
+    fileOps: filePlan.fileOps,
+    apiOps: apiPlan.apiOps,
+    blockers: [...inspection.blockers, ...apiPlan.blockers],
+  };
+
+  await writeJson(resolve(outDir, 'plan.json'), plan);
+
+  if (command === 'plan') {
+    return;
+  }
+
+  if (command === 'apply' || command === 'apply-files-only') {
+    const files = await applyFilePlan({ repoRoot, plan });
+    const api = command === 'apply'
+      ? await applyApiPlan({ repo: 'ddgutierrezc/legato', apiPlan, dryRun: !applyApi })
+      : { applied: [], blocked: [], skipped: [] };
+    await writeJson(resolve(outDir, 'apply-result.json'), { files, api });
+  }
+
+  if (command === 'snapshot-templates') {
+    await cp(resolve(repoRoot, 'tooling/open-source-repository-setup/templates'), resolve(outDir, 'templates-snapshot'), {
+      recursive: true,
+      force: true,
+    });
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+}

--- a/tooling/open-source-repository-setup/inspect.mjs
+++ b/tooling/open-source-repository-setup/inspect.mjs
@@ -1,0 +1,166 @@
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { resolve } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const REQUIRED_FILES = [
+  'README.md',
+  'LICENSE',
+  'CONTRIBUTING.md',
+  'CODE_OF_CONDUCT.md',
+  'SECURITY.md',
+  '.github/CODEOWNERS',
+  '.github/PULL_REQUEST_TEMPLATE.md',
+  '.github/ISSUE_TEMPLATE/bug_report.yml',
+  '.github/ISSUE_TEMPLATE/feature_request.yml',
+  '.github/ISSUE_TEMPLATE/config.yml',
+  '.github/dependabot.yml',
+];
+
+const WORKFLOWS_TO_PRESERVE = [
+  '.github/workflows/release-control.yml',
+  '.github/workflows/release-npm.yml',
+  '.github/workflows/release-android.yml',
+  '.github/workflows/npm-release-readiness.yml',
+];
+
+export async function fileExistsDefault(path) {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function inspectLocalState({ repoRoot, fileExists = fileExistsDefault }) {
+  const files = [];
+  for (const path of REQUIRED_FILES) {
+    const exists = await fileExists(resolve(repoRoot, path));
+    files.push({ path, status: exists ? 'present-compatible' : 'missing' });
+  }
+  return { files };
+}
+
+export async function inspectWorkflowInventory({ repoRoot }) {
+  const inventory = [];
+  for (const path of WORKFLOWS_TO_PRESERVE) {
+    const absolute = resolve(repoRoot, path);
+    const exists = await fileExistsDefault(absolute);
+    if (!exists) {
+      inventory.push({ path, missing: true });
+      continue;
+    }
+    const content = await readFile(absolute, 'utf8');
+    const sha256 = createHash('sha256').update(content).digest('hex');
+    inventory.push({ path, missing: false, sha256 });
+  }
+  return inventory;
+}
+
+async function runJsonGh(args) {
+  try {
+    const { stdout } = await execFileAsync('gh', args, { encoding: 'utf8' });
+    return { ok: true, value: JSON.parse(stdout) };
+  } catch (error) {
+    return { ok: false, error: String(error.message ?? error) };
+  }
+}
+
+export async function validatePreflight({
+  ghAuthStatus = async () => {
+    try {
+      await execFileAsync('gh', ['auth', 'status'], { encoding: 'utf8' });
+      return { ok: true };
+    } catch {
+      return { ok: false, reason: 'not-authenticated' };
+    }
+  },
+  getDefaultBranch = async () => 'main',
+  hasAdminAccess = async () => false,
+}) {
+  const blockers = [];
+  const auth = await ghAuthStatus();
+  const defaultBranch = await getDefaultBranch();
+  const admin = await hasAdminAccess();
+
+  if (!auth.ok) {
+    blockers.push({ code: 'GH_AUTH_MISSING', detail: auth.reason ?? 'unknown' });
+  }
+  if (!admin) {
+    blockers.push({ code: 'GH_ADMIN_REQUIRED', detail: 'API apply step will run in audit-only mode.' });
+  }
+  return {
+    ok: blockers.length === 0,
+    blockers,
+    defaultBranch,
+    permissions: { admin },
+  };
+}
+
+export async function runInspection({ repoRoot }) {
+  const local = await inspectLocalState({ repoRoot });
+  const workflows = await inspectWorkflowInventory({ repoRoot });
+  const repoRes = await runJsonGh(['repo', 'view', '--json', 'nameWithOwner,defaultBranchRef']);
+  const branch = repoRes.ok ? repoRes.value.defaultBranchRef?.name ?? 'main' : 'main';
+
+  const preflight = await validatePreflight({
+    getDefaultBranch: async () => branch,
+    hasAdminAccess: async () => {
+      const r = await runJsonGh(['api', 'repos/ddgutierrezc/legato', '--jq', '.permissions.admin']);
+      return Boolean(r.ok && r.value === true);
+    },
+  });
+
+  const labels = await runJsonGh(['api', 'repos/ddgutierrezc/legato/labels']);
+  const rulesets = await runJsonGh(['api', 'repos/ddgutierrezc/legato/rulesets']);
+  const branchProtection = await runJsonGh(['api', `repos/ddgutierrezc/legato/branches/${branch}/protection`]);
+  const security = await runJsonGh(['api', 'repos/ddgutierrezc/legato', '--jq', '.security_and_analysis']);
+  const repoSettings = await runJsonGh([
+    'api',
+    'repos/ddgutierrezc/legato',
+    '--jq',
+    '{allow_auto_merge:.allow_auto_merge,delete_branch_on_merge:.delete_branch_on_merge,allow_update_branch:.allow_update_branch,has_discussions:.has_discussions,allow_merge_commit:.allow_merge_commit,allow_rebase_merge:.allow_rebase_merge,allow_squash_merge:.allow_squash_merge,security_and_analysis:.security_and_analysis,topics:.topics}',
+  ]);
+
+  return {
+    git: { defaultBranch: branch },
+    files: local.files,
+    workflows,
+    github: {
+      repoSettings: repoSettings.ok ? {
+        allow_auto_merge: repoSettings.value.allow_auto_merge,
+        delete_branch_on_merge: repoSettings.value.delete_branch_on_merge,
+        allow_update_branch: repoSettings.value.allow_update_branch,
+        has_discussions: repoSettings.value.has_discussions,
+        allow_merge_commit: repoSettings.value.allow_merge_commit,
+        allow_rebase_merge: repoSettings.value.allow_rebase_merge,
+        allow_squash_merge: repoSettings.value.allow_squash_merge,
+        security_and_analysis: repoSettings.value.security_and_analysis,
+      } : null,
+      topics: repoSettings.ok ? repoSettings.value.topics : [],
+      labels: labels.ok ? labels.value : [],
+      rulesets: rulesets.ok ? rulesets.value : [],
+      branchProtection: branchProtection.ok ? branchProtection.value : null,
+      securityAndAnalysis: security.ok ? security.value : null,
+    },
+    blockers: preflight.blockers,
+    permissions: preflight.permissions,
+  };
+}
+
+async function main() {
+  const repoRoot = resolve(process.cwd());
+  const outDir = resolve(repoRoot, 'tooling/open-source-repository-setup/out');
+  await mkdir(outDir, { recursive: true });
+  const inspection = await runInspection({ repoRoot });
+  await writeFile(resolve(outDir, 'inspection.json'), `${JSON.stringify(inspection, null, 2)}\n`, 'utf8');
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+}

--- a/tooling/open-source-repository-setup/manifest.json
+++ b/tooling/open-source-repository-setup/manifest.json
@@ -1,0 +1,58 @@
+{
+  "files": [
+    { "path": "LICENSE", "template": "LICENSE", "strategy": "create-if-missing" },
+    { "path": "CONTRIBUTING.md", "template": "CONTRIBUTING.md", "strategy": "create-if-missing" },
+    { "path": "CODE_OF_CONDUCT.md", "template": "CODE_OF_CONDUCT.md", "strategy": "create-if-missing" },
+    { "path": "SECURITY.md", "template": "SECURITY.md", "strategy": "create-if-missing" },
+    { "path": ".github/CODEOWNERS", "template": ".github/CODEOWNERS", "strategy": "create-if-missing" },
+    { "path": ".github/PULL_REQUEST_TEMPLATE.md", "template": ".github/PULL_REQUEST_TEMPLATE.md", "strategy": "create-if-missing" },
+    { "path": ".github/ISSUE_TEMPLATE/bug_report.yml", "template": ".github/ISSUE_TEMPLATE/bug_report.yml", "strategy": "create-if-missing" },
+    { "path": ".github/ISSUE_TEMPLATE/feature_request.yml", "template": ".github/ISSUE_TEMPLATE/feature_request.yml", "strategy": "create-if-missing" },
+    { "path": ".github/ISSUE_TEMPLATE/config.yml", "template": ".github/ISSUE_TEMPLATE/config.yml", "strategy": "managed-block", "marker": "OSS_CONTACT_LINKS", "commentStyle": "hash", "base": "blank_issues_enabled: false\n" },
+    { "path": ".github/dependabot.yml", "template": ".github/dependabot.yml", "strategy": "managed-block", "marker": "OSS_DEPENDABOT", "commentStyle": "hash", "base": "version: 2\n" },
+    { "path": "README.md", "template": "README.oss-links.md", "strategy": "managed-block", "marker": "OSS_LINKS" }
+  ],
+  "github": {
+    "repo": {
+      "allow_auto_merge": false,
+      "delete_branch_on_merge": true,
+      "allow_update_branch": true,
+      "has_discussions": false,
+      "allow_merge_commit": true,
+      "allow_rebase_merge": true,
+      "allow_squash_merge": true,
+      "security_and_analysis": {
+        "dependabot_security_updates": { "status": "enabled" },
+        "secret_scanning": { "status": "enabled" },
+        "secret_scanning_push_protection": { "status": "enabled" }
+      }
+    },
+    "topics": ["legato", "capacitor", "audio", "opensource"],
+    "requiredLabels": [
+      { "name": "status:needs-review", "color": "d4c5f9", "description": "Needs reviewer triage" }
+    ],
+    "branchProtection": {
+      "branch": "main",
+      "required_status_checks": {
+        "strict": true,
+        "contexts": ["npm-readiness"]
+      },
+      "enforce_admins": false,
+      "required_pull_request_reviews": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false
+      },
+      "restrictions": null,
+      "allow_force_pushes": false,
+      "allow_deletions": false,
+      "required_linear_history": false
+    }
+  },
+  "dependabotTargets": [
+    { "ecosystem": "npm", "directory": "/apps/capacitor-demo" },
+    { "ecosystem": "npm", "directory": "/packages/capacitor" },
+    { "ecosystem": "npm", "directory": "/packages/contract" },
+    { "ecosystem": "github-actions", "directory": "/" }
+  ]
+}

--- a/tooling/open-source-repository-setup/out/apply-result.json
+++ b/tooling/open-source-repository-setup/out/apply-result.json
@@ -1,0 +1,63 @@
+{
+  "files": {
+    "applied": [],
+    "skipped": [
+      {
+        "path": "LICENSE",
+        "reason": "present-compatible"
+      },
+      {
+        "path": "CONTRIBUTING.md",
+        "reason": "present-compatible"
+      },
+      {
+        "path": "CODE_OF_CONDUCT.md",
+        "reason": "present-compatible"
+      },
+      {
+        "path": "SECURITY.md",
+        "reason": "present-compatible"
+      },
+      {
+        "path": ".github/CODEOWNERS",
+        "reason": "present-compatible"
+      },
+      {
+        "path": ".github/PULL_REQUEST_TEMPLATE.md",
+        "reason": "present-compatible"
+      },
+      {
+        "path": ".github/ISSUE_TEMPLATE/bug_report.yml",
+        "reason": "present-compatible"
+      },
+      {
+        "path": ".github/ISSUE_TEMPLATE/feature_request.yml",
+        "reason": "present-compatible"
+      },
+      {
+        "path": ".github/ISSUE_TEMPLATE/config.yml",
+        "reason": "present-compatible"
+      },
+      {
+        "path": ".github/dependabot.yml",
+        "reason": "present-compatible"
+      },
+      {
+        "path": "README.md",
+        "reason": "present-compatible"
+      }
+    ],
+    "blocked": [],
+    "suggestions": []
+  },
+  "api": {
+    "applied": [],
+    "blocked": [],
+    "skipped": [
+      {
+        "id": "branch-protection",
+        "reason": "dry-run"
+      }
+    ]
+  }
+}

--- a/tooling/open-source-repository-setup/out/final-state.json
+++ b/tooling/open-source-repository-setup/out/final-state.json
@@ -1,0 +1,54 @@
+{
+  "generatedAt": "2026-04-26T21:05:28.106Z",
+  "counts": {
+    "pass": 8
+  },
+  "blockers": [],
+  "applied": [],
+  "skipped": [
+    {
+      "path": "LICENSE",
+      "reason": "present-compatible"
+    },
+    {
+      "path": "CONTRIBUTING.md",
+      "reason": "present-compatible"
+    },
+    {
+      "path": "CODE_OF_CONDUCT.md",
+      "reason": "present-compatible"
+    },
+    {
+      "path": "SECURITY.md",
+      "reason": "present-compatible"
+    },
+    {
+      "path": ".github/CODEOWNERS",
+      "reason": "present-compatible"
+    },
+    {
+      "path": ".github/PULL_REQUEST_TEMPLATE.md",
+      "reason": "present-compatible"
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE/bug_report.yml",
+      "reason": "present-compatible"
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE/feature_request.yml",
+      "reason": "present-compatible"
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE/config.yml",
+      "reason": "present-compatible"
+    },
+    {
+      "path": ".github/dependabot.yml",
+      "reason": "present-compatible"
+    },
+    {
+      "path": "README.md",
+      "reason": "present-compatible"
+    }
+  ]
+}

--- a/tooling/open-source-repository-setup/out/inspection.json
+++ b/tooling/open-source-repository-setup/out/inspection.json
@@ -1,0 +1,337 @@
+{
+  "git": {
+    "defaultBranch": "main"
+  },
+  "files": [
+    {
+      "path": "README.md",
+      "status": "present-compatible"
+    },
+    {
+      "path": "LICENSE",
+      "status": "present-compatible"
+    },
+    {
+      "path": "CONTRIBUTING.md",
+      "status": "present-compatible"
+    },
+    {
+      "path": "CODE_OF_CONDUCT.md",
+      "status": "present-compatible"
+    },
+    {
+      "path": "SECURITY.md",
+      "status": "present-compatible"
+    },
+    {
+      "path": ".github/CODEOWNERS",
+      "status": "present-compatible"
+    },
+    {
+      "path": ".github/PULL_REQUEST_TEMPLATE.md",
+      "status": "present-compatible"
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE/bug_report.yml",
+      "status": "present-compatible"
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE/feature_request.yml",
+      "status": "present-compatible"
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE/config.yml",
+      "status": "present-compatible"
+    },
+    {
+      "path": ".github/dependabot.yml",
+      "status": "present-compatible"
+    }
+  ],
+  "workflows": [
+    {
+      "path": ".github/workflows/release-control.yml",
+      "missing": false,
+      "sha256": "5dbc5b01cc63c821b6ed2a15b5ef8725fadf20daedf96ec3af108088daf27148"
+    },
+    {
+      "path": ".github/workflows/release-npm.yml",
+      "missing": false,
+      "sha256": "32f1c20f750c7ba8aaba5fcf12bdbc2bfb7f2bb248795d219520ac2f18befadb"
+    },
+    {
+      "path": ".github/workflows/release-android.yml",
+      "missing": false,
+      "sha256": "63c49e7962b228d37a0712ce398c45584760d6a312677bebe974d7f02f16c0ff"
+    },
+    {
+      "path": ".github/workflows/npm-release-readiness.yml",
+      "missing": false,
+      "sha256": "1cdae6712f6ec0079d4a4a823b5697527dceb44d2d8a8d267c7575117b193d85"
+    }
+  ],
+  "github": {
+    "repoSettings": {
+      "allow_auto_merge": false,
+      "delete_branch_on_merge": true,
+      "allow_update_branch": true,
+      "has_discussions": false,
+      "allow_merge_commit": true,
+      "allow_rebase_merge": true,
+      "allow_squash_merge": true,
+      "security_and_analysis": {
+        "dependabot_security_updates": {
+          "status": "enabled"
+        },
+        "secret_scanning": {
+          "status": "enabled"
+        },
+        "secret_scanning_non_provider_patterns": {
+          "status": "disabled"
+        },
+        "secret_scanning_push_protection": {
+          "status": "enabled"
+        },
+        "secret_scanning_validity_checks": {
+          "status": "disabled"
+        }
+      }
+    },
+    "topics": [
+      "audio",
+      "capacitor",
+      "legato",
+      "opensource"
+    ],
+    "labels": [
+      {
+        "id": 10733039275,
+        "node_id": "LA_kwDOSGxLUs8AAAACf70uqw",
+        "url": "https://api.github.com/repos/ddgutierrezc/legato/labels/bug",
+        "name": "bug",
+        "color": "d73a4a",
+        "default": true,
+        "description": "Something isn't working"
+      },
+      {
+        "id": 10796089613,
+        "node_id": "LA_kwDOSGxLUs8AAAACg39BDQ",
+        "url": "https://api.github.com/repos/ddgutierrezc/legato/labels/dependencies",
+        "name": "dependencies",
+        "color": "0366d6",
+        "default": false,
+        "description": "Pull requests that update a dependency file"
+      },
+      {
+        "id": 10733039290,
+        "node_id": "LA_kwDOSGxLUs8AAAACf70uug",
+        "url": "https://api.github.com/repos/ddgutierrezc/legato/labels/documentation",
+        "name": "documentation",
+        "color": "0075ca",
+        "default": true,
+        "description": "Improvements or additions to documentation"
+      },
+      {
+        "id": 10733039303,
+        "node_id": "LA_kwDOSGxLUs8AAAACf70uxw",
+        "url": "https://api.github.com/repos/ddgutierrezc/legato/labels/duplicate",
+        "name": "duplicate",
+        "color": "cfd3d7",
+        "default": true,
+        "description": "This issue or pull request already exists"
+      },
+      {
+        "id": 10733039314,
+        "node_id": "LA_kwDOSGxLUs8AAAACf70u0g",
+        "url": "https://api.github.com/repos/ddgutierrezc/legato/labels/enhancement",
+        "name": "enhancement",
+        "color": "a2eeef",
+        "default": true,
+        "description": "New feature or request"
+      },
+      {
+        "id": 10733039334,
+        "node_id": "LA_kwDOSGxLUs8AAAACf70u5g",
+        "url": "https://api.github.com/repos/ddgutierrezc/legato/labels/good%20first%20issue",
+        "name": "good first issue",
+        "color": "7057ff",
+        "default": true,
+        "description": "Good for newcomers"
+      },
+      {
+        "id": 10733039327,
+        "node_id": "LA_kwDOSGxLUs8AAAACf70u3w",
+        "url": "https://api.github.com/repos/ddgutierrezc/legato/labels/help%20wanted",
+        "name": "help wanted",
+        "color": "008672",
+        "default": true,
+        "description": "Extra attention is needed"
+      },
+      {
+        "id": 10733039345,
+        "node_id": "LA_kwDOSGxLUs8AAAACf70u8Q",
+        "url": "https://api.github.com/repos/ddgutierrezc/legato/labels/invalid",
+        "name": "invalid",
+        "color": "e4e669",
+        "default": true,
+        "description": "This doesn't seem right"
+      },
+      {
+        "id": 10796089617,
+        "node_id": "LA_kwDOSGxLUs8AAAACg39BEQ",
+        "url": "https://api.github.com/repos/ddgutierrezc/legato/labels/javascript",
+        "name": "javascript",
+        "color": "168700",
+        "default": false,
+        "description": "Pull requests that update javascript code"
+      },
+      {
+        "id": 10733039354,
+        "node_id": "LA_kwDOSGxLUs8AAAACf70u-g",
+        "url": "https://api.github.com/repos/ddgutierrezc/legato/labels/question",
+        "name": "question",
+        "color": "d876e3",
+        "default": true,
+        "description": "Further information is requested"
+      },
+      {
+        "id": 10784246457,
+        "node_id": "LA_kwDOSGxLUs8AAAACgsqKuQ",
+        "url": "https://api.github.com/repos/ddgutierrezc/legato/labels/status:approved",
+        "name": "status:approved",
+        "color": "0e8a16",
+        "default": false,
+        "description": "Approved for implementation"
+      },
+      {
+        "id": 10796081429,
+        "node_id": "LA_kwDOSGxLUs8AAAACg38hFQ",
+        "url": "https://api.github.com/repos/ddgutierrezc/legato/labels/status:needs-review",
+        "name": "status:needs-review",
+        "color": "d4c5f9",
+        "default": false,
+        "description": "Needs reviewer triage"
+      },
+      {
+        "id": 10784316504,
+        "node_id": "LA_kwDOSGxLUs8AAAACgsucWA",
+        "url": "https://api.github.com/repos/ddgutierrezc/legato/labels/type:bug",
+        "name": "type:bug",
+        "color": "d73a4a",
+        "default": false,
+        "description": "Bug fix"
+      },
+      {
+        "id": 10784246475,
+        "node_id": "LA_kwDOSGxLUs8AAAACgsqKyw",
+        "url": "https://api.github.com/repos/ddgutierrezc/legato/labels/type:chore",
+        "name": "type:chore",
+        "color": "c5def5",
+        "default": false,
+        "description": "Maintenance or tooling change"
+      },
+      {
+        "id": 10788755403,
+        "node_id": "LA_kwDOSGxLUs8AAAACgw9Xyw",
+        "url": "https://api.github.com/repos/ddgutierrezc/legato/labels/type:docs",
+        "name": "type:docs",
+        "color": "0075ca",
+        "default": false,
+        "description": "Documentation only"
+      },
+      {
+        "id": 10787796789,
+        "node_id": "LA_kwDOSGxLUs8AAAACgwC3NQ",
+        "url": "https://api.github.com/repos/ddgutierrezc/legato/labels/type:feature",
+        "name": "type:feature",
+        "color": "0e8a16",
+        "default": false,
+        "description": "New feature"
+      },
+      {
+        "id": 10733039362,
+        "node_id": "LA_kwDOSGxLUs8AAAACf70vAg",
+        "url": "https://api.github.com/repos/ddgutierrezc/legato/labels/wontfix",
+        "name": "wontfix",
+        "color": "ffffff",
+        "default": true,
+        "description": "This will not be worked on"
+      }
+    ],
+    "rulesets": [],
+    "branchProtection": {
+      "url": "https://api.github.com/repos/ddgutierrezc/legato/branches/main/protection",
+      "required_status_checks": {
+        "url": "https://api.github.com/repos/ddgutierrezc/legato/branches/main/protection/required_status_checks",
+        "strict": true,
+        "contexts": [
+          "npm-readiness"
+        ],
+        "contexts_url": "https://api.github.com/repos/ddgutierrezc/legato/branches/main/protection/required_status_checks/contexts",
+        "checks": [
+          {
+            "context": "npm-readiness",
+            "app_id": 15368
+          }
+        ]
+      },
+      "required_pull_request_reviews": {
+        "url": "https://api.github.com/repos/ddgutierrezc/legato/branches/main/protection/required_pull_request_reviews",
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 1
+      },
+      "required_signatures": {
+        "url": "https://api.github.com/repos/ddgutierrezc/legato/branches/main/protection/required_signatures",
+        "enabled": false
+      },
+      "enforce_admins": {
+        "url": "https://api.github.com/repos/ddgutierrezc/legato/branches/main/protection/enforce_admins",
+        "enabled": false
+      },
+      "required_linear_history": {
+        "enabled": false
+      },
+      "allow_force_pushes": {
+        "enabled": false
+      },
+      "allow_deletions": {
+        "enabled": false
+      },
+      "block_creations": {
+        "enabled": false
+      },
+      "required_conversation_resolution": {
+        "enabled": false
+      },
+      "lock_branch": {
+        "enabled": false
+      },
+      "allow_fork_syncing": {
+        "enabled": false
+      }
+    },
+    "securityAndAnalysis": {
+      "dependabot_security_updates": {
+        "status": "enabled"
+      },
+      "secret_scanning": {
+        "status": "enabled"
+      },
+      "secret_scanning_non_provider_patterns": {
+        "status": "disabled"
+      },
+      "secret_scanning_push_protection": {
+        "status": "enabled"
+      },
+      "secret_scanning_validity_checks": {
+        "status": "disabled"
+      }
+    }
+  },
+  "blockers": [],
+  "permissions": {
+    "admin": true
+  }
+}

--- a/tooling/open-source-repository-setup/out/plan.json
+++ b/tooling/open-source-repository-setup/out/plan.json
@@ -1,0 +1,115 @@
+{
+  "generatedAt": "2026-04-26T21:05:21.569Z",
+  "fileOps": [
+    {
+      "path": "LICENSE",
+      "strategy": "create-if-missing",
+      "status": "present-compatible",
+      "existing": "MIT License\n\nCopyright (c) 2026 Legato contributors\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE.\n",
+      "desired": "MIT License\n\nCopyright (c) 2026 Legato contributors\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE.\n"
+    },
+    {
+      "path": "CONTRIBUTING.md",
+      "strategy": "create-if-missing",
+      "status": "present-compatible",
+      "existing": "# Contributing to legato\n\nThanks for contributing.\n\n## Before opening a PR\n\n1. Open or link an issue first.\n2. For implementation PRs, issue status must be `approved`.\n3. Use a branch name in the form `type/description` (lowercase `a-z0-9._-`).\n4. Use conventional commits.\n\n## Pull request checklist\n\n- Include `Closes #<issue>` / `Fixes #<issue>` / `Resolves #<issue>` in PR body.\n- Add exactly one `type:*` label (`type:feature`, `type:bug`, `type:docs`, `type:chore`).\n- Keep release workflows untouched unless your issue explicitly targets release automation.\n- Run relevant validation checks locally before asking for review.\n\n## Scope discipline\n\nLegato uses focused scope and contracts for release and runtime safety. Keep changes minimal and evidence-driven.\n",
+      "desired": "# Contributing to legato\n\nThanks for contributing.\n\n## Before opening a PR\n\n1. Open or link an issue first.\n2. For implementation PRs, issue status must be `approved`.\n3. Use a branch name in the form `type/description` (lowercase `a-z0-9._-`).\n4. Use conventional commits.\n\n## Pull request checklist\n\n- Include `Closes #<issue>` / `Fixes #<issue>` / `Resolves #<issue>` in PR body.\n- Add exactly one `type:*` label (`type:feature`, `type:bug`, `type:docs`, `type:chore`).\n- Keep release workflows untouched unless your issue explicitly targets release automation.\n- Run relevant validation checks locally before asking for review.\n\n## Scope discipline\n\nLegato uses focused scope and contracts for release and runtime safety. Keep changes minimal and evidence-driven.\n"
+    },
+    {
+      "path": "CODE_OF_CONDUCT.md",
+      "strategy": "create-if-missing",
+      "status": "present-compatible",
+      "existing": "# Contributor Covenant Code of Conduct\n\n## Our Pledge\n\nWe as members, contributors, and leaders pledge to make participation in our\ncommunity a harassment-free experience for everyone.\n\n## Our Standards\n\nExamples of behavior that contributes to a positive environment include:\n\n- Demonstrating empathy and kindness.\n- Being respectful of differing opinions and experiences.\n- Giving and gracefully accepting constructive feedback.\n\nExamples of unacceptable behavior include harassment, insulting comments,\npublic or private attacks, and other conduct inappropriate in a professional setting.\n\n## Enforcement Responsibilities\n\nProject maintainers are responsible for clarifying and enforcing standards and\nmay remove or edit comments, commits, code, issues, and other contributions.\n\n## Scope\n\nThis Code of Conduct applies within all project spaces and when an individual\nis officially representing the project in public spaces.\n\n## Enforcement\n\nReport incidents to maintainers via security channels documented in `SECURITY.md`.\nAll complaints will be reviewed and investigated promptly and fairly.\n\n## Attribution\n\nThis Code of Conduct is adapted from the Contributor Covenant, version 2.1:\nhttps://www.contributor-covenant.org/version/2/1/code_of_conduct.html\n",
+      "desired": "# Contributor Covenant Code of Conduct\n\n## Our Pledge\n\nWe as members, contributors, and leaders pledge to make participation in our\ncommunity a harassment-free experience for everyone.\n\n## Our Standards\n\nExamples of behavior that contributes to a positive environment include:\n\n- Demonstrating empathy and kindness.\n- Being respectful of differing opinions and experiences.\n- Giving and gracefully accepting constructive feedback.\n\nExamples of unacceptable behavior include harassment, insulting comments,\npublic or private attacks, and other conduct inappropriate in a professional setting.\n\n## Enforcement Responsibilities\n\nProject maintainers are responsible for clarifying and enforcing standards and\nmay remove or edit comments, commits, code, issues, and other contributions.\n\n## Scope\n\nThis Code of Conduct applies within all project spaces and when an individual\nis officially representing the project in public spaces.\n\n## Enforcement\n\nReport incidents to maintainers via security channels documented in `SECURITY.md`.\nAll complaints will be reviewed and investigated promptly and fairly.\n\n## Attribution\n\nThis Code of Conduct is adapted from the Contributor Covenant, version 2.1:\nhttps://www.contributor-covenant.org/version/2/1/code_of_conduct.html\n"
+    },
+    {
+      "path": "SECURITY.md",
+      "strategy": "create-if-missing",
+      "status": "present-compatible",
+      "existing": "# Security Policy\n\n## Reporting a Vulnerability\n\nPlease report suspected vulnerabilities privately via GitHub Security Advisories:\n\n- https://github.com/ddgutierrezc/legato/security/advisories/new\n\nIf advisories are unavailable for your access level, open a private report with maintainers and avoid public disclosure until triage is complete.\n\n## Response Expectations\n\n- Initial triage acknowledgment: within 7 days.\n- Mitigation or remediation plan: provided after triage.\n\n## Supported Versions\n\nThis repository currently focuses on the latest published package versions.\n",
+      "desired": "# Security Policy\n\n## Reporting a Vulnerability\n\nPlease report suspected vulnerabilities privately via GitHub Security Advisories:\n\n- https://github.com/ddgutierrezc/legato/security/advisories/new\n\nIf advisories are unavailable for your access level, open a private report with maintainers and avoid public disclosure until triage is complete.\n\n## Response Expectations\n\n- Initial triage acknowledgment: within 7 days.\n- Mitigation or remediation plan: provided after triage.\n\n## Supported Versions\n\nThis repository currently focuses on the latest published package versions.\n"
+    },
+    {
+      "path": ".github/CODEOWNERS",
+      "strategy": "create-if-missing",
+      "status": "present-compatible",
+      "existing": "# Default owner coverage\n* @ddgutierrezc\n\n# Workflows and release automation\n.github/workflows/* @ddgutierrezc\n",
+      "desired": "# Default owner coverage\n* @ddgutierrezc\n\n# Workflows and release automation\n.github/workflows/* @ddgutierrezc\n"
+    },
+    {
+      "path": ".github/PULL_REQUEST_TEMPLATE.md",
+      "strategy": "create-if-missing",
+      "status": "present-compatible",
+      "existing": "## Summary\n\n- Explain WHY this change is needed.\n\n## Linked issue\n\nResolves #<issue-number>\n\n## Validation\n\n- [ ] Relevant tests/checks were run\n- [ ] No unrelated workflows were changed\n\n## Policy checks\n\n- [ ] Exactly one `type:*` label added\n- [ ] Approved issue linked when required (`status:approved`)\n",
+      "desired": "## Summary\n\n- Explain WHY this change is needed.\n\n## Linked issue\n\nResolves #<issue-number>\n\n## Validation\n\n- [ ] Relevant tests/checks were run\n- [ ] No unrelated workflows were changed\n\n## Policy checks\n\n- [ ] Exactly one `type:*` label added\n- [ ] Approved issue linked when required (`status:approved`)\n"
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE/bug_report.yml",
+      "strategy": "create-if-missing",
+      "status": "present-compatible",
+      "existing": "name: Bug report\ndescription: Report something that is broken.\ntitle: \"bug: \"\nlabels: [\"type:bug\", \"status:needs-review\"]\nbody:\n  - type: markdown\n    attributes:\n      value: \"Please include reproducible steps and expected behavior.\"\n  - type: textarea\n    id: problem\n    attributes:\n      label: Problem\n      placeholder: What happened?\n    validations:\n      required: true\n  - type: textarea\n    id: reproduce\n    attributes:\n      label: Reproduction steps\n      placeholder: Step by step\n    validations:\n      required: true\n",
+      "desired": "name: Bug report\ndescription: Report something that is broken.\ntitle: \"bug: \"\nlabels: [\"type:bug\", \"status:needs-review\"]\nbody:\n  - type: markdown\n    attributes:\n      value: \"Please include reproducible steps and expected behavior.\"\n  - type: textarea\n    id: problem\n    attributes:\n      label: Problem\n      placeholder: What happened?\n    validations:\n      required: true\n  - type: textarea\n    id: reproduce\n    attributes:\n      label: Reproduction steps\n      placeholder: Step by step\n    validations:\n      required: true\n"
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE/feature_request.yml",
+      "strategy": "create-if-missing",
+      "status": "present-compatible",
+      "existing": "name: Feature request\ndescription: Propose an improvement.\ntitle: \"feature: \"\nlabels: [\"type:feature\", \"status:needs-review\"]\nbody:\n  - type: markdown\n    attributes:\n      value: \"Please describe the user need and expected outcomes.\"\n  - type: textarea\n    id: problem\n    attributes:\n      label: Problem / opportunity\n      placeholder: What should improve?\n    validations:\n      required: true\n  - type: textarea\n    id: proposal\n    attributes:\n      label: Proposed solution\n      placeholder: What are you proposing?\n    validations:\n      required: true\n",
+      "desired": "name: Feature request\ndescription: Propose an improvement.\ntitle: \"feature: \"\nlabels: [\"type:feature\", \"status:needs-review\"]\nbody:\n  - type: markdown\n    attributes:\n      value: \"Please describe the user need and expected outcomes.\"\n  - type: textarea\n    id: problem\n    attributes:\n      label: Problem / opportunity\n      placeholder: What should improve?\n    validations:\n      required: true\n  - type: textarea\n    id: proposal\n    attributes:\n      label: Proposed solution\n      placeholder: What are you proposing?\n    validations:\n      required: true\n"
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE/config.yml",
+      "strategy": "managed-block",
+      "marker": "OSS_CONTACT_LINKS",
+      "commentStyle": "hash",
+      "status": "present-compatible",
+      "existing": "blank_issues_enabled: false\n\n# OSS_CONTACT_LINKS:START\ncontact_links:\n  - name: Security policy\n    url: https://github.com/ddgutierrezc/legato/blob/main/SECURITY.md\n    about: Read security disclosure guidance before reporting vulnerabilities.\n  - name: Maintainers scope notes\n    url: https://github.com/ddgutierrezc/legato/tree/main/docs/maintainers\n    about: Maintainer process, release constraints, and scope boundaries.\n# OSS_CONTACT_LINKS:END\n",
+      "desired": "blank_issues_enabled: false\n\n# OSS_CONTACT_LINKS:START\ncontact_links:\n  - name: Security policy\n    url: https://github.com/ddgutierrezc/legato/blob/main/SECURITY.md\n    about: Read security disclosure guidance before reporting vulnerabilities.\n  - name: Maintainers scope notes\n    url: https://github.com/ddgutierrezc/legato/tree/main/docs/maintainers\n    about: Maintainer process, release constraints, and scope boundaries.\n# OSS_CONTACT_LINKS:END\n"
+    },
+    {
+      "path": ".github/dependabot.yml",
+      "strategy": "managed-block",
+      "marker": "OSS_DEPENDABOT",
+      "commentStyle": "hash",
+      "status": "present-compatible",
+      "existing": "version: 2\n\n# OSS_DEPENDABOT:START\nupdates:\n  - package-ecosystem: \"npm\"\n    directory: \"/apps/capacitor-demo\"\n    schedule:\n      interval: \"weekly\"\n  - package-ecosystem: \"npm\"\n    directory: \"/packages/capacitor\"\n    schedule:\n      interval: \"weekly\"\n  - package-ecosystem: \"npm\"\n    directory: \"/packages/contract\"\n    schedule:\n      interval: \"weekly\"\n  - package-ecosystem: \"github-actions\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n# OSS_DEPENDABOT:END\n",
+      "desired": "version: 2\n\n# OSS_DEPENDABOT:START\nupdates:\n  - package-ecosystem: \"npm\"\n    directory: \"/apps/capacitor-demo\"\n    schedule:\n      interval: \"weekly\"\n  - package-ecosystem: \"npm\"\n    directory: \"/packages/capacitor\"\n    schedule:\n      interval: \"weekly\"\n  - package-ecosystem: \"npm\"\n    directory: \"/packages/contract\"\n    schedule:\n      interval: \"weekly\"\n  - package-ecosystem: \"github-actions\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n# OSS_DEPENDABOT:END\n"
+    },
+    {
+      "path": "README.md",
+      "strategy": "managed-block",
+      "marker": "OSS_LINKS",
+      "status": "present-compatible",
+      "existing": "# legato\n\nLegato provides a contract package and a Capacitor integration package for continuous audio playback flows.\n\n## Which package should I install?\n\n## Package decision matrix\n\n| If you need... | Install | Read first |\n|---|---|---|\n| Shared playback types/events/contracts with no Capacitor runtime | `@ddgutierrezc/legato-contract` | [`packages/contract/README.md`](packages/contract/README.md) |\n| Capacitor plugin runtime + namespaced APIs (`audioPlayer`, `mediaSession`) | `@ddgutierrezc/legato-capacitor` + `@ddgutierrezc/legato-contract` | [`packages/capacitor/README.md`](packages/capacitor/README.md) |\n\n## Install\n\n```bash\nnpm install @ddgutierrezc/legato-contract\n```\n\nor\n\n```bash\nnpm install @ddgutierrezc/legato-capacitor @ddgutierrezc/legato-contract\n```\n\n## Usage\n\n- Contract-only consumers: use shared symbols like `LEGATO_EVENT_NAMES` from `@ddgutierrezc/legato-contract`.\n- Capacitor consumers: start from `@ddgutierrezc/legato-capacitor` and use `audioPlayer` / `mediaSession`.\n\n## Maintainers\n\nMaintainer-only scope and operational boundaries are documented in [`docs/maintainers/package-documentation-foundation-v1-scope.md`](docs/maintainers/package-documentation-foundation-v1-scope.md).\n\n## Non-goals for package-documentation-foundation-v1\n\n- Non-goal: runtime behavior expansion in native/player engines.\n- Non-goal: release-lane redesign.\n- Non-goal: platform bootstrap automation.\n\n## Contributing\n\nIf you update README/package docs, also run docs drift checks from `apps/capacitor-demo`.\n\n<!-- OSS_LINKS:START -->\n## Community\n\n- [Contributing](./CONTRIBUTING.md)\n- [Code of Conduct](./CODE_OF_CONDUCT.md)\n- [Security Policy](./SECURITY.md)\n<!-- OSS_LINKS:END -->\n",
+      "desired": "# legato\n\nLegato provides a contract package and a Capacitor integration package for continuous audio playback flows.\n\n## Which package should I install?\n\n## Package decision matrix\n\n| If you need... | Install | Read first |\n|---|---|---|\n| Shared playback types/events/contracts with no Capacitor runtime | `@ddgutierrezc/legato-contract` | [`packages/contract/README.md`](packages/contract/README.md) |\n| Capacitor plugin runtime + namespaced APIs (`audioPlayer`, `mediaSession`) | `@ddgutierrezc/legato-capacitor` + `@ddgutierrezc/legato-contract` | [`packages/capacitor/README.md`](packages/capacitor/README.md) |\n\n## Install\n\n```bash\nnpm install @ddgutierrezc/legato-contract\n```\n\nor\n\n```bash\nnpm install @ddgutierrezc/legato-capacitor @ddgutierrezc/legato-contract\n```\n\n## Usage\n\n- Contract-only consumers: use shared symbols like `LEGATO_EVENT_NAMES` from `@ddgutierrezc/legato-contract`.\n- Capacitor consumers: start from `@ddgutierrezc/legato-capacitor` and use `audioPlayer` / `mediaSession`.\n\n## Maintainers\n\nMaintainer-only scope and operational boundaries are documented in [`docs/maintainers/package-documentation-foundation-v1-scope.md`](docs/maintainers/package-documentation-foundation-v1-scope.md).\n\n## Non-goals for package-documentation-foundation-v1\n\n- Non-goal: runtime behavior expansion in native/player engines.\n- Non-goal: release-lane redesign.\n- Non-goal: platform bootstrap automation.\n\n## Contributing\n\nIf you update README/package docs, also run docs drift checks from `apps/capacitor-demo`.\n\n<!-- OSS_LINKS:START -->\n## Community\n\n- [Contributing](./CONTRIBUTING.md)\n- [Code of Conduct](./CODE_OF_CONDUCT.md)\n- [Security Policy](./SECURITY.md)\n<!-- OSS_LINKS:END -->\n"
+    }
+  ],
+  "apiOps": [
+    {
+      "id": "branch-protection",
+      "method": "PUT",
+      "endpoint": "/repos/{owner}/{repo}/branches/main/protection",
+      "status": "missing",
+      "payload": {
+        "branch": "main",
+        "required_status_checks": {
+          "strict": true,
+          "contexts": [
+            "npm-readiness"
+          ]
+        },
+        "enforce_admins": false,
+        "required_pull_request_reviews": {
+          "required_approving_review_count": 1,
+          "dismiss_stale_reviews": false,
+          "require_code_owner_reviews": false
+        },
+        "restrictions": null,
+        "allow_force_pushes": false,
+        "allow_deletions": false,
+        "required_linear_history": false
+      }
+    }
+  ],
+  "blockers": []
+}

--- a/tooling/open-source-repository-setup/out/summary.md
+++ b/tooling/open-source-repository-setup/out/summary.md
@@ -1,0 +1,8 @@
+# OSS Setup Validation Summary
+
+pass: 8
+fail: 0
+blocked: 0
+
+## Blockers
+- none

--- a/tooling/open-source-repository-setup/out/validation.json
+++ b/tooling/open-source-repository-setup/out/validation.json
@@ -1,0 +1,37 @@
+{
+  "requirements": {
+    "Current-State-Aware Initialization": {
+      "status": "pass",
+      "evidence": "File operations classified before mutation."
+    },
+    "GitHub CLI and Git Configuration Preconditions": {
+      "status": "pass",
+      "evidence": "Preflight blockers captured in inspection/plan."
+    },
+    "Repository Governance Baseline": {
+      "status": "pass",
+      "evidence": "Governance files generated or preserved via plan."
+    },
+    "Merge and Branch Protection Policy": {
+      "status": "pass",
+      "evidence": "Branch-protection planned with permission-aware behavior."
+    },
+    "Security and Dependency Hygiene Expectations": {
+      "status": "pass",
+      "evidence": "Dependabot and security policy are in target set."
+    },
+    "Non-Overwrite Safety": {
+      "status": "pass",
+      "evidence": "Divergent files are skipped with suggestion outputs."
+    },
+    "Validation and Audit Outputs": {
+      "status": "pass",
+      "evidence": "plan.json/apply-result.json/validation.json/final-state.json generated."
+    },
+    "Scope Boundaries and Best-Effort Semantics": {
+      "status": "pass",
+      "evidence": "Permission-blocked API ops retained as unresolved follow-ups."
+    }
+  },
+  "blockers": []
+}

--- a/tooling/open-source-repository-setup/templates/.github/CODEOWNERS
+++ b/tooling/open-source-repository-setup/templates/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Default owner coverage
+* @ddgutierrezc
+
+# Workflows and release automation
+.github/workflows/* @ddgutierrezc

--- a/tooling/open-source-repository-setup/templates/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/tooling/open-source-repository-setup/templates/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,22 @@
+name: Bug report
+description: Report something that is broken.
+title: "bug: "
+labels: ["type:bug", "status:needs-review"]
+body:
+  - type: markdown
+    attributes:
+      value: "Please include reproducible steps and expected behavior."
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      placeholder: What happened?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction steps
+      placeholder: Step by step
+    validations:
+      required: true

--- a/tooling/open-source-repository-setup/templates/.github/ISSUE_TEMPLATE/config.yml
+++ b/tooling/open-source-repository-setup/templates/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+contact_links:
+  - name: Security policy
+    url: https://github.com/ddgutierrezc/legato/blob/main/SECURITY.md
+    about: Read security disclosure guidance before reporting vulnerabilities.
+  - name: Maintainers scope notes
+    url: https://github.com/ddgutierrezc/legato/tree/main/docs/maintainers
+    about: Maintainer process, release constraints, and scope boundaries.

--- a/tooling/open-source-repository-setup/templates/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/tooling/open-source-repository-setup/templates/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,22 @@
+name: Feature request
+description: Propose an improvement.
+title: "feature: "
+labels: ["type:feature", "status:needs-review"]
+body:
+  - type: markdown
+    attributes:
+      value: "Please describe the user need and expected outcomes."
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / opportunity
+      placeholder: What should improve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      placeholder: What are you proposing?
+    validations:
+      required: true

--- a/tooling/open-source-repository-setup/templates/.github/PULL_REQUEST_TEMPLATE.md
+++ b/tooling/open-source-repository-setup/templates/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Summary
+
+- Explain WHY this change is needed.
+
+## Linked issue
+
+Resolves #<issue-number>
+
+## Validation
+
+- [ ] Relevant tests/checks were run
+- [ ] No unrelated workflows were changed
+
+## Policy checks
+
+- [ ] Exactly one `type:*` label added
+- [ ] Approved issue linked when required (`status:approved`)

--- a/tooling/open-source-repository-setup/templates/.github/dependabot.yml
+++ b/tooling/open-source-repository-setup/templates/.github/dependabot.yml
@@ -1,0 +1,17 @@
+updates:
+  - package-ecosystem: "npm"
+    directory: "/apps/capacitor-demo"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/packages/capacitor"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/packages/contract"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/tooling/open-source-repository-setup/templates/CODE_OF_CONDUCT.md
+++ b/tooling/open-source-repository-setup/templates/CODE_OF_CONDUCT.md
@@ -1,0 +1,37 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness.
+- Being respectful of differing opinions and experiences.
+- Giving and gracefully accepting constructive feedback.
+
+Examples of unacceptable behavior include harassment, insulting comments,
+public or private attacks, and other conduct inappropriate in a professional setting.
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing standards and
+may remove or edit comments, commits, code, issues, and other contributions.
+
+## Scope
+
+This Code of Conduct applies within all project spaces and when an individual
+is officially representing the project in public spaces.
+
+## Enforcement
+
+Report incidents to maintainers via security channels documented in `SECURITY.md`.
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1:
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/tooling/open-source-repository-setup/templates/CONTRIBUTING.md
+++ b/tooling/open-source-repository-setup/templates/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing to legato
+
+Thanks for contributing.
+
+## Before opening a PR
+
+1. Open or link an issue first.
+2. For implementation PRs, issue status must be `approved`.
+3. Use a branch name in the form `type/description` (lowercase `a-z0-9._-`).
+4. Use conventional commits.
+
+## Pull request checklist
+
+- Include `Closes #<issue>` / `Fixes #<issue>` / `Resolves #<issue>` in PR body.
+- Add exactly one `type:*` label (`type:feature`, `type:bug`, `type:docs`, `type:chore`).
+- Keep release workflows untouched unless your issue explicitly targets release automation.
+- Run relevant validation checks locally before asking for review.
+
+## Scope discipline
+
+Legato uses focused scope and contracts for release and runtime safety. Keep changes minimal and evidence-driven.

--- a/tooling/open-source-repository-setup/templates/LICENSE
+++ b/tooling/open-source-repository-setup/templates/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Legato contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tooling/open-source-repository-setup/templates/README.oss-links.md
+++ b/tooling/open-source-repository-setup/templates/README.oss-links.md
@@ -1,0 +1,5 @@
+## Community
+
+- [Contributing](./CONTRIBUTING.md)
+- [Code of Conduct](./CODE_OF_CONDUCT.md)
+- [Security Policy](./SECURITY.md)

--- a/tooling/open-source-repository-setup/templates/SECURITY.md
+++ b/tooling/open-source-repository-setup/templates/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report suspected vulnerabilities privately via GitHub Security Advisories:
+
+- https://github.com/ddgutierrezc/legato/security/advisories/new
+
+If advisories are unavailable for your access level, open a private report with maintainers and avoid public disclosure until triage is complete.
+
+## Response Expectations
+
+- Initial triage acknowledgment: within 7 days.
+- Mitigation or remediation plan: provided after triage.
+
+## Supported Versions
+
+This repository currently focuses on the latest published package versions.

--- a/tooling/open-source-repository-setup/validate.mjs
+++ b/tooling/open-source-repository-setup/validate.mjs
@@ -1,0 +1,128 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+export function validateRequirements({ plan, applyResult }) {
+  const blockers = [...(plan.blockers ?? []), ...(applyResult.blocked ?? [])];
+  const governanceTargets = new Set([
+    'CONTRIBUTING.md',
+    'CODE_OF_CONDUCT.md',
+    'SECURITY.md',
+    '.github/CODEOWNERS',
+    '.github/PULL_REQUEST_TEMPLATE.md',
+  ]);
+  const governanceSeen = [...(applyResult.applied ?? []), ...(applyResult.skipped ?? [])]
+    .filter((entry) => governanceTargets.has(entry.path))
+    .length;
+  const nonManagedDivergences = (plan.fileOps ?? [])
+    .filter((entry) => entry.status === 'present-divergent' && entry.strategy !== 'managed-block')
+    .map((entry) => entry.path);
+  const skippedDivergences = new Set(
+    (applyResult.skipped ?? [])
+      .filter((entry) => entry.reason === 'present-divergent')
+      .map((entry) => entry.path),
+  );
+  const suggestedDivergences = new Set((applyResult.suggestions ?? []).map((entry) => entry.path));
+  const nonOverwritePass = nonManagedDivergences.length === 0 || nonManagedDivergences.every(
+    (path) => skippedDivergences.has(path) && suggestedDivergences.has(path),
+  );
+  const requirements = {
+    'Current-State-Aware Initialization': {
+      status: (plan.fileOps ?? []).length > 0 ? 'pass' : 'fail',
+      evidence: 'File operations classified before mutation.',
+    },
+    'GitHub CLI and Git Configuration Preconditions': {
+      status: blockers.some((entry) => String(entry.code ?? entry.reason).includes('GH_AUTH')) ? 'blocked' : 'pass',
+      evidence: 'Preflight blockers captured in inspection/plan.',
+    },
+    'Repository Governance Baseline': {
+      status: governanceSeen === governanceTargets.size ? 'pass' : 'fail',
+      evidence: 'Governance files generated or preserved via plan.',
+    },
+    'Merge and Branch Protection Policy': {
+      status: blockers.some((entry) => String(entry.id ?? entry.scope ?? '').includes('branch-protection')) ? 'blocked' : 'pass',
+      evidence: 'Branch-protection planned with permission-aware behavior.',
+    },
+    'Security and Dependency Hygiene Expectations': {
+      status: (plan.fileOps ?? []).some((entry) => entry.path === '.github/dependabot.yml') ? 'pass' : 'fail',
+      evidence: 'Dependabot and security policy are in target set.',
+    },
+    'Non-Overwrite Safety': {
+      status: nonOverwritePass ? 'pass' : 'fail',
+      evidence: 'Divergent files are skipped with suggestion outputs.',
+    },
+    'Validation and Audit Outputs': {
+      status: 'pass',
+      evidence: 'plan.json/apply-result.json/validation.json/final-state.json generated.',
+    },
+    'Scope Boundaries and Best-Effort Semantics': {
+      status: blockers.length > 0 ? 'blocked' : 'pass',
+      evidence: 'Permission-blocked API ops retained as unresolved follow-ups.',
+    },
+  };
+
+  return { requirements, blockers };
+}
+
+export function summarizeValidation({ validation }) {
+  const counts = { pass: 0, fail: 0, blocked: 0 };
+  for (const value of Object.values(validation.requirements)) {
+    counts[value.status] = (counts[value.status] ?? 0) + 1;
+  }
+
+  const blockers = validation.blockers.map((entry) => `- ${entry.code ?? entry.id ?? 'BLOCKED'} (${entry.scope ?? entry.reason ?? 'n/a'})`);
+  return [
+    '# OSS Setup Validation Summary',
+    '',
+    `pass: ${counts.pass}`,
+    `fail: ${counts.fail}`,
+    `blocked: ${counts.blocked}`,
+    '',
+    '## Blockers',
+    ...(blockers.length > 0 ? blockers : ['- none']),
+    '',
+  ].join('\n');
+}
+
+async function readJson(path) {
+  const value = await readFile(path, 'utf8');
+  return JSON.parse(value);
+}
+
+async function writeJson(path, value) {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+async function main() {
+  const repoRoot = resolve(process.cwd());
+  const outDir = resolve(repoRoot, 'tooling/open-source-repository-setup/out');
+  const plan = await readJson(resolve(outDir, 'plan.json'));
+  const applyPayload = await readJson(resolve(outDir, 'apply-result.json'));
+  const applyResult = {
+    applied: applyPayload.files?.applied ?? [],
+    skipped: applyPayload.files?.skipped ?? [],
+    blocked: [...(applyPayload.files?.blocked ?? []), ...(applyPayload.api?.blocked ?? [])],
+    suggestions: applyPayload.files?.suggestions ?? [],
+  };
+
+  const validation = validateRequirements({ plan, applyResult });
+  await writeJson(resolve(outDir, 'validation.json'), validation);
+  const summary = summarizeValidation({ validation });
+  await writeFile(resolve(outDir, 'summary.md'), summary, 'utf8');
+
+  const finalState = {
+    generatedAt: new Date().toISOString(),
+    counts: Object.values(validation.requirements).reduce(
+      (acc, item) => ({ ...acc, [item.status]: (acc[item.status] ?? 0) + 1 }),
+      {},
+    ),
+    blockers: validation.blockers,
+    applied: applyResult.applied,
+    skipped: applyResult.skipped,
+  };
+  await writeJson(resolve(outDir, 'final-state.json'), finalState);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+}


### PR DESCRIPTION
Closes #83

## Summary
- persist the open-source repository baseline files, GitHub templates, and Dependabot/CODEOWNERS configuration
- add idempotent inspect/apply/validate tooling plus audit outputs for OSS repo setup
- preserve existing release workflows while making the repository configuration more professionally open-source and reproducible

## Changes
| File | Change |
|------|--------|
| `LICENSE`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md` | add standard open-source governance files |
| `.github/CODEOWNERS`, `.github/PULL_REQUEST_TEMPLATE.md`, `.github/ISSUE_TEMPLATE/*`, `.github/dependabot.yml` | add GitHub contribution and dependency-management baseline |
| `tooling/open-source-repository-setup/*` | add inspect/apply/validate tooling, templates, tests, and audit artifacts |
| `README.md` | align root README with the OSS setup baseline where needed |

## Test Plan
- [x] `node --test tooling/open-source-repository-setup/__tests__/planner.test.mjs tooling/open-source-repository-setup/__tests__/inspect-validate.test.mjs tooling/open-source-repository-setup/__tests__/workflows-preserved.test.mjs`
- [x] No shell scripts changed
- [x] Existing release workflows preserved by dedicated test

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers