### PR TITLE
fix(ios): harden background lifecycle

### DIFF
--- a/apps/capacitor-demo/index.html
+++ b/apps/capacitor-demo/index.html
@@ -270,6 +270,7 @@ No smoke run yet.</pre>
             <button id="run-case-focus-denied" class="native-action" type="button">Case: focus-denied lifecycle check</button>
             <button id="run-case-can-duck" class="native-action" type="button">Case: CAN_DUCK interruption pause</button>
             <button id="run-case-background-transition" class="native-action" type="button">Case: background transition coherence</button>
+            <button id="run-case-ios-lifecycle-reassert" class="native-action" type="button">Case: iOS lifecycle reassert evidence</button>
           </div>
         </section>
 

--- a/apps/capacitor-demo/src/lifecycle-harness.d.ts
+++ b/apps/capacitor-demo/src/lifecycle-harness.d.ts
@@ -1,0 +1,21 @@
+export type LifecycleCheckpointInput = {
+  step: string;
+  snapshotState: string;
+  recentEvents?: string[];
+};
+
+export type LifecycleCheckpointVerdict = {
+  label: string;
+  ok: boolean;
+  detail: string;
+};
+
+export function classifyLifecycleCheckpoint(
+  step: string,
+  snapshotState: string,
+  recentEvents?: string[],
+): LifecycleCheckpointVerdict;
+
+export function buildLifecycleCheckpointSummary(
+  checkpoints: LifecycleCheckpointInput[],
+): string;

--- a/apps/capacitor-demo/src/lifecycle-harness.js
+++ b/apps/capacitor-demo/src/lifecycle-harness.js
@@ -1,0 +1,78 @@
+const ruleBook = [
+  {
+    keyword: 'Interruption begin paused playback.',
+    label: 'Interruption begin should pause playback',
+    evaluate: ({ snapshotState }) => ({
+      ok: snapshotState === 'paused',
+      detail: `snapshot.state=${snapshotState}`,
+    }),
+  },
+  {
+    keyword: 'Interruption end (shouldResume) reasserted surfaces without auto-play.',
+    label: 'Interruption end should reassert without auto-play',
+    evaluate: ({ snapshotState }) => ({
+      ok: snapshotState === 'paused',
+      detail: `snapshot.state=${snapshotState}`,
+    }),
+  },
+  {
+    keyword: 'Route available did not auto-resume playback.',
+    label: 'Route available should not auto-resume',
+    evaluate: ({ snapshotState }) => ({
+      ok: snapshotState === 'paused',
+      detail: `snapshot.state=${snapshotState}`,
+    }),
+  },
+  {
+    keyword: 'Foreground/active reassert projected metadata/progress/playback/capabilities.',
+    label: 'Foreground/active reassert should republish playback surfaces',
+    evaluate: ({ snapshotState, recentEvents }) => {
+      const hasReplaySignals = recentEvents.some((event) => /playback-progress|playback-state-changed/i.test(event));
+      return {
+        ok: hasReplaySignals && snapshotState !== 'idle' && snapshotState !== 'error',
+        detail: hasReplaySignals
+          ? `observed replay-related events and snapshot.state=${snapshotState}`
+          : `missing replay-related events; snapshot.state=${snapshotState}`,
+      };
+    },
+  },
+];
+
+export const classifyLifecycleCheckpoint = (step, snapshotState, recentEvents = []) => {
+  const normalizedStep = typeof step === 'string' ? step : '';
+  const normalizedState = typeof snapshotState === 'string' ? snapshotState : 'unknown';
+  const normalizedEvents = Array.isArray(recentEvents) ? recentEvents.map((event) => String(event)) : [];
+  const rule = ruleBook.find((entry) => entry.keyword === normalizedStep);
+
+  if (!rule) {
+    return {
+      label: normalizedStep || 'Unknown lifecycle checkpoint',
+      ok: false,
+      detail: `no lifecycle rule matched; snapshot.state=${normalizedState}`,
+    };
+  }
+
+  const verdict = rule.evaluate({ snapshotState: normalizedState, recentEvents: normalizedEvents });
+  return {
+    label: rule.label,
+    ok: verdict.ok,
+    detail: verdict.detail,
+  };
+};
+
+export const buildLifecycleCheckpointSummary = (checkpoints) => {
+  const lines = (Array.isArray(checkpoints) ? checkpoints : [])
+    .map((checkpoint) => {
+      const verdict = classifyLifecycleCheckpoint(
+        checkpoint?.step,
+        checkpoint?.snapshotState,
+        checkpoint?.recentEvents,
+      );
+      const icon = verdict.ok ? '✅' : '❌';
+      return `${icon} ${verdict.label} — ${verdict.detail}`;
+    });
+
+  return lines.length > 0
+    ? lines.join('\n')
+    : 'No lifecycle checkpoints captured yet. Run lifecycle evidence flow and paste checkpoints from the log.';
+};

--- a/apps/capacitor-demo/src/lifecycle-harness.test.mjs
+++ b/apps/capacitor-demo/src/lifecycle-harness.test.mjs
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildLifecycleCheckpointSummary,
+  classifyLifecycleCheckpoint,
+} from './lifecycle-harness.js';
+
+test('classifyLifecycleCheckpoint marks interruption and route expectations', () => {
+  assert.deepEqual(
+    classifyLifecycleCheckpoint('Interruption begin paused playback.', 'paused'),
+    {
+      label: 'Interruption begin should pause playback',
+      ok: true,
+      detail: 'snapshot.state=paused',
+    },
+  );
+
+  assert.deepEqual(
+    classifyLifecycleCheckpoint('Route available did not auto-resume playback.', 'paused'),
+    {
+      label: 'Route available should not auto-resume',
+      ok: true,
+      detail: 'snapshot.state=paused',
+    },
+  );
+});
+
+test('classifyLifecycleCheckpoint marks active/foreground reassert checkpoint by signal presence', () => {
+  assert.deepEqual(
+    classifyLifecycleCheckpoint(
+      'Foreground/active reassert projected metadata/progress/playback/capabilities.',
+      'playing',
+      ['event:playback-progress', 'event:playback-state-changed'],
+    ),
+    {
+      label: 'Foreground/active reassert should republish playback surfaces',
+      ok: true,
+      detail: 'observed replay-related events and snapshot.state=playing',
+    },
+  );
+});
+
+test('buildLifecycleCheckpointSummary renders compact copy-friendly lines', () => {
+  const summary = buildLifecycleCheckpointSummary([
+    {
+      step: 'Interruption begin paused playback.',
+      snapshotState: 'paused',
+      recentEvents: ['event:playback-state-changed'],
+    },
+    {
+      step: 'Foreground/active reassert projected metadata/progress/playback/capabilities.',
+      snapshotState: 'playing',
+      recentEvents: ['event:playback-progress', 'event:playback-state-changed'],
+    },
+  ]);
+
+  assert.match(summary, /✅ Interruption begin should pause playback — snapshot.state=paused/);
+  assert.match(summary, /✅ Foreground\/active reassert should republish playback surfaces — observed replay-related events and snapshot.state=playing/);
+});

--- a/apps/capacitor-demo/src/main.ts
+++ b/apps/capacitor-demo/src/main.ts
@@ -27,6 +27,9 @@ import {
   createBoundarySurfaceSnapshot,
   summarizeBoundaryValidation,
 } from './boundary-harness.js';
+import {
+  buildLifecycleCheckpointSummary,
+} from './lifecycle-harness.js';
 
 type LegatoSyncController = ReturnType<typeof createAudioPlayerSync>;
 
@@ -42,6 +45,7 @@ const remoteSeekCaseButton = document.querySelector<HTMLButtonElement>('#run-cas
 const focusDeniedCaseButton = document.querySelector<HTMLButtonElement>('#run-case-focus-denied');
 const canDuckCaseButton = document.querySelector<HTMLButtonElement>('#run-case-can-duck');
 const backgroundTransitionCaseButton = document.querySelector<HTMLButtonElement>('#run-case-background-transition');
+const iosLifecycleReassertCaseButton = document.querySelector<HTMLButtonElement>('#run-case-ios-lifecycle-reassert');
 const copyLogButton = document.querySelector<HTMLButtonElement>('#copy-log');
 const copyEventsButton = document.querySelector<HTMLButtonElement>('#copy-events');
 const copySmokeReportButton = document.querySelector<HTMLButtonElement>('#copy-smoke-report');
@@ -87,6 +91,7 @@ if (
   || !focusDeniedCaseButton
   || !canDuckCaseButton
   || !backgroundTransitionCaseButton
+  || !iosLifecycleReassertCaseButton
   || !copyLogButton
   || !copyEventsButton
   || !copySmokeReportButton
@@ -163,6 +168,7 @@ const observedSyncEvents = new Set<string>();
 let activePlaybackSurface: PlaybackSurface = 'legato';
 let boundaryChecks: BoundaryCheck[] = [];
 let syncEventHistory: SyncEventRecord[] = [];
+let lifecycleCheckpoints: Array<{ step: string; snapshotState: string; recentEvents: string[] }> = [];
 
 const resolvePlaybackApi = (surface: PlaybackSurface): AudioPlayerApi => (
   surface === 'audioPlayer' ? audioPlayer : Legato
@@ -805,6 +811,7 @@ const clearFlows = (): void => {
   logNode.value = '';
   recentEvents = [];
   syncEventHistory = [];
+  lifecycleCheckpoints = [];
   latestSmokeReport = null;
   observedSyncEvents.clear();
   renderRecentEvents();
@@ -1347,6 +1354,56 @@ const runBackgroundTransitionCaseFlow = async (): Promise<void> => {
   log('[guided-case] end | background transition coherence check');
 };
 
+const captureLifecycleCheckpoint = (step: string): void => {
+  const snapshotState = latestSnapshot?.state ?? 'unknown';
+  const recentSignals = recentEvents.slice(-8);
+  lifecycleCheckpoints = [
+    ...lifecycleCheckpoints,
+    {
+      step,
+      snapshotState,
+      recentEvents: recentSignals,
+    },
+  ];
+  log(`[lifecycle-evidence] ${step}`, {
+    snapshotState,
+    recentSignals,
+  });
+};
+
+const runIOSLifecycleReassertCaseFlow = async (): Promise<void> => {
+  await setupGuidedRemoteCaseBaseline('ios lifecycle reassert evidence');
+
+  log('[guided-case] action required: trigger and dismiss a real interruption (call/siri/navigation), then keep playback paused and return to app.');
+  await waitForCondition(
+    () => latestSnapshot?.state === 'paused',
+    guidedCaseTimeoutMs,
+  );
+  await sleep(guidedCaseSettleMs);
+  await snapshotAction('legato');
+  captureLifecycleCheckpoint('Interruption begin paused playback.');
+  captureLifecycleCheckpoint('Interruption end (shouldResume) reasserted surfaces without auto-play.');
+
+  log('[guided-case] action required: disconnect/reconnect output route (e.g. bluetooth/headphones) and keep playback paused.');
+  await waitForCondition(
+    () => latestSnapshot?.state === 'paused',
+    guidedCaseTimeoutMs,
+  );
+  await sleep(guidedCaseSettleMs);
+  await snapshotAction('legato');
+  captureLifecycleCheckpoint('Route available did not auto-resume playback.');
+
+  log('[guided-case] action required: background app for ~5s, bring to foreground, then capture snapshot for reassert evidence.');
+  await sleep(5000);
+  await snapshotAction('legato');
+  captureLifecycleCheckpoint('Foreground/active reassert projected metadata/progress/playback/capabilities.');
+
+  const lifecycleSummary = buildLifecycleCheckpointSummary(lifecycleCheckpoints);
+  boundarySummaryNode.textContent = `${boundarySummaryNode.textContent}\n\nLifecycle evidence checkpoints\n${lifecycleSummary}`;
+  snapshotJsonNode.value = JSON.stringify({ lifecycleCheckpoints }, null, 2);
+  log('[guided-case] lifecycle summary', lifecycleSummary);
+};
+
 const setPlaybackSurface = (surface: PlaybackSurface): void => {
   activePlaybackSurface = surface;
   renderBoundarySummary();
@@ -1407,6 +1464,10 @@ canDuckCaseButton.addEventListener('click', () => {
 
 backgroundTransitionCaseButton.addEventListener('click', () => {
   void runNativeAction('run guided case: background transition coherence check', runBackgroundTransitionCaseFlow);
+});
+
+iosLifecycleReassertCaseButton.addEventListener('click', () => {
+  void runNativeAction('run guided case: ios lifecycle reassert evidence', runIOSLifecycleReassertCaseFlow);
 });
 
 setupButton.addEventListener('click', () => {

--- a/docs/architecture/ios-runtime-playback-v1-scope-guardrails.md
+++ b/docs/architecture/ios-runtime-playback-v1-scope-guardrails.md
@@ -1,6 +1,7 @@
 # iOS Runtime Playback v1 — Scope Guardrails
 
 This document defines what `ios-runtime-playback-v1` is allowed to include and what MUST stay out.
+It now cross-references `ios-background-lifecycle-v1` to keep lifecycle hardening boundaries explicit.
 
 ## In Scope
 
@@ -8,15 +9,24 @@ This document defines what `ios-runtime-playback-v1` is allowed to include and w
 - Direct runtime evidence for AVPlayer-backed behavior (transport/progress/end/snapshot coherence).
 - Smoke/report checklist hardening for reproducible iOS runtime-integrity artifacts.
 - Documentation/spec cleanup where iOS runtime was still described as pending.
+- Process-alive lifecycle hardening from `ios-background-lifecycle-v1`:
+  - interruption begin/end policy hardening,
+  - selected route-change policy hardening,
+  - foreground/active reassertion of now-playing + remote-command surfaces,
+  - guided harness evidence for lifecycle checkpoints.
 
 ## Non-goals
 
 - Full background/interruption lifecycle hardening.
 - Broad Android/iOS parity expansion.
 - New end-user playback features.
+- Process-death restore/relaunch recovery.
+- Provisioning/signing/entitlements host setup.
+- Full iOS/Android lifecycle parity redesign.
 
 ## Reviewer checklist
 
 - Verify changes do not claim lifecycle/background completion.
 - Verify docs keep runtime status as implemented with explicit current limits.
 - Verify smoke evidence includes runtime-integrity payload fields.
+- Verify lifecycle hardening claims are process-alive only (no process-death restore).

--- a/native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSPlayerEngine.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSPlayerEngine.swift
@@ -25,6 +25,8 @@ public final class LegatoiOSPlayerEngine: LegatoiOSPlaybackRuntimeObserver {
     private var isSetup = false
     private var lastProgressEmission: ProgressEmissionToken?
     private var sessionSignalListenerID: UUID?
+    private var isInterruptionActive = false
+    private var isRouteUnavailable = false
 
     public init(
         queueManager: LegatoiOSQueueManager,
@@ -376,6 +378,26 @@ public final class LegatoiOSPlayerEngine: LegatoiOSPlaybackRuntimeObserver {
         sessionManager.releaseSession()
         isSetup = false
         lastProgressEmission = nil
+        isInterruptionActive = false
+        isRouteUnavailable = false
+    }
+
+    public func reassertPlaybackSurfaces() {
+        guard isSetup else {
+            return
+        }
+
+        let snapshot = snapshotStore.getPlaybackSnapshot()
+        if snapshot.currentTrack == nil && snapshot.queue.items.isEmpty {
+            return
+        }
+
+        publishMetadata(snapshot.currentTrack)
+        publishProgress(snapshot)
+        projectPlaybackState(snapshot.state)
+        remoteCommandManager.updateTransportCapabilities(
+            LegatoiOSTransportCapabilitiesProjector.fromSnapshot(snapshot)
+        )
     }
 
     public func playbackRuntimeDidUpdateProgress(_ snapshot: LegatoiOSRuntimeSnapshot) {
@@ -476,6 +498,10 @@ public final class LegatoiOSPlayerEngine: LegatoiOSPlaybackRuntimeObserver {
 
     private func publishState(_ state: LegatoiOSPlaybackState) {
         eventEmitter.emit(name: .playbackStateChanged, payload: .playbackStateChanged(state: state))
+        projectPlaybackState(state)
+    }
+
+    private func projectPlaybackState(_ state: LegatoiOSPlaybackState) {
         sessionManager.updatePlaybackState(state)
         remoteCommandManager.updatePlaybackState(state)
         nowPlayingManager.updatePlaybackState(state)
@@ -766,13 +792,22 @@ public final class LegatoiOSPlayerEngine: LegatoiOSPlaybackRuntimeObserver {
 
     private func handleSessionSignal(_ signal: LegatoiOSSessionSignal) {
         switch signal {
-        case .outputRouteRemoved, .interruptionBegan:
+        case .interruptionBegan:
+            isInterruptionActive = true
             pausePlaybackForSessionSignal()
-        case .interruptionEnded(let shouldResume):
-            if !shouldResume {
+        case .interruptionEnded(let intent):
+            isInterruptionActive = false
+            if intent != .shouldResume {
                 pausePlaybackForSessionSignal()
+            } else {
+                reassertPlaybackSurfaces()
             }
-            // Conservative behavior: interruption end with shouldResume=true does not auto-resume.
+        case .outputRouteLost:
+            isRouteUnavailable = true
+            pausePlaybackForSessionSignal()
+        case .outputRouteAvailable:
+            isRouteUnavailable = false
+            reassertPlaybackSurfaces()
         case .runtimeError(let message):
             publishSessionRuntimeError(message)
         }

--- a/native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSSessionRuntime.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSSessionRuntime.swift
@@ -1,9 +1,22 @@
 import Foundation
 
-public enum LegatoiOSSessionSignal {
+public enum LegatoiOSInterruptionResumeIntent: Equatable {
+    case shouldResume
+    case shouldNotResume
+    case unknown
+}
+
+public enum LegatoiOSRouteChangeReason: Equatable {
+    case oldDeviceUnavailable
+    case noSuitableRoute
+    case newDeviceAvailable
+}
+
+public enum LegatoiOSSessionSignal: Equatable {
     case interruptionBegan
-    case interruptionEnded(shouldResume: Bool)
-    case outputRouteRemoved
+    case interruptionEnded(intent: LegatoiOSInterruptionResumeIntent)
+    case outputRouteLost(reason: LegatoiOSRouteChangeReason)
+    case outputRouteAvailable(reason: LegatoiOSRouteChangeReason)
     case runtimeError(message: String)
 }
 

--- a/native/ios/LegatoCore/Sources/LegatoCoreSessionRuntimeiOS/LegatoiOSAVAudioSessionRuntime.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCoreSessionRuntimeiOS/LegatoiOSAVAudioSessionRuntime.swift
@@ -14,6 +14,46 @@ internal func legatoShouldActivateSession(for state: LegatoiOSPlaybackState) -> 
     }
 }
 
+internal enum LegatoiOSAVAudioSessionRawValue {
+    static let interruptionTypeEnded: UInt = 0
+    static let interruptionTypeBegan: UInt = 1
+    static let interruptionOptionShouldResume: UInt = 1 << 0
+    static let routeReasonNewDeviceAvailable: UInt = 1
+    static let routeReasonOldDeviceUnavailable: UInt = 2
+    static let routeReasonNoSuitableRoute: UInt = 7
+}
+
+internal func legatoExtractInterruptionSignal(typeRaw: UInt, optionsRaw: UInt?) -> LegatoiOSSessionSignal? {
+    switch typeRaw {
+    case LegatoiOSAVAudioSessionRawValue.interruptionTypeBegan:
+        return .interruptionBegan
+    case LegatoiOSAVAudioSessionRawValue.interruptionTypeEnded:
+        let intent: LegatoiOSInterruptionResumeIntent
+        if let optionsRaw {
+            let shouldResume = (optionsRaw & LegatoiOSAVAudioSessionRawValue.interruptionOptionShouldResume) != 0
+            intent = shouldResume ? .shouldResume : .shouldNotResume
+        } else {
+            intent = .unknown
+        }
+        return .interruptionEnded(intent: intent)
+    default:
+        return nil
+    }
+}
+
+internal func legatoExtractRouteSignal(reasonRaw: UInt) -> LegatoiOSSessionSignal? {
+    switch reasonRaw {
+    case LegatoiOSAVAudioSessionRawValue.routeReasonOldDeviceUnavailable:
+        return .outputRouteLost(reason: .oldDeviceUnavailable)
+    case LegatoiOSAVAudioSessionRawValue.routeReasonNoSuitableRoute:
+        return .outputRouteLost(reason: .noSuitableRoute)
+    case LegatoiOSAVAudioSessionRawValue.routeReasonNewDeviceAvailable:
+        return .outputRouteAvailable(reason: .newDeviceAvailable)
+    default:
+        return nil
+    }
+}
+
 #if canImport(AVFAudio) && os(iOS)
 public final class LegatoiOSAVAudioSessionRuntime: NSObject, LegatoiOSSessionRuntime {
     public var onSignal: ((LegatoiOSSessionSignal) -> Void)?
@@ -106,38 +146,23 @@ public final class LegatoiOSAVAudioSessionRuntime: NSObject, LegatoiOSSessionRun
     }
 
     private func handleInterruptionNotification(_ notification: Notification) {
-        guard
-            let typeRaw = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
-            let type = AVAudioSession.InterruptionType(rawValue: typeRaw)
-        else {
+        guard let typeRaw = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt else {
             return
         }
 
-        switch type {
-        case .began:
-            onSignal?(.interruptionBegan)
-        case .ended:
-            let optionsRaw = notification.userInfo?[AVAudioSessionInterruptionOptionKey] as? UInt ?? 0
-            let options = AVAudioSession.InterruptionOptions(rawValue: optionsRaw)
-            onSignal?(.interruptionEnded(shouldResume: options.contains(.shouldResume)))
-        @unknown default:
-            break
+        let optionsRaw = notification.userInfo?[AVAudioSessionInterruptionOptionKey] as? UInt
+        if let signal = legatoExtractInterruptionSignal(typeRaw: typeRaw, optionsRaw: optionsRaw) {
+            onSignal?(signal)
         }
     }
 
     private func handleRouteChangeNotification(_ notification: Notification) {
-        guard
-            let reasonRaw = notification.userInfo?[AVAudioSessionRouteChangeReasonKey] as? UInt,
-            let reason = AVAudioSession.RouteChangeReason(rawValue: reasonRaw)
-        else {
+        guard let reasonRaw = notification.userInfo?[AVAudioSessionRouteChangeReasonKey] as? UInt else {
             return
         }
 
-        switch reason {
-        case .oldDeviceUnavailable, .noSuitableRouteForCategory:
-            onSignal?(.outputRouteRemoved)
-        default:
-            break
+        if let signal = legatoExtractRouteSignal(reasonRaw: reasonRaw) {
+            onSignal?(signal)
         }
     }
 

--- a/native/ios/LegatoCore/Tests/LegatoCoreSessionRuntimeiOSTests/LegatoiOSAVAudioSessionRuntimeExtractionTests.swift
+++ b/native/ios/LegatoCore/Tests/LegatoCoreSessionRuntimeiOSTests/LegatoiOSAVAudioSessionRuntimeExtractionTests.swift
@@ -11,4 +11,46 @@ final class LegatoiOSAVAudioSessionRuntimeExtractionTests: XCTestCase {
         XCTAssertFalse(legatoShouldActivateSession(for: .idle))
         XCTAssertFalse(legatoShouldActivateSession(for: .error))
     }
+
+    func testInterruptionExtractionMapsBeginAndResumeIntentVariants() {
+        XCTAssertEqual(
+            legatoExtractInterruptionSignal(typeRaw: 1, optionsRaw: nil),
+            .interruptionBegan
+        )
+        XCTAssertEqual(
+            legatoExtractInterruptionSignal(typeRaw: 0, optionsRaw: 1),
+            .interruptionEnded(intent: .shouldResume)
+        )
+        XCTAssertEqual(
+            legatoExtractInterruptionSignal(typeRaw: 0, optionsRaw: 0),
+            .interruptionEnded(intent: .shouldNotResume)
+        )
+        XCTAssertEqual(
+            legatoExtractInterruptionSignal(typeRaw: 0, optionsRaw: nil),
+            .interruptionEnded(intent: .unknown)
+        )
+    }
+
+    func testInterruptionExtractionIgnoresUnknownType() {
+        XCTAssertNil(legatoExtractInterruptionSignal(typeRaw: 99, optionsRaw: nil))
+    }
+
+    func testRouteExtractionMapsLostUnavailableAndAvailableReasons() {
+        XCTAssertEqual(
+            legatoExtractRouteSignal(reasonRaw: 2),
+            .outputRouteLost(reason: .oldDeviceUnavailable)
+        )
+        XCTAssertEqual(
+            legatoExtractRouteSignal(reasonRaw: 7),
+            .outputRouteLost(reason: .noSuitableRoute)
+        )
+        XCTAssertEqual(
+            legatoExtractRouteSignal(reasonRaw: 1),
+            .outputRouteAvailable(reason: .newDeviceAvailable)
+        )
+    }
+
+    func testRouteExtractionIgnoresUnhandledReason() {
+        XCTAssertNil(legatoExtractRouteSignal(reasonRaw: 4))
+    }
 }

--- a/native/ios/LegatoCore/Tests/LegatoCoreTests/Core/LegatoiOSPlayerEngineLifecycleTests.swift
+++ b/native/ios/LegatoCore/Tests/LegatoCoreTests/Core/LegatoiOSPlayerEngineLifecycleTests.swift
@@ -1,0 +1,300 @@
+import XCTest
+@testable import LegatoCore
+
+final class LegatoiOSPlayerEngineLifecycleTests: XCTestCase {
+    func testInterruptionBeginPausesActivePlaybackAndMarksPausedState() throws {
+        let fixture = makeFixture()
+        try fixture.engine.setup()
+        try fixture.engine.load(tracks: [makeTrack(id: "track-1")], startIndex: 0)
+        try fixture.engine.play()
+
+        fixture.sessionRuntime.emit(.interruptionBegan)
+
+        XCTAssertEqual(fixture.playbackRuntime.pauseCallCount, 1)
+        XCTAssertEqual(fixture.engine.snapshot().state, .paused)
+    }
+
+    func testInterruptionEndShouldResumeReassertsWithoutAutoPlay() throws {
+        let fixture = makeFixture()
+        try fixture.engine.setup()
+        try fixture.engine.load(tracks: [makeTrack(id: "track-1")], startIndex: 0)
+        try fixture.engine.play()
+        fixture.sessionRuntime.emit(.interruptionBegan)
+
+        let playCallsBeforeEnd = fixture.playbackRuntime.playCallCount
+        let transportBeforeEnd = fixture.remoteRuntime.transportCapabilityUpdates.count
+
+        fixture.sessionRuntime.emit(.interruptionEnded(intent: .shouldResume))
+
+        XCTAssertEqual(fixture.playbackRuntime.playCallCount, playCallsBeforeEnd)
+        XCTAssertEqual(fixture.engine.snapshot().state, .paused)
+        XCTAssertEqual(fixture.remoteRuntime.transportCapabilityUpdates.count, transportBeforeEnd + 1)
+    }
+
+    func testInterruptionEndUnknownIntentKeepsPausedWithoutExtraPause() throws {
+        let fixture = makeFixture()
+        try fixture.engine.setup()
+        try fixture.engine.load(tracks: [makeTrack(id: "track-1")], startIndex: 0)
+        try fixture.engine.play()
+        fixture.sessionRuntime.emit(.interruptionBegan)
+
+        fixture.sessionRuntime.emit(.interruptionEnded(intent: .unknown))
+
+        XCTAssertEqual(fixture.playbackRuntime.pauseCallCount, 1)
+        XCTAssertEqual(fixture.engine.snapshot().state, .paused)
+    }
+
+    func testRouteLostReasonsPauseActivePlayback() throws {
+        for reason in [LegatoiOSRouteChangeReason.oldDeviceUnavailable, .noSuitableRoute] {
+            let fixture = makeFixture()
+            try fixture.engine.setup()
+            try fixture.engine.load(tracks: [makeTrack(id: "track-1")], startIndex: 0)
+            try fixture.engine.play()
+
+            fixture.sessionRuntime.emit(.outputRouteLost(reason: reason))
+
+            XCTAssertEqual(fixture.playbackRuntime.pauseCallCount, 1)
+            XCTAssertEqual(fixture.engine.snapshot().state, .paused)
+        }
+    }
+
+    func testRouteAvailableReassertsWithoutAutoResuming() throws {
+        let fixture = makeFixture()
+        try fixture.engine.setup()
+        try fixture.engine.load(tracks: [makeTrack(id: "track-1")], startIndex: 0)
+        try fixture.engine.play()
+        fixture.sessionRuntime.emit(.outputRouteLost(reason: .oldDeviceUnavailable))
+
+        let playCallsBeforeAvailable = fixture.playbackRuntime.playCallCount
+        let transportBeforeAvailable = fixture.remoteRuntime.transportCapabilityUpdates.count
+
+        fixture.sessionRuntime.emit(.outputRouteAvailable(reason: .newDeviceAvailable))
+
+        XCTAssertEqual(fixture.playbackRuntime.playCallCount, playCallsBeforeAvailable)
+        XCTAssertEqual(fixture.engine.snapshot().state, .paused)
+        XCTAssertEqual(fixture.remoteRuntime.transportCapabilityUpdates.count, transportBeforeAvailable + 1)
+    }
+
+    func testReassertPlaybackSurfacesIsNoopWithoutMediaContext() throws {
+        let fixture = makeFixture()
+        try fixture.engine.setup()
+
+        let metadataUpdatesBefore = fixture.nowPlayingRuntime.metadataUpdates.count
+        let progressUpdatesBefore = fixture.nowPlayingRuntime.progressUpdates.count
+        let stateUpdatesBefore = fixture.nowPlayingRuntime.stateUpdates.count
+        let transportBefore = fixture.remoteRuntime.transportCapabilityUpdates.count
+
+        fixture.engine.reassertPlaybackSurfaces()
+
+        XCTAssertEqual(fixture.nowPlayingRuntime.metadataUpdates.count, metadataUpdatesBefore)
+        XCTAssertEqual(fixture.nowPlayingRuntime.progressUpdates.count, progressUpdatesBefore)
+        XCTAssertEqual(fixture.nowPlayingRuntime.stateUpdates.count, stateUpdatesBefore)
+        XCTAssertEqual(fixture.remoteRuntime.transportCapabilityUpdates.count, transportBefore)
+    }
+
+    func testRepeatedReassertDoesNotEmitDuplicatePlaybackStateEvents() throws {
+        let fixture = makeFixture()
+        try fixture.engine.setup()
+        try fixture.engine.load(tracks: [makeTrack(id: "track-1")], startIndex: 0)
+
+        var reassertStateEvents = 0
+        _ = fixture.eventEmitter.addListener { event in
+            if event.name == .playbackStateChanged {
+                reassertStateEvents += 1
+            }
+        }
+
+        fixture.engine.reassertPlaybackSurfaces()
+        fixture.engine.reassertPlaybackSurfaces()
+
+        XCTAssertEqual(reassertStateEvents, 0)
+    }
+
+    private func makeFixture() -> LifecycleFixture {
+        let playbackRuntime = LifecycleFakePlaybackRuntime()
+        let sessionRuntime = LifecycleFakeSessionRuntime()
+        let nowPlayingRuntime = LifecycleSpyNowPlayingRuntime()
+        let remoteRuntime = LifecycleSpyRemoteRuntime()
+        let eventEmitter = LegatoiOSEventEmitter()
+
+        let engine = LegatoiOSPlayerEngine(
+            queueManager: LegatoiOSQueueManager(),
+            eventEmitter: eventEmitter,
+            snapshotStore: LegatoiOSSnapshotStore(),
+            trackMapper: LegatoiOSTrackMapper(),
+            errorMapper: LegatoiOSErrorMapper(),
+            stateMachine: LegatoiOSStateMachine(),
+            sessionManager: LegatoiOSSessionManager(runtime: sessionRuntime),
+            nowPlayingManager: LegatoiOSNowPlayingManager(runtime: nowPlayingRuntime),
+            remoteCommandManager: LegatoiOSRemoteCommandManager(runtime: remoteRuntime),
+            playbackRuntime: playbackRuntime
+        )
+
+        return LifecycleFixture(
+            engine: engine,
+            playbackRuntime: playbackRuntime,
+            sessionRuntime: sessionRuntime,
+            nowPlayingRuntime: nowPlayingRuntime,
+            remoteRuntime: remoteRuntime,
+            eventEmitter: eventEmitter
+        )
+    }
+
+    private func makeTrack(id: String) -> LegatoiOSTrack {
+        LegatoiOSTrack(
+            id: id,
+            url: "https://example.com/\(id).mp3",
+            title: id,
+            artist: "Legato",
+            album: "Lifecycle Fixture",
+            artwork: "https://example.com/artwork-\(id).jpg",
+            durationMs: 10_000
+        )
+    }
+}
+
+private struct LifecycleFixture {
+    let engine: LegatoiOSPlayerEngine
+    let playbackRuntime: LifecycleFakePlaybackRuntime
+    let sessionRuntime: LifecycleFakeSessionRuntime
+    let nowPlayingRuntime: LifecycleSpyNowPlayingRuntime
+    let remoteRuntime: LifecycleSpyRemoteRuntime
+    let eventEmitter: LegatoiOSEventEmitter
+}
+
+private final class LifecycleFakePlaybackRuntime: LegatoiOSPlaybackRuntime {
+    private weak var observer: LegatoiOSPlaybackRuntimeObserver?
+    private var runtimeSnapshot = LegatoiOSRuntimeSnapshot(
+        stateHint: .ready,
+        currentIndex: nil,
+        progress: LegatoiOSRuntimeProgress(positionMs: 0, durationMs: nil, bufferedPositionMs: nil)
+    )
+
+    private(set) var playCallCount = 0
+    private(set) var pauseCallCount = 0
+
+    func configure() {}
+
+    func setObserver(_ observer: LegatoiOSPlaybackRuntimeObserver?) {
+        self.observer = observer
+    }
+
+    func replaceQueue(items: [LegatoiOSRuntimeTrackSource], startIndex: Int?) throws {
+        let index = items.isEmpty ? nil : (startIndex ?? 0)
+        runtimeSnapshot = LegatoiOSRuntimeSnapshot(
+            stateHint: items.isEmpty ? .idle : .ready,
+            currentIndex: index,
+            progress: LegatoiOSRuntimeProgress(positionMs: 0, durationMs: 10_000, bufferedPositionMs: 0)
+        )
+        observer?.playbackRuntimeDidUpdateProgress(runtimeSnapshot)
+    }
+
+    func selectIndex(_ index: Int) throws {
+        runtimeSnapshot = LegatoiOSRuntimeSnapshot(
+            stateHint: runtimeSnapshot.stateHint,
+            currentIndex: index,
+            progress: LegatoiOSRuntimeProgress(positionMs: 0, durationMs: 10_000, bufferedPositionMs: 0)
+        )
+        observer?.playbackRuntimeDidUpdateProgress(runtimeSnapshot)
+    }
+
+    func play() throws {
+        playCallCount += 1
+        runtimeSnapshot = LegatoiOSRuntimeSnapshot(
+            stateHint: .playing,
+            currentIndex: runtimeSnapshot.currentIndex,
+            progress: runtimeSnapshot.progress
+        )
+        observer?.playbackRuntimeDidUpdateProgress(runtimeSnapshot)
+    }
+
+    func pause() throws {
+        pauseCallCount += 1
+        runtimeSnapshot = LegatoiOSRuntimeSnapshot(
+            stateHint: .paused,
+            currentIndex: runtimeSnapshot.currentIndex,
+            progress: runtimeSnapshot.progress
+        )
+        observer?.playbackRuntimeDidUpdateProgress(runtimeSnapshot)
+    }
+
+    func stop(resetPosition: Bool) throws {
+        runtimeSnapshot = LegatoiOSRuntimeSnapshot(
+            stateHint: .paused,
+            currentIndex: runtimeSnapshot.currentIndex,
+            progress: LegatoiOSRuntimeProgress(positionMs: 0, durationMs: runtimeSnapshot.progress.durationMs, bufferedPositionMs: 0)
+        )
+        observer?.playbackRuntimeDidUpdateProgress(runtimeSnapshot)
+    }
+
+    func seek(to positionMs: Int64) throws {
+        runtimeSnapshot = LegatoiOSRuntimeSnapshot(
+            stateHint: runtimeSnapshot.stateHint,
+            currentIndex: runtimeSnapshot.currentIndex,
+            progress: LegatoiOSRuntimeProgress(
+                positionMs: max(0, positionMs),
+                durationMs: runtimeSnapshot.progress.durationMs,
+                bufferedPositionMs: runtimeSnapshot.progress.bufferedPositionMs
+            )
+        )
+        observer?.playbackRuntimeDidUpdateProgress(runtimeSnapshot)
+    }
+
+    func snapshot() -> LegatoiOSRuntimeSnapshot {
+        runtimeSnapshot
+    }
+
+    func release() {}
+}
+
+private final class LifecycleFakeSessionRuntime: LegatoiOSSessionRuntime {
+    var onSignal: ((LegatoiOSSessionSignal) -> Void)?
+
+    func configureSession() {}
+    func updatePlaybackState(_ state: LegatoiOSPlaybackState) {}
+    func releaseSession() {}
+
+    func emit(_ signal: LegatoiOSSessionSignal) {
+        onSignal?(signal)
+    }
+}
+
+private final class LifecycleSpyNowPlayingRuntime: LegatoiOSNowPlayingRuntime {
+    private(set) var metadataUpdates: [LegatoiOSNowPlayingMetadata?] = []
+    private(set) var progressUpdates: [LegatoiOSProgressUpdate] = []
+    private(set) var stateUpdates: [LegatoiOSPlaybackState] = []
+    private(set) var clearCount = 0
+
+    func updateMetadata(_ metadata: LegatoiOSNowPlayingMetadata?) {
+        metadataUpdates.append(metadata)
+    }
+
+    func updateProgress(_ progress: LegatoiOSProgressUpdate) {
+        progressUpdates.append(progress)
+    }
+
+    func updatePlaybackState(_ state: LegatoiOSPlaybackState) {
+        stateUpdates.append(state)
+    }
+
+    func clear() {
+        clearCount += 1
+    }
+}
+
+private final class LifecycleSpyRemoteRuntime: LegatoiOSRemoteCommandRuntime {
+    private(set) var playbackStateUpdates: [LegatoiOSPlaybackState] = []
+    private(set) var transportCapabilityUpdates: [LegatoiOSTransportCapabilities] = []
+
+    func bind(dispatch: @escaping (LegatoiOSRemoteCommand) -> Void) {}
+
+    func updatePlaybackState(_ state: LegatoiOSPlaybackState) {
+        playbackStateUpdates.append(state)
+    }
+
+    func updateTransportCapabilities(_ capabilities: LegatoiOSTransportCapabilities) {
+        transportCapabilityUpdates.append(capabilities)
+    }
+
+    func unbind() {}
+}

--- a/native/ios/LegatoCore/Tests/LegatoCoreTests/Session/LegatoiOSSessionManagerTests.swift
+++ b/native/ios/LegatoCore/Tests/LegatoCoreTests/Session/LegatoiOSSessionManagerTests.swift
@@ -19,12 +19,12 @@ final class LegatoiOSSessionManagerTests: XCTestCase {
         let expectation = expectation(description: "manager forwards runtime signal")
 
         _ = manager.addSignalListener { signal in
-            if case .outputRouteRemoved = signal {
+            if case .outputRouteLost = signal {
                 expectation.fulfill()
             }
         }
 
-        runtime.emit(.outputRouteRemoved)
+        runtime.emit(.outputRouteLost(reason: .oldDeviceUnavailable))
 
         wait(for: [expectation], timeout: 0.1)
     }

--- a/packages/capacitor/ios/Sources/LegatoPlugin/LegatoPlugin.swift
+++ b/packages/capacitor/ios/Sources/LegatoPlugin/LegatoPlugin.swift
@@ -1,6 +1,9 @@
 import Capacitor
 import Foundation
 import LegatoCore
+#if canImport(UIKit)
+import UIKit
+#endif
 
 @objc(LegatoPlugin)
 public final class LegatoPlugin: CAPPlugin, CAPBridgedPlugin {
@@ -28,6 +31,8 @@ public final class LegatoPlugin: CAPPlugin, CAPBridgedPlugin {
 
     private let core = LegatoiOSCoreFactory.make()
     private var eventListenerID: UUID?
+    private var willEnterForegroundObserver: NSObjectProtocol?
+    private var didBecomeActiveObserver: NSObjectProtocol?
 
     public override func load() {
         super.load()
@@ -35,12 +40,15 @@ public final class LegatoPlugin: CAPPlugin, CAPBridgedPlugin {
         eventListenerID = core.eventEmitter.addListener { [weak self] event in
             self?.notifyListeners(event.name.rawValue, data: LegatoCapacitorMapper.payloadToDictionary(event.payload))
         }
+
+        registerLifecycleObservers()
     }
 
     deinit {
         if let eventListenerID {
             core.eventEmitter.removeListener(eventListenerID)
         }
+        unregisterLifecycleObservers()
         core.playerEngine.release()
     }
 
@@ -217,5 +225,46 @@ public final class LegatoPlugin: CAPPlugin, CAPBridgedPlugin {
             mapped = core.errorMapper.map(error)
         }
         call.reject(mapped.message, mapped.code.rawValue, error)
+    }
+
+    private func registerLifecycleObservers() {
+#if canImport(UIKit)
+        let center = NotificationCenter.default
+
+        if willEnterForegroundObserver == nil {
+            willEnterForegroundObserver = center.addObserver(
+                forName: UIApplication.willEnterForegroundNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                self?.core.playerEngine.reassertPlaybackSurfaces()
+            }
+        }
+
+        if didBecomeActiveObserver == nil {
+            didBecomeActiveObserver = center.addObserver(
+                forName: UIApplication.didBecomeActiveNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                self?.core.playerEngine.reassertPlaybackSurfaces()
+            }
+        }
+#endif
+    }
+
+    private func unregisterLifecycleObservers() {
+#if canImport(UIKit)
+        let center = NotificationCenter.default
+        if let willEnterForegroundObserver {
+            center.removeObserver(willEnterForegroundObserver)
+            self.willEnterForegroundObserver = nil
+        }
+
+        if let didBecomeActiveObserver {
+            center.removeObserver(didBecomeActiveObserver)
+            self.didBecomeActiveObserver = nil
+        }
+#endif
     }
 }


### PR DESCRIPTION
Closes #77

## Summary
- harden iOS interruption/route-change policy and process-alive lifecycle reassertion for the existing AVPlayer-based runtime
- add direct runtime and lifecycle evidence/tests for AVAudioSession extraction, engine lifecycle handling, and harness checkpoints
- update stale docs/spec wording so iOS runtime/lifecycle support is described accurately without overclaiming process-death or full parity

## Changes
| File | Change |
|------|--------|
| `native/ios/LegatoCore/Sources/LegatoCoreSessionRuntimeiOS/LegatoiOSAVAudioSessionRuntime.swift` | strengthens interruption/route extraction and lifecycle signal normalization |
| `native/ios/LegatoCore/Sources/LegatoCore/Session/LegatoiOSSessionRuntime.swift` | aligns process-alive lifecycle/session handling with the hardened runtime path |
| `native/ios/LegatoCore/Sources/LegatoCore/Core/LegatoiOSPlayerEngine.swift` | hardens interruption/route/reassert policy in the canonical engine path |
| `packages/capacitor/ios/Sources/LegatoPlugin/LegatoPlugin.swift` | wires foreground/active observer callbacks into package-specific lifecycle reassertion |
| `native/ios/LegatoCore/Tests/*` | adds direct extraction and engine lifecycle regression tests |
| `apps/capacitor-demo/src/lifecycle-harness.*`, `src/main.ts`, `index.html` | adds package-specific lifecycle evidence harness + UI wiring |
| `docs/architecture/ios-runtime-playback-v1-scope-guardrails.md`, `specs/native-core-v0.md`, `specs/task-breakdown-v0.md`, `arquitectura_cambio.md`, `apps/capacitor-demo/README.md` | refreshes stale wording and explicit scope boundaries |

## Test Plan
- [x] `swift test --filter "LegatoiOSPlayerEngineRuntimeOwnershipTests|LegatoiOSAVAudioSessionRuntimeExtractionTests|LegatoiOSPlayerEngineLifecycleTests|LegatoiOSPlayerEngineNowPlayingProjectionTests"` from `native/ios/LegatoCore`
- [x] `node --test src/lifecycle-harness.test.mjs src/smoke-verdict.test.mjs scripts/collect-ios-smoke.test.mjs scripts/validate-smoke-report.test.mjs` from `apps/capacitor-demo`
- [x] No shell scripts changed

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Docs updated where public/runtime wording changed
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers