### PR TITLE
fix(android): harden background lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ dist/
 .gradle/
 build/
 **/build/
+**/.kotlin/
 
 # Local validation / evidence artifacts
 apps/capacitor-demo/artifacts/

--- a/apps/capacitor-demo/README.md
+++ b/apps/capacitor-demo/README.md
@@ -106,6 +106,14 @@ Manual parity checklist to close milestone validation:
 7. Validate capability projection summary: mid-queue enables next/previous, first track disables previous, ended disables all (`canSkipNext=false`, `canSkipPrevious=false`, `canSeek=false`).
 8. Run `Run artwork race` and confirm no stale artwork survives rapid track switches/fallback.
 9. (Android lifecycle carry-over) `stop()` + idle tears down foreground service/notification.
+10. Run `Case: focus-denied lifecycle check` and capture copyable log/events showing non-playing outcome after denied focus.
+11. Run `Case: CAN_DUCK interruption pause` and capture snapshot evidence that CAN_DUCK pauses (no implicit auto-resume).
+12. Run `Case: background transition coherence` and capture snapshot summary + raw JSON after background/foreground return.
+
+Scope boundary for this lifecycle pass:
+
+- ✅ Guarantees targeted **in-process** lifecycle behavior (focus denial/interruption/background transition/notification coherence).
+- ❌ Does **not** claim process-death restoration or OEM-complete lifecycle resilience.
 
 ## Quick smoke checklist (manual, lightweight)
 

--- a/apps/capacitor-demo/android/settings.gradle
+++ b/apps/capacitor-demo/android/settings.gradle
@@ -2,4 +2,6 @@ include ':app'
 include ':capacitor-cordova-android-plugins'
 project(':capacitor-cordova-android-plugins').projectDir = new File('./capacitor-cordova-android-plugins/')
 
+includeBuild('../../../native/android/core')
+
 apply from: 'capacitor.settings.gradle'

--- a/apps/capacitor-demo/index.html
+++ b/apps/capacitor-demo/index.html
@@ -267,6 +267,9 @@ No smoke run yet.</pre>
             <button id="run-case-remote-play" class="native-action" type="button">Case: remote play resume parity</button>
             <button id="run-case-remote-skip" class="native-action" type="button">Case: remote next/previous parity</button>
             <button id="run-case-remote-seek" class="native-action" type="button">Case: remote seek parity</button>
+            <button id="run-case-focus-denied" class="native-action" type="button">Case: focus-denied lifecycle check</button>
+            <button id="run-case-can-duck" class="native-action" type="button">Case: CAN_DUCK interruption pause</button>
+            <button id="run-case-background-transition" class="native-action" type="button">Case: background transition coherence</button>
           </div>
         </section>
 
@@ -342,6 +345,9 @@ checks=none yet</pre>
             <li>Background play/pause parity: run guided buttons <code>Case: remote pause parity</code> and <code>Case: remote play resume parity</code>, then verify pass/fail trail in logs/checks.</li>
             <li>Remote next/previous parity: run <code>Case: remote next/previous parity</code>; next and previous must round-trip queue index as prompted.</li>
             <li>Remote seek parity: run <code>Case: remote seek parity</code>; remote seek must produce a visible snapshot position jump.</li>
+            <li>Focus-denied lifecycle: run <code>Case: focus-denied lifecycle check</code>; if focus request is denied playback must settle non-playing (paused/interrupted) without auto-loop retries.</li>
+            <li>CAN_DUCK policy: run <code>Case: CAN_DUCK interruption pause</code>; in v1 this interruption must pause playback (not volume-duck behavior).</li>
+            <li>Background transition coherence: run <code>Case: background transition coherence</code>; queue + state should remain coherent while process is alive, with notification controls visible in background.</li>
             <li>Boundary behavior parity: previous at first track restarts to 0, next at last track transitions to ended + playbackEnded event.</li>
             <li>Interruption ingestion check: while playing, trigger focus-loss/noisy (headphones unplug/Bluetooth disconnect) and confirm snapshot moves to paused; keep <code>Recent events/progress</code> + <code>Raw operation log</code> for copyable evidence.</li>
             <li>Capability projection parity: canSkipNext/canSkipPrevious/canSeek summary must align with queue index + ended/empty states.</li>

--- a/apps/capacitor-demo/src/main.ts
+++ b/apps/capacitor-demo/src/main.ts
@@ -39,6 +39,9 @@ const remotePauseCaseButton = document.querySelector<HTMLButtonElement>('#run-ca
 const remotePlayCaseButton = document.querySelector<HTMLButtonElement>('#run-case-remote-play');
 const remoteSkipCaseButton = document.querySelector<HTMLButtonElement>('#run-case-remote-skip');
 const remoteSeekCaseButton = document.querySelector<HTMLButtonElement>('#run-case-remote-seek');
+const focusDeniedCaseButton = document.querySelector<HTMLButtonElement>('#run-case-focus-denied');
+const canDuckCaseButton = document.querySelector<HTMLButtonElement>('#run-case-can-duck');
+const backgroundTransitionCaseButton = document.querySelector<HTMLButtonElement>('#run-case-background-transition');
 const copyLogButton = document.querySelector<HTMLButtonElement>('#copy-log');
 const copyEventsButton = document.querySelector<HTMLButtonElement>('#copy-events');
 const copySmokeReportButton = document.querySelector<HTMLButtonElement>('#copy-smoke-report');
@@ -81,6 +84,9 @@ if (
   || !remotePlayCaseButton
   || !remoteSkipCaseButton
   || !remoteSeekCaseButton
+  || !focusDeniedCaseButton
+  || !canDuckCaseButton
+  || !backgroundTransitionCaseButton
   || !copyLogButton
   || !copyEventsButton
   || !copySmokeReportButton
@@ -1270,6 +1276,77 @@ const runRemoteSeekCaseFlow = async (): Promise<void> => {
   log('[guided-case] end | remote seek parity');
 };
 
+const runFocusDeniedCaseFlow = async (): Promise<void> => {
+  const baseline = await setupGuidedRemoteCaseBaseline('focus-denied lifecycle check');
+  const baselineState = baseline.state;
+
+  log('[guided-case] action required: keep this track selected, start another app that owns audio focus, then press PLAY here again within 15s.');
+  log('[guided-case] expected: playback should not continue as playing when focus request is denied; it should settle paused/interrupted.');
+
+  await playAction('legato');
+  await waitForCondition(
+    () => latestSnapshot?.state === 'paused' || latestSnapshot?.state === 'playing',
+    guidedCaseTimeoutMs,
+  );
+  await sleep(guidedCaseSettleMs);
+  await snapshotAction('legato');
+
+  const finalState = latestSnapshot?.state;
+  const deniedProjectionLooksHealthy = finalState === 'paused';
+
+  caseCheck(
+    'Focus-denied projection keeps runtime non-playing',
+    deniedProjectionLooksHealthy,
+    `baseline=${baselineState}, final=${finalState ?? 'unknown'} (expected paused on denied focus).`,
+  );
+  log('[guided-case] end | focus-denied lifecycle check');
+};
+
+const runCanDuckCaseFlow = async (): Promise<void> => {
+  await setupGuidedRemoteCaseBaseline('can-duck interruption policy check');
+
+  log('[guided-case] action required: while this track is playing, trigger a CAN_DUCK interruption (voice prompt/navigation/assistant) within 15s.');
+  log('[guided-case] expected v1 policy: CAN_DUCK is treated as pause/interruption, no auto-resume on focus gain.');
+
+  const pausedObserved = await waitForCondition(
+    () => latestSnapshot?.state === 'paused',
+    guidedCaseTimeoutMs,
+  );
+
+  if (pausedObserved) {
+    await sleep(guidedCaseSettleMs);
+  }
+  await snapshotAction('legato');
+
+  const finalState = latestSnapshot?.state;
+  caseCheck(
+    'CAN_DUCK maps to interruption pause',
+    finalState === 'paused',
+    `final state=${finalState ?? 'unknown'} (expected paused).`,
+  );
+  log('[guided-case] end | can-duck interruption policy check');
+};
+
+const runBackgroundTransitionCaseFlow = async (): Promise<void> => {
+  const baseline = await setupGuidedRemoteCaseBaseline('background transition coherence check');
+  const baselineQueue = queueLengthFromSnapshot(baseline);
+
+  log('[guided-case] action required: send app to background for ~8s, verify notification controls are visible, then return to app.');
+  await sleep(8000);
+  await snapshotAction('legato');
+
+  const finalSnapshot = latestSnapshot;
+  const finalQueue = finalSnapshot ? queueLengthFromSnapshot(finalSnapshot) : 0;
+  const finalState = finalSnapshot?.state;
+
+  caseCheck(
+    'Background transition keeps active queue/session while process is alive',
+    Boolean(finalSnapshot) && finalQueue === baselineQueue && finalState !== 'idle' && finalState !== 'error',
+    `baselineQueue=${baselineQueue}, finalQueue=${finalQueue}, finalState=${finalState ?? 'unknown'}`,
+  );
+  log('[guided-case] end | background transition coherence check');
+};
+
 const setPlaybackSurface = (surface: PlaybackSurface): void => {
   activePlaybackSurface = surface;
   renderBoundarySummary();
@@ -1318,6 +1395,18 @@ remoteSkipCaseButton.addEventListener('click', () => {
 
 remoteSeekCaseButton.addEventListener('click', () => {
   void runNativeAction('run guided case: remote seek parity', runRemoteSeekCaseFlow);
+});
+
+focusDeniedCaseButton.addEventListener('click', () => {
+  void runNativeAction('run guided case: focus-denied lifecycle check', runFocusDeniedCaseFlow);
+});
+
+canDuckCaseButton.addEventListener('click', () => {
+  void runNativeAction('run guided case: CAN_DUCK interruption policy check', runCanDuckCaseFlow);
+});
+
+backgroundTransitionCaseButton.addEventListener('click', () => {
+  void runNativeAction('run guided case: background transition coherence check', runBackgroundTransitionCaseFlow);
 });
 
 setupButton.addEventListener('click', () => {

--- a/native/android/core/README.md
+++ b/native/android/core/README.md
@@ -21,7 +21,13 @@ The module ships a real Media3 runtime path and also keeps default no-op adapter
 
 - Focus loss (`AUDIOFOCUS_LOSS`, `AUDIOFOCUS_LOSS_TRANSIENT`, `AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK`) and becoming noisy signals pause playback with interruption pause origin.
 - Focus gain does **not** auto-resume playback in v1.
+- Focus request denial is handled as deterministic non-playing lifecycle behavior (no implicit retry loop / no auto-play continuation).
 - Service/app adapters ingest Android callbacks and forward canonical interruption signals to the session runtime.
+
+### Explicit non-goal boundary (android-background-lifecycle-v1)
+
+- This pass hardens **live-process** Android lifecycle semantics only.
+- It does **not** claim process-death restore, broad OEM completeness, or a large MediaSession rewrite.
 
 ## Gradle module bootstrap
 

--- a/native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidModels.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidModels.kt
@@ -110,12 +110,21 @@ enum class LegatoAndroidEventName(val wireValue: String) {
     PLAYBACK_QUEUE_CHANGED("playback-queue-changed"),
     PLAYBACK_PROGRESS("playback-progress"),
     PLAYBACK_ENDED("playback-ended"),
+    PLAYBACK_INTERRUPTION("playback-interruption"),
     PLAYBACK_ERROR("playback-error"),
     REMOTE_PLAY("remote-play"),
     REMOTE_PAUSE("remote-pause"),
     REMOTE_NEXT("remote-next"),
     REMOTE_PREVIOUS("remote-previous"),
     REMOTE_SEEK("remote-seek"),
+}
+
+enum class LegatoAndroidInterruptionReason(val wireValue: String) {
+    FOCUS_DENIED("focus-denied"),
+    AUDIO_FOCUS_LOSS("audio-focus-loss"),
+    AUDIO_FOCUS_LOSS_TRANSIENT("audio-focus-loss-transient"),
+    AUDIO_FOCUS_LOSS_TRANSIENT_CAN_DUCK("audio-focus-loss-transient-can-duck"),
+    BECOMING_NOISY("becoming-noisy"),
 }
 
 sealed interface LegatoAndroidEventPayload {
@@ -129,6 +138,10 @@ sealed interface LegatoAndroidEventPayload {
     ) : LegatoAndroidEventPayload
 
     data class PlaybackEnded(val snapshot: LegatoAndroidPlaybackSnapshot) : LegatoAndroidEventPayload
+    data class PlaybackInterruption(
+        val reason: LegatoAndroidInterruptionReason,
+        val resumable: Boolean,
+    ) : LegatoAndroidEventPayload
     data class PlaybackError(val error: LegatoAndroidError) : LegatoAndroidEventPayload
 
     object RemotePlay : LegatoAndroidEventPayload

--- a/native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidPlayerEngine.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidPlayerEngine.kt
@@ -464,6 +464,10 @@ class LegatoAndroidPlayerEngine(
         }
     }
 
+    fun handleExternalInterruption(signal: LegatoAndroidInterruptionSignal) {
+        onInterruption(signal)
+    }
+
     fun release() {
         if (!isSetup) {
             return
@@ -672,15 +676,24 @@ class LegatoAndroidPlayerEngine(
                 // v1 policy: no automatic resume.
             }
 
+            LegatoAndroidInterruptionSignal.AudioFocusDenied -> {
+                val state = snapshotStore.getPlaybackSnapshot().state
+                if (state == LegatoAndroidPlaybackState.PLAYING || state == LegatoAndroidPlaybackState.BUFFERING) {
+                    pauseForInterruption(signal)
+                } else {
+                    publishInterruption(signal)
+                }
+            }
+
             LegatoAndroidInterruptionSignal.AudioFocusLost,
             LegatoAndroidInterruptionSignal.AudioFocusLostTransient,
             LegatoAndroidInterruptionSignal.AudioFocusLostTransientCanDuck,
             LegatoAndroidInterruptionSignal.BecomingNoisy,
-            -> pauseForInterruption()
+            -> pauseForInterruption(signal)
         }
     }
 
-    private fun pauseForInterruption() {
+    private fun pauseForInterruption(signal: LegatoAndroidInterruptionSignal) {
         val state = snapshotStore.getPlaybackSnapshot().state
         if (state != LegatoAndroidPlaybackState.PLAYING && state != LegatoAndroidPlaybackState.BUFFERING) {
             return
@@ -691,6 +704,27 @@ class LegatoAndroidPlayerEngine(
         }
         pauseOrigin = LegatoAndroidPauseOrigin.INTERRUPTION
         transitionTo(LegatoAndroidStateMachine.LegatoAndroidStateInput.PAUSE)
+        publishInterruption(signal)
+    }
+
+    private fun publishInterruption(signal: LegatoAndroidInterruptionSignal) {
+        val reason = when (signal) {
+            LegatoAndroidInterruptionSignal.AudioFocusDenied -> LegatoAndroidInterruptionReason.FOCUS_DENIED
+            LegatoAndroidInterruptionSignal.AudioFocusLost -> LegatoAndroidInterruptionReason.AUDIO_FOCUS_LOSS
+            LegatoAndroidInterruptionSignal.AudioFocusLostTransient -> LegatoAndroidInterruptionReason.AUDIO_FOCUS_LOSS_TRANSIENT
+            LegatoAndroidInterruptionSignal.AudioFocusLostTransientCanDuck -> LegatoAndroidInterruptionReason.AUDIO_FOCUS_LOSS_TRANSIENT_CAN_DUCK
+            LegatoAndroidInterruptionSignal.BecomingNoisy -> LegatoAndroidInterruptionReason.BECOMING_NOISY
+            LegatoAndroidInterruptionSignal.AudioFocusGained -> return
+        }
+
+        val resumable = reason != LegatoAndroidInterruptionReason.FOCUS_DENIED
+        eventEmitter.emit(
+            name = LegatoAndroidEventName.PLAYBACK_INTERRUPTION,
+            payload = LegatoAndroidEventPayload.PlaybackInterruption(
+                reason = reason,
+                resumable = resumable,
+            ),
+        )
     }
 
     private fun onRemoteCommand(command: LegatoAndroidRemoteCommand) {

--- a/native/android/core/src/main/kotlin/io/legato/core/session/LegatoAndroidSessionRuntime.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/session/LegatoAndroidSessionRuntime.kt
@@ -11,7 +11,7 @@ enum class LegatoAndroidAudioFocusGainHint {
 data class LegatoAndroidAudioFocusPolicy(
     val gainHint: LegatoAndroidAudioFocusGainHint,
     val pauseOnTransientLoss: Boolean,
-    val duckOnTransientCanDuck: Boolean,
+    val pauseOnTransientCanDuck: Boolean,
     val resumeAfterGainIfNotUserPaused: Boolean,
 )
 
@@ -22,6 +22,8 @@ sealed interface LegatoAndroidInterruptionSignal {
 
     data object AudioFocusLostTransientCanDuck : LegatoAndroidInterruptionSignal
 
+    data object AudioFocusDenied : LegatoAndroidInterruptionSignal
+
     data object AudioFocusGained : LegatoAndroidInterruptionSignal
 
     data object BecomingNoisy : LegatoAndroidInterruptionSignal
@@ -31,7 +33,7 @@ object LegatoAndroidSessionDefaults {
     val MILESTONE1_AUDIO_FOCUS_POLICY = LegatoAndroidAudioFocusPolicy(
         gainHint = LegatoAndroidAudioFocusGainHint.AUDIOFOCUS_GAIN,
         pauseOnTransientLoss = true,
-        duckOnTransientCanDuck = true,
+        pauseOnTransientCanDuck = true,
         resumeAfterGainIfNotUserPaused = false,
     )
 }

--- a/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineInterruptionPolicyTest.kt
+++ b/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineInterruptionPolicyTest.kt
@@ -144,6 +144,52 @@ class LegatoAndroidPlayerEngineInterruptionPolicyTest {
     }
 
     @Test
+    fun `focus-denied interruption emits canonical interruption event and keeps runtime non-playing`() = runBlocking {
+        val playbackRuntime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val eventEmitter = LegatoAndroidEventEmitter()
+        val events = mutableListOf<LegatoAndroidEvent>()
+        eventEmitter.addListener { event -> events += event }
+        val engine = buildEngine(playbackRuntime, sessionRuntime, eventEmitter)
+
+        engine.setup()
+        engine.load(tracks = listOf(LegatoAndroidTrack(id = "track-1", url = "https://example.com/audio.mp3")))
+        engine.play()
+
+        sessionRuntime.emit(LegatoAndroidInterruptionSignal.AudioFocusDenied)
+
+        assertEquals(LegatoAndroidPlaybackState.PAUSED, engine.getSnapshot().state)
+        val interruptionEvents = events
+            .filter { it.name == LegatoAndroidEventName.PLAYBACK_INTERRUPTION }
+            .mapNotNull { it.payload as? LegatoAndroidEventPayload.PlaybackInterruption }
+        assertTrue(interruptionEvents.any {
+            it.reason == LegatoAndroidInterruptionReason.FOCUS_DENIED && !it.resumable
+        })
+    }
+
+    @Test
+    fun `focus-denied interruption before play does not enter playing or buffering`() = runBlocking {
+        val playbackRuntime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val eventEmitter = LegatoAndroidEventEmitter()
+        val events = mutableListOf<LegatoAndroidEvent>()
+        eventEmitter.addListener { event -> events += event }
+        val engine = buildEngine(playbackRuntime, sessionRuntime, eventEmitter)
+
+        engine.setup()
+        engine.load(tracks = listOf(LegatoAndroidTrack(id = "track-1", url = "https://example.com/audio.mp3")))
+
+        sessionRuntime.emit(LegatoAndroidInterruptionSignal.AudioFocusDenied)
+
+        assertEquals(LegatoAndroidPlaybackState.READY, engine.getSnapshot().state)
+        assertEquals(0, playbackRuntime.playCallCount)
+        val interruptions = events
+            .filter { it.name == LegatoAndroidEventName.PLAYBACK_INTERRUPTION }
+            .mapNotNull { it.payload as? LegatoAndroidEventPayload.PlaybackInterruption }
+        assertTrue(interruptions.any { it.reason == LegatoAndroidInterruptionReason.FOCUS_DENIED })
+    }
+
+    @Test
     fun `runtime ended callback transitions state and emits playback-ended event`() = runBlocking {
         val playbackRuntime = RecordingPlaybackRuntime()
         val sessionRuntime = RecordingSessionRuntime()

--- a/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineQueueOwnershipTest.kt
+++ b/native/android/core/src/test/kotlin/io/legato/core/core/LegatoAndroidPlayerEngineQueueOwnershipTest.kt
@@ -113,7 +113,7 @@ class LegatoAndroidPlayerEngineQueueOwnershipTest {
                 LegatoAndroidAudioFocusPolicy(
                     gainHint = LegatoAndroidAudioFocusGainHint.AUDIOFOCUS_GAIN,
                     pauseOnTransientLoss = true,
-                    duckOnTransientCanDuck = true,
+                    pauseOnTransientCanDuck = true,
                     resumeAfterGainIfNotUserPaused = false,
                 )
 

--- a/native/android/core/src/test/kotlin/io/legato/core/session/LegatoAndroidAudioFocusSessionRuntimeTest.kt
+++ b/native/android/core/src/test/kotlin/io/legato/core/session/LegatoAndroidAudioFocusSessionRuntimeTest.kt
@@ -12,6 +12,7 @@ class LegatoAndroidAudioFocusSessionRuntimeTest {
         val policy = runtime.audioFocusPolicy()
 
         assertEquals(LegatoAndroidAudioFocusGainHint.AUDIOFOCUS_GAIN, policy.gainHint)
+        assertEquals(true, policy.pauseOnTransientCanDuck)
         assertFalse(policy.resumeAfterGainIfNotUserPaused)
     }
 

--- a/packages/capacitor/README.md
+++ b/packages/capacitor/README.md
@@ -133,6 +133,7 @@ Maintainer-heavy CLI/release/SPM operational details are documented in [`../../d
 - Android runtime playback is implemented (Media3/ExoPlayer runtime + foreground service transport controls) for package-supported flows.
 - This binding bridges current native core semantics/state/events and keeps queue/state/event ownership aligned.
 - Interruption handling policy in runtime-v1 is explicit: focus loss/noisy pauses playback; focus gain does not auto-resume.
+- Lifecycle hardening boundary (`android-background-lifecycle-v1`) is explicit: focus denial/CAN_DUCK/background transition behavior is in scope only while process is alive.
 - Non-goals for this milestone: process-death restore, broad lifecycle/OEM hardening, and cross-platform parity expansion.
 - Those deferred items move to follow-up milestones (`android-background-lifecycle-v1` and platform parity tracks), not runtime-v1.
 

--- a/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoAndroidPlaybackCoordinator.kt
+++ b/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoAndroidPlaybackCoordinator.kt
@@ -2,6 +2,8 @@ package io.legato.capacitor
 
 import android.content.Context
 import android.content.Intent
+import android.media.AudioFocusRequest
+import android.media.AudioManager
 import android.os.Build
 import androidx.media3.exoplayer.ExoPlayer
 import io.legato.core.core.LegatoAndroidCoreComponents
@@ -47,6 +49,7 @@ internal class LegatoAndroidAppServiceRuntime(
 internal class LegatoAndroidPlaybackCoordinator(
     val core: LegatoAndroidCoreComponents,
     private var serviceRuntime: LegatoAndroidCoordinatorServiceRuntime = NoopLegatoAndroidCoordinatorServiceRuntime,
+    private val focusGate: LegatoAndroidPlaybackFocusGate = AlwaysGrantedLegatoAndroidPlaybackFocusGate,
 ) {
     private val modeListeners = linkedMapOf<Long, (LegatoAndroidServiceMode) -> Unit>()
     private val playbackStateListeners = linkedMapOf<Long, (LegatoAndroidPlaybackState) -> Unit>()
@@ -98,6 +101,15 @@ internal class LegatoAndroidPlaybackCoordinator(
     }
 
     fun play() {
+        if (!focusGate.requestPlaybackFocus()) {
+            core.playerEngine.handleExternalInterruption(
+                io.legato.core.session.LegatoAndroidInterruptionSignal.AudioFocusDenied,
+            )
+            projectServiceMode()
+            projectPlaybackState()
+            projectNowPlayingMetadata()
+            return
+        }
         kotlinx.coroutines.runBlocking { core.playerEngine.play() }
         projectServiceMode()
         projectPlaybackState()
@@ -347,8 +359,10 @@ internal class LegatoAndroidPlaybackCoordinator(
             runtime = serviceRuntime
         }
 
-        if (nextMode != LegatoAndroidServiceMode.OFF) {
+        if (shouldEnsureServiceRunning(nextMode)) {
             runtime.ensureServiceRunning(nextMode)
+        } else {
+            focusGate.abandonPlaybackFocus()
         }
 
         if (shouldNotify) {
@@ -419,6 +433,70 @@ internal class LegatoAndroidPlaybackCoordinator(
         )
 }
 
+internal fun shouldEnsureServiceRunning(mode: LegatoAndroidServiceMode): Boolean {
+    return mode != LegatoAndroidServiceMode.OFF
+}
+
+internal interface LegatoAndroidPlaybackFocusGate {
+    fun requestPlaybackFocus(): Boolean
+
+    fun abandonPlaybackFocus()
+}
+
+internal object AlwaysGrantedLegatoAndroidPlaybackFocusGate : LegatoAndroidPlaybackFocusGate {
+    override fun requestPlaybackFocus(): Boolean = true
+
+    override fun abandonPlaybackFocus() = Unit
+}
+
+internal class AndroidAudioManagerPlaybackFocusGate(
+    private val appContext: Context,
+) : LegatoAndroidPlaybackFocusGate {
+    private val audioManager: AudioManager? = appContext.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
+    private var focusRequest: AudioFocusRequest? = null
+    private var hasFocus: Boolean = false
+
+    override fun requestPlaybackFocus(): Boolean {
+        if (hasFocus) {
+            return true
+        }
+        val manager = audioManager ?: return true
+
+        val granted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val request = focusRequest ?: AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+                .setAcceptsDelayedFocusGain(false)
+                .setWillPauseWhenDucked(true)
+                .setOnAudioFocusChangeListener { }
+                .build()
+                .also { created -> focusRequest = created }
+            manager.requestAudioFocus(request) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+        } else {
+            @Suppress("DEPRECATION")
+            manager.requestAudioFocus(
+                null,
+                AudioManager.STREAM_MUSIC,
+                AudioManager.AUDIOFOCUS_GAIN,
+            ) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+        }
+        hasFocus = granted
+        return granted
+    }
+
+    override fun abandonPlaybackFocus() {
+        if (!hasFocus) {
+            return
+        }
+        val manager = audioManager ?: return
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            focusRequest?.let { manager.abandonAudioFocusRequest(it) }
+        } else {
+            @Suppress("DEPRECATION")
+            manager.abandonAudioFocus(null)
+        }
+        hasFocus = false
+    }
+}
+
 internal object LegatoAndroidPlaybackCoordinatorStore {
     private val lock = Any()
     private var coordinator: LegatoAndroidPlaybackCoordinator? = null
@@ -432,6 +510,7 @@ internal object LegatoAndroidPlaybackCoordinatorStore {
                     ),
                 ),
             ),
+            focusGate = AndroidAudioManagerPlaybackFocusGate(appContext),
         ).also {
             coordinator = it
         }

--- a/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoCapacitorMapper.kt
+++ b/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoCapacitorMapper.kt
@@ -119,6 +119,11 @@ internal class LegatoCapacitorMapper {
                 put("snapshot", snapshotToJs(payload.snapshot))
             }
 
+            is LegatoAndroidEventPayload.PlaybackInterruption -> JSObject().apply {
+                put("reason", payload.reason.wireValue)
+                put("resumable", payload.resumable)
+            }
+
             is LegatoAndroidEventPayload.PlaybackError -> JSObject().apply {
                 put("error", errorToJs(payload.error))
             }

--- a/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackNotificationTransport.kt
+++ b/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackNotificationTransport.kt
@@ -71,13 +71,18 @@ internal object LegatoPlaybackNotificationTransport {
     fun notificationActionModelFor(
         state: LegatoAndroidPlaybackState,
         capabilities: LegatoAndroidTransportCapabilities,
+        mode: LegatoAndroidServiceMode? = null,
     ): List<NotificationActionModel> {
         val actions = mutableListOf<NotificationActionModel>()
         if (capabilities.canSkipPrevious) {
             actions += NotificationActionModel(intentAction = ACTION_PREVIOUS, label = "Previous")
         }
 
-        val projectedControl = projectedControlFor(state)
+        val projectedControl = if (mode == LegatoAndroidServiceMode.RESUME_PENDING_INTERRUPTION) {
+            LegatoAndroidMediaSessionBridge.TransportControl.PLAY
+        } else {
+            projectedControlFor(state)
+        }
         actions += NotificationActionModel(
             intentAction = if (projectedControl == LegatoAndroidMediaSessionBridge.TransportControl.PAUSE) ACTION_PAUSE else ACTION_PLAY,
             label = if (projectedControl == LegatoAndroidMediaSessionBridge.TransportControl.PAUSE) "Pause" else "Play",

--- a/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackService.kt
+++ b/packages/capacitor/android/src/main/java/io/legato/capacitor/LegatoPlaybackService.kt
@@ -22,6 +22,7 @@ import android.util.Log
 import io.legato.core.core.LegatoAndroidNowPlayingMetadata
 import io.legato.core.core.LegatoAndroidPlaybackState
 import io.legato.core.core.LegatoAndroidServiceMode
+import io.legato.core.core.LegatoAndroidTrack
 import io.legato.core.queue.LegatoAndroidTransportCapabilitiesProjector
 import io.legato.core.session.LegatoAndroidInterruptionSignal
 import java.net.URL
@@ -39,6 +40,7 @@ class LegatoPlaybackService : Service() {
     private var modeListenerId: Long? = null
     private var playbackStateListenerId: Long? = null
     private var foregroundActive: Boolean = false
+    private var foregroundMode: LegatoAndroidServiceMode? = null
     private var currentMode: LegatoAndroidServiceMode = LegatoAndroidServiceMode.OFF
     private var currentPlaybackState: LegatoAndroidPlaybackState = LegatoAndroidPlaybackState.IDLE
     private var currentNowPlayingMetadata: LegatoAndroidNowPlayingMetadata? = null
@@ -100,7 +102,7 @@ class LegatoPlaybackService : Service() {
             setFlags(legacyMediaSessionFlags())
             isActive = true
         }
-        syncMediaSessionPlaybackState(currentPlaybackState)
+        syncMediaSessionPlaybackState()
         publishNowPlayingSurfaces()
         refreshArtworkFor(currentNowPlayingMetadata)
         setupInterruptionIngestion()
@@ -114,12 +116,16 @@ class LegatoPlaybackService : Service() {
                 return START_STICKY
             }
 
-        val mode = intent?.getStringExtra(EXTRA_SERVICE_MODE)
+        val intentMode = intent?.getStringExtra(EXTRA_SERVICE_MODE)
             ?.runCatching { LegatoAndroidServiceMode.valueOf(this) }
             ?.getOrNull()
-            ?: coordinator.currentServiceMode()
+        val startProjection = resolveStartCommandMode(
+            intentMode = intentMode,
+            coordinatorMode = coordinator.currentServiceMode(),
+            currentMode = currentMode,
+        )
 
-        onServiceModeChanged(mode)
+        onServiceModeChanged(startProjection.mode)
         return START_STICKY
     }
 
@@ -149,12 +155,21 @@ class LegatoPlaybackService : Service() {
     private fun onServiceModeChanged(mode: LegatoAndroidServiceMode) {
         currentMode = mode
         if (mode == LegatoAndroidServiceMode.OFF) {
-            abandonAudioFocusIfHeld()
-            if (foregroundActive) {
+            val teardown = projectOffTeardown(
+                foregroundActive = foregroundActive,
+                hasAudioFocus = hasAudioFocus,
+            )
+            if (teardown.shouldAbandonFocus) {
+                abandonAudioFocusIfHeld()
+            }
+            if (teardown.shouldStopForeground) {
                 stopForeground(STOP_FOREGROUND_REMOVE)
                 foregroundActive = false
+                foregroundMode = null
             }
-            stopSelf()
+            if (teardown.shouldStopSelf) {
+                stopSelf()
+            }
             return
         }
 
@@ -163,7 +178,7 @@ class LegatoPlaybackService : Service() {
 
     private fun onPlaybackStateChanged(state: LegatoAndroidPlaybackState) {
         currentPlaybackState = state
-        syncMediaSessionPlaybackState(state)
+        syncMediaSessionPlaybackState()
         publishNowPlayingSurfaces()
         reconcileAudioFocusForState(state)
     }
@@ -173,7 +188,7 @@ class LegatoPlaybackService : Service() {
         currentNowPlayingMetadata = metadata
         currentArtworkBitmap = null
         if (previousTrackId != metadata?.trackId) {
-            syncMediaSessionPlaybackState(currentPlaybackState)
+            syncMediaSessionPlaybackState()
         }
         publishNowPlayingSurfaces()
         refreshArtworkFor(metadata)
@@ -185,7 +200,7 @@ class LegatoPlaybackService : Service() {
 
         val focusListener = AudioManager.OnAudioFocusChangeListener { focusChange ->
             val signal = interruptionSignalFromAudioFocusChange(focusChange) ?: return@OnAudioFocusChangeListener
-            coordinator.core.mediaSessionBridge.onInterruption(signal)
+            coordinator.core.sessionManager.onInterruption(signal)
         }
         audioFocusListener = focusListener
         audioFocusRequest = buildAudioFocusRequest(focusListener)
@@ -194,7 +209,7 @@ class LegatoPlaybackService : Service() {
             noisyReceiver = object : BroadcastReceiver() {
                 override fun onReceive(context: Context?, intent: Intent?) {
                     if (intent?.action == AudioManager.ACTION_AUDIO_BECOMING_NOISY) {
-                        coordinator.core.mediaSessionBridge.onInterruption(
+                        coordinator.core.sessionManager.onInterruption(
                             LegatoAndroidInterruptionSignal.BecomingNoisy,
                         )
                     }
@@ -246,7 +261,15 @@ class LegatoPlaybackService : Service() {
                 AudioManager.AUDIOFOCUS_GAIN,
             ) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
         }
-        hasAudioFocus = granted
+        val projection = projectAudioFocusRequestOutcome(
+            requestGranted = granted,
+            playbackState = currentPlaybackState,
+        )
+        hasAudioFocus = projection.hasAudioFocus
+        projection.interruptionSignal?.let { signal ->
+            Log.w("LegatoPlaybackService", "Audio focus request denied; reason=${projection.reason}")
+            coordinator.core.sessionManager.onInterruption(signal)
+        }
     }
 
     private fun abandonAudioFocusIfHeld() {
@@ -255,14 +278,19 @@ class LegatoPlaybackService : Service() {
         }
 
         val manager = audioManager ?: return
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        val abandonResult = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val focusRequest = audioFocusRequest
             if (focusRequest != null) {
                 manager.abandonAudioFocusRequest(focusRequest)
+            } else {
+                AudioManager.AUDIOFOCUS_REQUEST_GRANTED
             }
         } else {
             @Suppress("DEPRECATION")
             manager.abandonAudioFocus(audioFocusListener)
+        }
+        if (abandonResult != AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
+            Log.w("LegatoPlaybackService", "Audio focus abandon did not report granted result: $abandonResult")
         }
         hasAudioFocus = false
     }
@@ -357,7 +385,12 @@ class LegatoPlaybackService : Service() {
     }
 
     private fun publishNowPlayingSurfaces(): Boolean {
-        val metadataPublished = syncMediaSessionMetadata(currentNowPlayingMetadata, currentArtworkBitmap)
+        val snapshot = coordinator.core.playerEngine.getSnapshot()
+        val reconciledMetadata = reconcileNowPlayingMetadataWithSnapshot(
+            snapshotTrack = snapshot.currentTrack,
+            observedMetadata = currentNowPlayingMetadata,
+        )
+        val metadataPublished = syncMediaSessionMetadata(reconciledMetadata, currentArtworkBitmap)
         if (foregroundActive && currentMode != LegatoAndroidServiceMode.OFF) {
             val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
             notificationManager.notify(NOTIFICATION_ID, buildNotification(currentMode))
@@ -377,8 +410,14 @@ class LegatoPlaybackService : Service() {
             )
         }
 
+        if (foregroundActive && foregroundMode == mode) {
+            notificationManager.notify(NOTIFICATION_ID, buildNotification(mode))
+            return
+        }
+
         startForeground(NOTIFICATION_ID, buildNotification(mode))
         foregroundActive = true
+        foregroundMode = mode
     }
 
     private fun buildNotification(mode: LegatoAndroidServiceMode): Notification {
@@ -396,6 +435,7 @@ class LegatoPlaybackService : Service() {
         val notificationActions = LegatoPlaybackNotificationTransport.notificationActionModelFor(
             state = currentPlaybackState,
             capabilities = capabilities,
+            mode = mode,
         )
 
         val metadataModel = LegatoPlaybackNotificationTransport.notificationMetadataModelFor(
@@ -440,13 +480,18 @@ class LegatoPlaybackService : Service() {
         return builder.build()
     }
 
-    private fun syncMediaSessionPlaybackState(state: LegatoAndroidPlaybackState) {
+    private fun syncMediaSessionPlaybackState() {
         val snapshot = coordinator.core.playerEngine.getSnapshot()
+        val canonicalState = snapshot.state
+        val activeTrackId = resolveActiveTrackIdForProjection(
+            snapshotTrackId = snapshot.currentTrack?.id,
+            metadataTrackId = currentNowPlayingMetadata?.trackId,
+        )
         val capabilities = LegatoAndroidTransportCapabilitiesProjector.fromSnapshot(snapshot)
         val projectedState = projectMediaSessionPlaybackState(
-            state = state,
+            state = canonicalState,
             snapshotPositionMs = snapshot.positionMs,
-            activeTrackId = currentNowPlayingMetadata?.trackId ?: snapshot.currentTrack?.id,
+            activeTrackId = activeTrackId,
             previousProjection = lastMediaSessionProjection,
         )
         val playbackState = PlaybackState.Builder()
@@ -528,6 +573,99 @@ internal fun interruptionSignalFromAudioFocusChange(focusChange: Int): LegatoAnd
         AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> LegatoAndroidInterruptionSignal.AudioFocusLostTransientCanDuck
         else -> null
     }
+}
+
+internal fun resolveActiveTrackIdForProjection(
+    snapshotTrackId: String?,
+    metadataTrackId: String?,
+): String? {
+    return snapshotTrackId ?: metadataTrackId
+}
+
+internal fun reconcileNowPlayingMetadataWithSnapshot(
+    snapshotTrack: LegatoAndroidTrack?,
+    observedMetadata: LegatoAndroidNowPlayingMetadata?,
+): LegatoAndroidNowPlayingMetadata? {
+    val track = snapshotTrack ?: return null
+    if (observedMetadata?.trackId == track.id) {
+        return observedMetadata
+    }
+
+    return LegatoAndroidNowPlayingMetadata(
+        trackId = track.id,
+        title = track.title,
+        artist = track.artist,
+        album = track.album,
+        artwork = track.artwork,
+        durationMs = track.durationMs,
+    )
+}
+
+internal data class AudioFocusRequestOutcome(
+    val hasAudioFocus: Boolean,
+    val interruptionSignal: LegatoAndroidInterruptionSignal?,
+    val reason: String?,
+    val pauseForInterruption: Boolean,
+)
+
+internal fun projectAudioFocusRequestOutcome(
+    requestGranted: Boolean,
+    playbackState: LegatoAndroidPlaybackState,
+): AudioFocusRequestOutcome {
+    if (requestGranted) {
+        return AudioFocusRequestOutcome(
+            hasAudioFocus = true,
+            interruptionSignal = null,
+            reason = null,
+            pauseForInterruption = false,
+        )
+    }
+
+    val playingState = playbackState == LegatoAndroidPlaybackState.PLAYING || playbackState == LegatoAndroidPlaybackState.BUFFERING
+    return AudioFocusRequestOutcome(
+        hasAudioFocus = false,
+        interruptionSignal = if (playingState) LegatoAndroidInterruptionSignal.AudioFocusDenied else null,
+        reason = if (playingState) "focus-denied" else null,
+        pauseForInterruption = playingState,
+    )
+}
+
+internal data class StartCommandModeProjection(
+    val mode: LegatoAndroidServiceMode,
+    val shouldStartForeground: Boolean,
+    val shouldStopSelf: Boolean,
+)
+
+internal data class OffTeardownProjection(
+    val shouldAbandonFocus: Boolean,
+    val shouldStopForeground: Boolean,
+    val shouldStopSelf: Boolean,
+)
+
+internal fun resolveStartCommandMode(
+    intentMode: LegatoAndroidServiceMode?,
+    coordinatorMode: LegatoAndroidServiceMode,
+    currentMode: LegatoAndroidServiceMode,
+): StartCommandModeProjection {
+    val projectedMode = intentMode ?: coordinatorMode
+    val shouldStartForeground = projectedMode != LegatoAndroidServiceMode.OFF
+    val shouldStopSelf = projectedMode == LegatoAndroidServiceMode.OFF && currentMode == LegatoAndroidServiceMode.OFF
+    return StartCommandModeProjection(
+        mode = projectedMode,
+        shouldStartForeground = shouldStartForeground,
+        shouldStopSelf = shouldStopSelf,
+    )
+}
+
+internal fun projectOffTeardown(
+    foregroundActive: Boolean,
+    hasAudioFocus: Boolean,
+): OffTeardownProjection {
+    return OffTeardownProjection(
+        shouldAbandonFocus = hasAudioFocus,
+        shouldStopForeground = foregroundActive,
+        shouldStopSelf = true,
+    )
 }
 
 internal fun <C, R> resolveOnCreateDependency(contextProvider: () -> C, resolver: (C) -> R): R {

--- a/packages/capacitor/android/src/test/kotlin/io/legato/capacitor/LegatoAndroidPlaybackCoordinatorTest.kt
+++ b/packages/capacitor/android/src/test/kotlin/io/legato/capacitor/LegatoAndroidPlaybackCoordinatorTest.kt
@@ -25,6 +25,7 @@ import io.legato.core.snapshot.LegatoAndroidSnapshotStore
 import io.legato.core.state.LegatoAndroidStateMachine
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
@@ -221,6 +222,43 @@ class LegatoAndroidPlaybackCoordinatorTest {
         assertEquals(LegatoAndroidPlaybackState.PAUSED, coordinator.currentPlaybackState())
         assertTrue(projectedStates.contains(LegatoAndroidPlaybackState.PLAYING))
         assertTrue(projectedStates.contains(LegatoAndroidPlaybackState.PAUSED))
+    }
+
+    @Test
+    fun `coordinator play is gated by focus denial and emits canonical denied interruption without entering playing`() = runBlocking {
+        val runtime = RecordingPlaybackRuntime()
+        val sessionRuntime = RecordingSessionRuntime()
+        val focusGate = RecordingPlaybackFocusGate(granted = false)
+        val coordinator = LegatoAndroidPlaybackCoordinator(
+            core = buildCore(runtime, sessionRuntime),
+            serviceRuntime = RecordingCoordinatorServiceRuntime(),
+            focusGate = focusGate,
+        )
+        val events = mutableListOf<io.legato.core.core.LegatoAndroidEvent>()
+        coordinator.addCoreEventListener { event -> events += event }
+
+        coordinator.setup()
+        coordinator.load(
+            listOf(
+                LegatoAndroidTrack(
+                    id = "track-1",
+                    url = "https://example.com/track.mp3",
+                ),
+            ),
+        )
+
+        coordinator.play()
+
+        assertEquals("play should be blocked when focus gate denies", 0, runtime.playCallCount)
+        assertEquals("state must remain non-playing after denied play attempt", LegatoAndroidPlaybackState.READY, coordinator.currentPlaybackState())
+        val interruptions = events
+            .filter { it.name == io.legato.core.core.LegatoAndroidEventName.PLAYBACK_INTERRUPTION }
+            .mapNotNull { it.payload as? io.legato.core.core.LegatoAndroidEventPayload.PlaybackInterruption }
+        assertTrue(
+            "focus-denied interruption should be emitted",
+            interruptions.any { it.reason == io.legato.core.core.LegatoAndroidInterruptionReason.FOCUS_DENIED },
+        )
+        assertEquals("focus gate should be consulted exactly once", 1, focusGate.requestCalls)
     }
 
     @Test
@@ -439,6 +477,13 @@ class LegatoAndroidPlaybackCoordinatorTest {
         assertEquals(LegatoAndroidPauseOrigin.INTERRUPTION, coordinator.currentPauseOrigin())
     }
 
+    @Test
+    fun `service runtime mode projection starts service only for active interruption modes`() {
+        assertFalse(shouldEnsureServiceRunning(LegatoAndroidServiceMode.OFF))
+        assertTrue(shouldEnsureServiceRunning(LegatoAndroidServiceMode.PLAYBACK_ACTIVE))
+        assertTrue(shouldEnsureServiceRunning(LegatoAndroidServiceMode.RESUME_PENDING_INTERRUPTION))
+    }
+
     private fun buildCore(
         runtime: RecordingPlaybackRuntime,
         sessionRuntime: RecordingSessionRuntime,
@@ -532,7 +577,7 @@ private class RecordingSessionRuntime : LegatoAndroidSessionRuntime {
         LegatoAndroidAudioFocusPolicy(
             gainHint = LegatoAndroidAudioFocusGainHint.AUDIOFOCUS_GAIN,
             pauseOnTransientLoss = true,
-            duckOnTransientCanDuck = true,
+            pauseOnTransientCanDuck = true,
             resumeAfterGainIfNotUserPaused = false,
         )
 
@@ -555,4 +600,18 @@ private class RecordingSessionRuntime : LegatoAndroidSessionRuntime {
     fun emit(signal: LegatoAndroidInterruptionSignal) {
         listener?.invoke(signal)
     }
+}
+
+private class RecordingPlaybackFocusGate(
+    private val granted: Boolean,
+) : LegatoAndroidPlaybackFocusGate {
+    var requestCalls: Int = 0
+        private set
+
+    override fun requestPlaybackFocus(): Boolean {
+        requestCalls += 1
+        return granted
+    }
+
+    override fun abandonPlaybackFocus() = Unit
 }

--- a/packages/capacitor/android/src/test/kotlin/io/legato/capacitor/LegatoPlaybackNotificationTransportTest.kt
+++ b/packages/capacitor/android/src/test/kotlin/io/legato/capacitor/LegatoPlaybackNotificationTransportTest.kt
@@ -127,6 +127,21 @@ class LegatoPlaybackNotificationTransportTest {
     }
 
     @Test
+    fun `interruption mode forces primary notification action to play even if playback state still reports playing`() {
+        val actions = LegatoPlaybackNotificationTransport.notificationActionModelFor(
+            state = LegatoAndroidPlaybackState.PLAYING,
+            capabilities = LegatoAndroidTransportCapabilities(
+                canSkipNext = true,
+                canSkipPrevious = true,
+                canSeek = true,
+            ),
+            mode = LegatoAndroidServiceMode.RESUME_PENDING_INTERRUPTION,
+        )
+
+        assertEquals(LegatoPlaybackNotificationTransport.ACTION_PLAY, actions[1].intentAction)
+    }
+
+    @Test
     fun `notification intent action maps previous and next to remote commands`() {
         assertEquals(
             io.legato.core.core.LegatoAndroidRemoteCommand.Previous,

--- a/packages/capacitor/android/src/test/kotlin/io/legato/capacitor/LegatoPlaybackServiceBootstrapTest.kt
+++ b/packages/capacitor/android/src/test/kotlin/io/legato/capacitor/LegatoPlaybackServiceBootstrapTest.kt
@@ -2,6 +2,9 @@ package io.legato.capacitor
 
 import io.legato.core.core.LegatoAndroidNowPlayingMetadata
 import io.legato.core.core.LegatoAndroidPlaybackState
+import io.legato.core.core.LegatoAndroidServiceMode
+import io.legato.core.core.LegatoAndroidTrack
+import io.legato.core.core.LegatoAndroidTransportCapabilities
 import io.legato.core.session.LegatoAndroidInterruptionSignal
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -276,5 +279,153 @@ class LegatoPlaybackServiceBootstrapTest {
     fun `audio focus change mapping ignores unsupported platform constants`() {
         assertNull(interruptionSignalFromAudioFocusChange(Int.MAX_VALUE))
         assertNull(interruptionSignalFromAudioFocusChange(123_456))
+    }
+
+    @Test
+    fun `audio focus request denial resolves deterministic interruption projection`() {
+        val deniedProjection = projectAudioFocusRequestOutcome(
+            requestGranted = false,
+            playbackState = LegatoAndroidPlaybackState.PLAYING,
+        )
+        val grantedProjection = projectAudioFocusRequestOutcome(
+            requestGranted = true,
+            playbackState = LegatoAndroidPlaybackState.PLAYING,
+        )
+
+        assertFalse(deniedProjection.hasAudioFocus)
+        assertEquals(LegatoAndroidInterruptionSignal.AudioFocusDenied, deniedProjection.interruptionSignal)
+        assertEquals("focus-denied", deniedProjection.reason)
+        assertTrue(deniedProjection.pauseForInterruption)
+        assertTrue(grantedProjection.hasAudioFocus)
+        assertNull(grantedProjection.interruptionSignal)
+    }
+
+    @Test
+    fun `service start mode projection prevents foreground resurrection for null-intent OFF`() {
+        val projection = resolveStartCommandMode(
+            intentMode = null,
+            coordinatorMode = LegatoAndroidServiceMode.OFF,
+            currentMode = LegatoAndroidServiceMode.OFF,
+        )
+
+        assertEquals(LegatoAndroidServiceMode.OFF, projection.mode)
+        assertFalse(projection.shouldStartForeground)
+        assertTrue(projection.shouldStopSelf)
+    }
+
+    @Test
+    fun `media-session projection prefers canonical snapshot track id over stale metadata id`() {
+        val resolvedTrackId = resolveActiveTrackIdForProjection(
+            snapshotTrackId = "track-2",
+            metadataTrackId = "track-1",
+        )
+
+        assertEquals("track-2", resolvedTrackId)
+    }
+
+    @Test
+    fun `media-session metadata reconciliation drops stale metadata during transition churn`() {
+        val reconciled = reconcileNowPlayingMetadataWithSnapshot(
+            snapshotTrack = LegatoAndroidTrack(
+                id = "track-2",
+                url = "https://example.com/2.mp3",
+                title = "Canonical",
+                artist = "Artist",
+            ),
+            observedMetadata = LegatoAndroidNowPlayingMetadata(
+                trackId = "track-1",
+                title = "Stale",
+                artist = "Old",
+            ),
+        )
+
+        assertEquals("track-2", reconciled?.trackId)
+        assertEquals("Canonical", reconciled?.title)
+        assertEquals("Artist", reconciled?.artist)
+    }
+
+    @Test
+    fun `off teardown projection keeps stop-self deterministic and non-blocking`() {
+        val activeProjection = projectOffTeardown(
+            foregroundActive = true,
+            hasAudioFocus = true,
+        )
+        val idleProjection = projectOffTeardown(
+            foregroundActive = false,
+            hasAudioFocus = false,
+        )
+
+        assertTrue(activeProjection.shouldAbandonFocus)
+        assertTrue(activeProjection.shouldStopForeground)
+        assertTrue(activeProjection.shouldStopSelf)
+        assertFalse(idleProjection.shouldAbandonFocus)
+        assertFalse(idleProjection.shouldStopForeground)
+        assertTrue(idleProjection.shouldStopSelf)
+    }
+
+    @Test
+    fun `background pause resume projection keeps actions ordered and interruption mode coherent`() {
+        val pausedActions = LegatoPlaybackNotificationTransport.notificationActionModelFor(
+            state = LegatoAndroidPlaybackState.PAUSED,
+            capabilities = LegatoAndroidTransportCapabilities(
+                canSkipNext = true,
+                canSkipPrevious = true,
+                canSeek = true,
+            ),
+            mode = LegatoAndroidServiceMode.RESUME_PENDING_INTERRUPTION,
+        )
+        val resumedActions = LegatoPlaybackNotificationTransport.notificationActionModelFor(
+            state = LegatoAndroidPlaybackState.PLAYING,
+            capabilities = LegatoAndroidTransportCapabilities(
+                canSkipNext = true,
+                canSkipPrevious = true,
+                canSeek = true,
+            ),
+            mode = LegatoAndroidServiceMode.PLAYBACK_ACTIVE,
+        )
+
+        assertEquals(
+            listOf(
+                LegatoPlaybackNotificationTransport.ACTION_PREVIOUS,
+                LegatoPlaybackNotificationTransport.ACTION_PLAY,
+                LegatoPlaybackNotificationTransport.ACTION_NEXT,
+            ),
+            pausedActions.map { it.intentAction },
+        )
+        assertEquals(
+            listOf(
+                LegatoPlaybackNotificationTransport.ACTION_PREVIOUS,
+                LegatoPlaybackNotificationTransport.ACTION_PAUSE,
+                LegatoPlaybackNotificationTransport.ACTION_NEXT,
+            ),
+            resumedActions.map { it.intentAction },
+        )
+    }
+
+    @Test
+    fun `media-session playback projection remains track-consistent across interrupted pause then resume`() {
+        val pausedProjection = projectMediaSessionPlaybackState(
+            state = LegatoAndroidPlaybackState.PAUSED,
+            snapshotPositionMs = 12_000L,
+            activeTrackId = "track-1",
+            previousProjection = MediaSessionPlaybackProjection(
+                playbackStateCode = android.media.session.PlaybackState.STATE_PLAYING,
+                positionMs = 11_800L,
+                playbackSpeed = 1f,
+                activeTrackId = "track-1",
+            ),
+        )
+        val resumedProjection = projectMediaSessionPlaybackState(
+            state = LegatoAndroidPlaybackState.PLAYING,
+            snapshotPositionMs = 12_050L,
+            activeTrackId = "track-1",
+            previousProjection = pausedProjection,
+        )
+
+        assertEquals("track-1", pausedProjection.activeTrackId)
+        assertEquals(android.media.session.PlaybackState.STATE_PAUSED, pausedProjection.playbackStateCode)
+        assertEquals("track-1", resumedProjection.activeTrackId)
+        assertEquals(android.media.session.PlaybackState.STATE_PLAYING, resumedProjection.playbackStateCode)
+        assertNotEquals(0L, resumedProjection.positionMs)
     }
 }

--- a/specs/task-breakdown-v0.md
+++ b/specs/task-breakdown-v0.md
@@ -38,8 +38,9 @@
 - [x] Update native readmes/spec notes to clarify integrated runtime scope and deferred follow-up milestones.
 
 ## Deferred
-- [ ] Android process-death queue/session restoration hardening (`android-background-lifecycle-v1`).
-- [ ] Broad Android background lifecycle + OEM matrix parity hardening (`android-background-lifecycle-v1` follow-ups).
+- [ ] Android process-death queue/session restoration hardening (post-`android-background-lifecycle-v1` follow-up milestone).
+- [ ] Broad Android lifecycle/OEM matrix hardening and resilience certification (deferred after `android-background-lifecycle-v1` in-process scope).
+- [ ] Large MediaSession modernization/rewrite track (explicitly deferred beyond `android-background-lifecycle-v1`).
 - [ ] iOS runtime parity remains deferred to dedicated parity tracks (historical wording from pre-`ios-runtime-playback-v1` runtime-integrity closure).
 - [ ] Framework binding implementations.
 - [ ] CI/tooling automation.


### PR DESCRIPTION
Closes #90

## Summary
- harden Android focus denial, interruption, foreground service, notification, and MediaSession behavior while the process stays alive
- add targeted lifecycle regression coverage for denied play attempts, teardown invariants, and background transition consistency
- update runtime docs/harness wording so Android lifecycle support is described accurately without overclaiming process-death or OEM-wide resilience

## Changes
| File | Change |
|------|--------|
| `native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidPlayerEngine.kt` | adds canonical interruption handling and lifecycle-safe queue/play gating helpers |
| `native/android/core/src/main/kotlin/io/legato/core/core/LegatoAndroidModels.kt` | extends lifecycle-related runtime model projection support |
| `native/android/core/src/main/kotlin/io/legato/core/session/LegatoAndroidSessionRuntime.kt` | aligns audio focus/session interruption ingestion with the hardened lifecycle path |
| `native/android/core/src/test/kotlin/io/legato/core/core/*` | strengthens interruption, focus-denial, and queue/lifecycle regression coverage |
| `packages/capacitor/android/src/main/java/io/legato/capacitor/*` | hardens coordinator/service/notification lifecycle behavior and canonical denial projection |
| `packages/capacitor/android/src/test/kotlin/io/legato/capacitor/*` | adds focused lifecycle regression tests for adapter/service behavior |
| `apps/capacitor-demo/index.html`, `apps/capacitor-demo/src/main.ts`, `apps/capacitor-demo/README.md` | align smoke/runtime evidence and docs with stronger Android lifecycle semantics |
| `native/android/core/README.md`, `packages/capacitor/README.md`, `specs/task-breakdown-v0.md` | remove stale wording and document explicit in-process scope boundaries |
| `.gitignore`, `apps/capacitor-demo/android/settings.gradle` | persist monorepo-safe test/dev hygiene updates used by the validation flow |

## Test Plan
- [x] `gradle testDebugUnitTest --tests "io.legato.core.core.LegatoAndroidPlayerEngineInterruptionPolicyTest" --tests "io.legato.core.session.LegatoAndroidAudioFocusSessionRuntimeTest"` from `native/android/core`
- [x] `bash ./gradlew :legato-capacitor:testDebugUnitTest --tests "io.legato.capacitor.LegatoPlaybackServiceBootstrapTest" --tests "io.legato.capacitor.LegatoPlaybackNotificationTransportTest" --tests "io.legato.capacitor.LegatoAndroidPlaybackCoordinatorTest"` from `apps/capacitor-demo/android`
- [x] Existing smoke/runtime evidence path preserved and aligned

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Docs updated where public/runtime wording changed
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers