### PR TITLE
test(release): persist publication pipeline docs guard

### DIFF
--- a/apps/capacitor-demo/scripts/publication-pipeline-v2-docs.test.mjs
+++ b/apps/capacitor-demo/scripts/publication-pipeline-v2-docs.test.mjs
@@ -56,3 +56,19 @@ test('publication pipeline v2 runbook documents release-confidence pre-canary te
   assert.match(runbook, /typecheck/i);
   assert.match(runbook, /out of scope/i);
 });
+
+test('publication pipeline v2 runbook links governance policies, templates, and deploy contracts', async () => {
+  const runbook = await readFile(docsPath, 'utf8');
+
+  assert.match(runbook, /release-communication-governance-v1\.md/i);
+  assert.match(runbook, /release-notes-policy-v1\.md/i);
+  assert.match(runbook, /reconciliation-stop-the-line-rules-v1\.md/i);
+  assert.match(runbook, /release-note-template-governance-v1\.md/i);
+  assert.match(runbook, /ios-derivative-release-template\.md/i);
+  assert.match(runbook, /android-deploy-procedure-contract-v1\.md/i);
+  assert.match(runbook, /npm-deploy-procedure-contract-v1\.md/i);
+  assert.match(runbook, /ios-distribution-deploy-procedure-contract-v1\.md/i);
+  assert.match(runbook, /future-release-skill-io-contract-v1\.md/i);
+  assert.match(runbook, /docs\/releases\/notes\/<release_id>-ios-derivative\.md/i);
+  assert.match(runbook, /required when ios lane is selected/i);
+});


### PR DESCRIPTION
Closes #96

## Summary
- persist the missing publication pipeline v2 documentation guard that was left out of the previous release communication PR
- keep the release communication/documentation test surface fully aligned with the merged governance model

## Changes
| File | Change |
|------|--------|
| `apps/capacitor-demo/scripts/publication-pipeline-v2-docs.test.mjs` | adds/retains the governance-aware documentation assertions for the v2 publication pipeline runbook |

## Test Plan
- [x] `node --test scripts/publication-pipeline-v2-docs.test.mjs`
- [x] No shell scripts changed

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers