### PR TITLE
fix(runtime): support authenticated media requests

### DIFF
--- a/apps/capacitor-demo/scripts/report-schema.mjs
+++ b/apps/capacitor-demo/scripts/report-schema.mjs
@@ -68,6 +68,48 @@ const hasParityEvidencePayload = (value) => isPlainObject(value)
   && typeof value.details.capabilities === 'string'
   && value.details.capabilities.trim() !== '';
 
+const hasRequestEvidencePayload = (value) => {
+  if (!isPlainObject(value)) {
+    return false;
+  }
+
+  if (!isPlainObject(value.byRuntime)) {
+    return false;
+  }
+
+  if (!Array.isArray(value.assertions) || !value.assertions.every((entry) => isPlainObject(entry)
+    && typeof entry.label === 'string'
+    && entry.label.trim() !== ''
+    && typeof entry.ok === 'boolean'
+    && typeof entry.detail === 'string')) {
+    return false;
+  }
+
+  for (const runtimeEntry of Object.values(value.byRuntime)) {
+    if (!isPlainObject(runtimeEntry) || !isPlainObject(runtimeEntry.byTrack)) {
+      return false;
+    }
+
+    for (const trackEntry of Object.values(runtimeEntry.byTrack)) {
+      if (!isPlainObject(trackEntry) || !Array.isArray(trackEntry.requests)) {
+        return false;
+      }
+
+      const hasValidRequests = trackEntry.requests.every((request) => isPlainObject(request)
+        && typeof request.requestUrl === 'string'
+        && request.requestUrl.trim() !== ''
+        && isPlainObject(request.requestHeaders)
+        && Object.values(request.requestHeaders).every((headerValue) => typeof headerValue === 'string'));
+
+      if (!hasValidRequests) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+};
+
 export const validateSmokeReportV1 = (candidate) => {
   const errors = [];
 
@@ -120,6 +162,10 @@ export const validateSmokeReportV1 = (candidate) => {
 
   if (!hasParityEvidencePayload(candidate.parityEvidence)) {
     errors.push('parityEvidence must include boolean checks plus non-empty details for addStartIndex/remoteOrder/eventStateSnapshot/capabilities');
+  }
+
+  if (candidate.requestEvidence !== undefined && !hasRequestEvidencePayload(candidate.requestEvidence)) {
+    errors.push('requestEvidence, when provided, must include byRuntime.byTrack request records plus assertion checks');
   }
 
   if (candidate.status === FAIL && (!Array.isArray(candidate.errors) || candidate.errors.length === 0)) {

--- a/apps/capacitor-demo/scripts/validate-smoke-report.mjs
+++ b/apps/capacitor-demo/scripts/validate-smoke-report.mjs
@@ -70,6 +70,25 @@ const evaluateArtifact = ({ path, report }) => {
     if (!hasParityEvidence) {
       failures.push(`[${platform}] ${path}: PASS reports must include parity evidence payload (add(startIndex), remote order, event/state/snapshot, capabilities).`);
     }
+
+    const requestEvidence = report?.requestEvidence;
+    const hasRequestEvidence = requestEvidence
+      && typeof requestEvidence === 'object'
+      && typeof requestEvidence.byRuntime === 'object'
+      && requestEvidence.byRuntime !== null
+      && Array.isArray(requestEvidence.assertions);
+
+    if (!hasRequestEvidence) {
+      failures.push(`[${platform}] ${path}: PASS reports must include requestEvidence payload with runtime/track request records and assertions.`);
+    } else {
+      const failingAssertions = requestEvidence.assertions
+        .filter((assertion) => assertion?.ok === false)
+        .map((assertion) => `${assertion.label}: ${assertion.detail}`);
+
+      if (failingAssertions.length > 0) {
+        failures.push(`[${platform}] ${path}: requestEvidence assertions failed: ${failingAssertions.join(' | ')}`);
+      }
+    }
   }
 
   if (report?.status === FAIL) {

--- a/apps/capacitor-demo/scripts/validate-smoke-report.test.mjs
+++ b/apps/capacitor-demo/scripts/validate-smoke-report.test.mjs
@@ -53,6 +53,42 @@ const createPassReport = (platform) => ({
       capabilities: 'getCapabilities payload matched projected transport capabilities.',
     },
   },
+  requestEvidence: {
+    byRuntime: {
+      [platform]: {
+        byTrack: {
+          'track-auth-a': {
+            requests: [
+              {
+                requestUrl: 'https://media.example.com/auth-a.m3u8',
+                requestHeaders: { Authorization: 'Bearer auth-a' },
+              },
+            ],
+          },
+          'track-public': {
+            requests: [
+              {
+                requestUrl: 'https://media.example.com/public.mp3',
+                requestHeaders: {},
+              },
+            ],
+          },
+        },
+      },
+    },
+    assertions: [
+      {
+        label: 'auth track includes authorization header',
+        ok: true,
+        detail: 'track-auth-a request carried Authorization header',
+      },
+      {
+        label: 'public track has no leaked authorization header',
+        ok: true,
+        detail: 'track-public request headers were empty',
+      },
+    ],
+  },
 });
 
 const withRuntimeIntegrity = (report) => ({
@@ -244,4 +280,37 @@ test('shared validator fails PASS artifacts when parity evidence payload is miss
   assert.equal(result.status, 'FAIL');
   assert.equal(result.platforms.android.status, 'FAIL');
   assert.match(result.failures[0], /parity.?evidence/i);
+});
+
+test('shared validator fails PASS artifacts when request evidence payload is missing', () => {
+  const reportWithoutRequestEvidence = createPassReport('android');
+  delete reportWithoutRequestEvidence.requestEvidence;
+
+  const result = validateSmokeReports([
+    { path: 'android.json', report: reportWithoutRequestEvidence },
+  ]);
+
+  assert.equal(result.status, 'FAIL');
+  assert.equal(result.platforms.android.status, 'FAIL');
+  assert.match(result.failures[0], /request.?evidence/i);
+});
+
+test('shared validator fails PASS artifacts when request evidence assertions flag leakage', () => {
+  const leakedReport = createPassReport('ios');
+  leakedReport.requestEvidence.assertions = [
+    {
+      label: 'public track has no leaked authorization header',
+      ok: false,
+      detail: 'track-public request leaked Authorization header from previous track',
+    },
+  ];
+
+  const result = validateSmokeReports([
+    { path: 'ios.json', report: leakedReport },
+  ]);
+
+  assert.equal(result.status, 'FAIL');
+  assert.equal(result.platforms.ios.status, 'FAIL');
+  assert.match(result.failures[0], /request.?evidence/i);
+  assert.match(result.failures[0], /leaked Authorization/i);
 });

--- a/apps/capacitor-demo/src/main.ts
+++ b/apps/capacitor-demo/src/main.ts
@@ -173,6 +173,29 @@ type ParityEvidencePayload = {
   };
 };
 
+type RequestEvidenceRecord = {
+  runtime: string;
+  trackId: string;
+  requestUrl: string;
+  requestHeaders: Record<string, string>;
+};
+
+type RequestEvidencePayload = {
+  byRuntime: Record<string, {
+    byTrack: Record<string, {
+      requests: Array<{
+        requestUrl: string;
+        requestHeaders: Record<string, string>;
+      }>;
+    }>;
+  }>;
+  assertions: Array<{
+    label: string;
+    ok: boolean;
+    detail: string;
+  }>;
+};
+
 let syncController: LegatoSyncController | null = null;
 let latestSnapshot: PlaybackSnapshot | null = null;
 let recentEvents: string[] = [];
@@ -186,6 +209,7 @@ let boundaryChecks: BoundaryCheck[] = [];
 let syncEventHistory: SyncEventRecord[] = [];
 let lifecycleCheckpoints: Array<{ step: string; snapshotState: string; recentEvents: string[] }> = [];
 let latestCapabilities: BindingCapabilitiesSnapshot | null = null;
+let capturedRequestEvidenceRecords: RequestEvidenceRecord[] = [];
 
 const resolvePlaybackApi = (surface: PlaybackSurface): AudioPlayerApi => (
   surface === 'audioPlayer' ? audioPlayer : Legato
@@ -200,6 +224,9 @@ const demoTracks: Track[] = [
     album: 'Legato Artwork Fixture A',
     artwork: 'https://i.pravatar.cc/300',
     duration: 12000,
+    headers: {
+      Authorization: 'Bearer demo-auth-a',
+    },
     type: 'progressive',
   },
   {
@@ -210,6 +237,7 @@ const demoTracks: Track[] = [
     album: 'Legato Artwork Fixture B',
     artwork: 'https://i.pravatar.cc/300',
     duration: 19200,
+    headers: {},
     type: 'progressive',
   },
   {
@@ -220,9 +248,18 @@ const demoTracks: Track[] = [
     album: 'Legato Artwork Fallback Fixture',
     artwork: 'https://i.pravatar.cc/300',
     duration: 9613,
+    headers: {
+      Authorization: 'Bearer demo-auth-b',
+    },
     type: 'progressive',
   },
 ];
+
+const expectedAuthHeaderByTrackId: Record<string, string | null> = {
+  'track-demo-1': 'Bearer demo-auth-a',
+  'track-demo-2': null,
+  'track-demo-3': 'Bearer demo-auth-b',
+};
 
 const expectedArtworkByTrackId: Record<string, string | null> = {
   'track-demo-1': demoTracks[0].artwork ?? null,
@@ -682,6 +719,110 @@ const deriveParityEvidencePayload = (): ParityEvidencePayload => {
   };
 };
 
+const extractRequestEvidenceRecords = (payload: unknown): RequestEvidenceRecord[] => {
+  if (!payload || typeof payload !== 'object') {
+    return [];
+  }
+
+  const payloadObject = payload as {
+    requestEvidence?: unknown;
+    records?: unknown;
+  };
+
+  const maybeRecords = Array.isArray(payloadObject.records)
+    ? payloadObject.records
+    : (payloadObject.requestEvidence as { records?: unknown } | undefined)?.records;
+
+  if (!Array.isArray(maybeRecords)) {
+    return [];
+  }
+
+  return maybeRecords
+    .filter((record) => record && typeof record === 'object')
+    .map((record) => {
+      const candidate = record as {
+        runtime?: unknown;
+        trackId?: unknown;
+        requestUrl?: unknown;
+        requestURL?: unknown;
+        requestHeaders?: unknown;
+      };
+
+      const requestHeaders = candidate.requestHeaders && typeof candidate.requestHeaders === 'object'
+        ? Object.fromEntries(Object.entries(candidate.requestHeaders as Record<string, unknown>)
+          .filter(([, headerValue]) => typeof headerValue === 'string')
+          .map(([headerKey, headerValue]) => [headerKey, String(headerValue)]))
+        : {};
+
+      return {
+        runtime: typeof candidate.runtime === 'string' ? candidate.runtime : platform,
+        trackId: typeof candidate.trackId === 'string' ? candidate.trackId : 'unknown-track',
+        requestUrl: typeof candidate.requestUrl === 'string'
+          ? candidate.requestUrl
+          : (typeof candidate.requestURL === 'string' ? candidate.requestURL : ''),
+        requestHeaders,
+      };
+    })
+    .filter((record) => record.requestUrl.trim() !== '' && record.trackId !== 'unknown-track');
+};
+
+const deriveRequestEvidencePayload = (): RequestEvidencePayload => {
+  const byRuntime: RequestEvidencePayload['byRuntime'] = {};
+
+  for (const record of capturedRequestEvidenceRecords) {
+    const runtimeKey = record.runtime || platform;
+    if (!byRuntime[runtimeKey]) {
+      byRuntime[runtimeKey] = { byTrack: {} };
+    }
+
+    if (!byRuntime[runtimeKey].byTrack[record.trackId]) {
+      byRuntime[runtimeKey].byTrack[record.trackId] = { requests: [] };
+    }
+
+    byRuntime[runtimeKey].byTrack[record.trackId].requests.push({
+      requestUrl: record.requestUrl,
+      requestHeaders: record.requestHeaders,
+    });
+  }
+
+  const runtimeKey = platform;
+  const runtimeTracks = byRuntime[runtimeKey]?.byTrack ?? {};
+  const assertions = demoTracks.map((track) => {
+    const expectedAuthorization = expectedAuthHeaderByTrackId[track.id] ?? null;
+    const requests = runtimeTracks[track.id]?.requests ?? [];
+    const observedAuthValues = requests
+      .map((request) => request.requestHeaders.Authorization)
+      .filter((value): value is string => typeof value === 'string');
+
+    if (expectedAuthorization) {
+      const ok = observedAuthValues.includes(expectedAuthorization);
+      return {
+        label: `request evidence ${track.id} includes expected Authorization header`,
+        ok,
+        detail: ok
+          ? `Observed ${observedAuthValues.length} request(s) for ${track.id} with expected Authorization value.`
+          : `Expected Authorization=${expectedAuthorization} for ${track.id}, observed=${observedAuthValues.join(', ') || 'none'}.`,
+      };
+    }
+
+    const leaked = observedAuthValues.length > 0;
+    return {
+      label: `request evidence ${track.id} does not leak Authorization header`,
+      ok: requests.length > 0 && !leaked,
+      detail: requests.length === 0
+        ? `No captured requests for ${track.id}; runtime request evidence unavailable.`
+        : leaked
+          ? `Unexpected Authorization values on public track ${track.id}: ${observedAuthValues.join(', ')}`
+          : `Observed ${requests.length} public request(s) for ${track.id} without Authorization header leakage.`,
+    };
+  });
+
+  return {
+    byRuntime,
+    assertions,
+  };
+};
+
 const startSmokeVerdict = (flow: SmokeFlow): void => {
   activeSmokeFlow = flow;
   smokeVerdict = reduceSmokeVerdict(smokeVerdict, { type: 'start', flow });
@@ -700,6 +841,7 @@ const completeSmokeVerdict = (): void => {
       recentEvents,
       runtimeIntegrity: deriveRuntimeIntegrityPayload(),
       parityEvidence: deriveParityEvidencePayload(),
+      requestEvidence: deriveRequestEvidencePayload(),
     });
     log(buildSmokeMarkerLine(latestSmokeReport));
     renderAutomationPanel();
@@ -718,6 +860,7 @@ const failSmokeVerdict = (errorSummary: string): void => {
       recentEvents,
       runtimeIntegrity: deriveRuntimeIntegrityPayload(),
       parityEvidence: deriveParityEvidencePayload(),
+      requestEvidence: deriveRequestEvidencePayload(),
     });
     log(buildSmokeMarkerLine(latestSmokeReport));
     renderAutomationPanel();
@@ -783,6 +926,13 @@ const startSync = async (): Promise<void> => {
     },
     onEvent: (eventName, payload) => {
       observedSyncEvents.add(eventName);
+      const extractedRecords = extractRequestEvidenceRecords(payload);
+      if (extractedRecords.length > 0) {
+        capturedRequestEvidenceRecords = [
+          ...capturedRequestEvidenceRecords,
+          ...extractedRecords,
+        ].slice(-160);
+      }
       const details = summarizePayload(payload);
       syncEventHistory = [
         ...syncEventHistory.slice(-95),
@@ -914,6 +1064,7 @@ const clearFlows = (): void => {
   syncEventHistory = [];
   lifecycleCheckpoints = [];
   latestSmokeReport = null;
+  capturedRequestEvidenceRecords = [];
   observedSyncEvents.clear();
   renderRecentEvents();
   renderAutomationPanel();

--- a/apps/capacitor-demo/src/smoke-report.test.mjs
+++ b/apps/capacitor-demo/src/smoke-report.test.mjs
@@ -79,6 +79,53 @@ test('SmokeReportV1 compatibility allows additive fields without breaking v1 con
   assert.deepEqual(compatibility.errors, []);
 });
 
+test('SmokeReportV1 accepts optional request evidence payload keyed by runtime + track', () => {
+  const report = buildSmokeReportV1({
+    verdict: createPassingVerdict(),
+    recentEvents: ['setup complete'],
+    requestEvidence: {
+      byRuntime: {
+        ios: {
+          byTrack: {
+            'track-auth-a': {
+              requests: [
+                {
+                  requestUrl: 'https://media.example.com/auth-a.m3u8',
+                  requestHeaders: { Authorization: 'Bearer ios-a' },
+                },
+              ],
+            },
+            'track-public': {
+              requests: [
+                {
+                  requestUrl: 'https://media.example.com/public.mp3',
+                  requestHeaders: {},
+                },
+              ],
+            },
+          },
+        },
+      },
+      assertions: [
+        {
+          label: 'auth track includes authorization header',
+          ok: true,
+          detail: 'track-auth-a request carried Authorization header',
+        },
+        {
+          label: 'public track has no leaked authorization header',
+          ok: true,
+          detail: 'track-public request did not include auth header',
+        },
+      ],
+    },
+  });
+
+  const validation = validateSmokeReportV1(report);
+  assert.equal(validation.ok, true);
+  assert.deepEqual(validation.errors, []);
+});
+
 test('SmokeReportV1 compatibility fails when required keys are removed', () => {
   const report = buildSmokeReportV1({
     verdict: createPassingVerdict(),

--- a/apps/capacitor-demo/src/smoke-verdict.d.ts
+++ b/apps/capacitor-demo/src/smoke-verdict.d.ts
@@ -48,6 +48,17 @@ export type SmokeReportV1 = {
       capabilities: string;
     };
   };
+  requestEvidence?: {
+    byRuntime: Record<string, {
+      byTrack: Record<string, {
+        requests: Array<{
+          requestUrl: string;
+          requestHeaders: Record<string, string>;
+        }>;
+      }>;
+    }>;
+    assertions: SmokeVerdictCheck[];
+  };
 };
 
 export type SmokeVerdictAction =
@@ -86,6 +97,21 @@ export function buildSmokeReportV1(input: {
       eventStateSnapshot?: string;
       capabilities?: string;
     };
+  };
+  requestEvidence?: {
+    byRuntime?: Record<string, {
+      byTrack?: Record<string, {
+        requests?: Array<{
+          requestUrl?: string;
+          requestHeaders?: Record<string, string>;
+        }>;
+      }>;
+    }>;
+    assertions?: Array<{
+      label?: string;
+      ok?: boolean;
+      detail?: string;
+    }>;
   };
 }): SmokeReportV1;
 export function reduceSmokeVerdict(state: SmokeVerdict, action: SmokeVerdictAction): SmokeVerdict;

--- a/apps/capacitor-demo/src/smoke-verdict.js
+++ b/apps/capacitor-demo/src/smoke-verdict.js
@@ -9,6 +9,8 @@ const FLOW_BOUNDARY = 'boundary';
 
 const createCheck = (label, ok, detail) => ({ label, ok, detail });
 
+const isPlainObject = (value) => typeof value === 'object' && value !== null && !Array.isArray(value);
+
 const normalizeRuntimeIntegrity = (value) => ({
   transportCommandsObserved: value?.transportCommandsObserved === true,
   progressAdvancedWhilePlaying: value?.progressAdvancedWhilePlaying === true,
@@ -42,6 +44,65 @@ const normalizeParityEvidence = (value) => ({
       : 'capabilities evidence unavailable',
   },
 });
+
+const normalizeRequestEvidence = (value) => {
+  if (!isPlainObject(value)) {
+    return {
+      byRuntime: {},
+      assertions: [],
+    };
+  }
+
+  const byRuntimeInput = isPlainObject(value.byRuntime) ? value.byRuntime : {};
+  const byRuntime = Object.fromEntries(
+    Object.entries(byRuntimeInput)
+      .filter(([, runtimeEntry]) => isPlainObject(runtimeEntry))
+      .map(([runtime, runtimeEntry]) => {
+        const byTrackInput = isPlainObject(runtimeEntry.byTrack) ? runtimeEntry.byTrack : {};
+        const byTrack = Object.fromEntries(
+          Object.entries(byTrackInput)
+            .filter(([, trackEntry]) => isPlainObject(trackEntry))
+            .map(([trackId, trackEntry]) => {
+              const requests = Array.isArray(trackEntry.requests)
+                ? trackEntry.requests
+                  .filter((request) => isPlainObject(request) && typeof request.requestUrl === 'string')
+                  .map((request) => {
+                    const inputHeaders = isPlainObject(request.requestHeaders) ? request.requestHeaders : {};
+                    const requestHeaders = Object.fromEntries(
+                      Object.entries(inputHeaders).filter(([, headerValue]) => typeof headerValue === 'string'),
+                    );
+                    return {
+                      requestUrl: request.requestUrl,
+                      requestHeaders,
+                    };
+                  })
+                : [];
+
+              return [trackId, { requests }];
+            }),
+        );
+        return [runtime, { byTrack }];
+      }),
+  );
+
+  const assertions = Array.isArray(value.assertions)
+    ? value.assertions
+      .filter((entry) => isPlainObject(entry)
+        && typeof entry.label === 'string'
+        && typeof entry.ok === 'boolean'
+        && typeof entry.detail === 'string')
+      .map((entry) => ({
+        label: entry.label,
+        ok: entry.ok,
+        detail: entry.detail,
+      }))
+    : [];
+
+  return {
+    byRuntime,
+    assertions,
+  };
+};
 
 const asNumberOrNull = (value) => (typeof value === 'number' && Number.isFinite(value) ? value : null);
 
@@ -90,6 +151,18 @@ const statusFromChecks = (checks) => {
   return checks.every((check) => check.ok) ? PASS : FAIL;
 };
 
+const createRequestEvidenceChecks = (requestEvidence) => {
+  if (!requestEvidence || !Array.isArray(requestEvidence.assertions)) {
+    return [];
+  }
+
+  return requestEvidence.assertions.map((assertion) => createCheck(
+    `request evidence: ${assertion.label}`,
+    assertion.ok === true,
+    assertion.detail,
+  ));
+};
+
 export const deriveSmokeStatusFromChecks = (checks, errorSummary = null) => {
   if (typeof errorSummary === 'string' && errorSummary.trim() !== '') {
     return FAIL;
@@ -115,19 +188,46 @@ export const createSmokeSnapshotSummary = (snapshot) => {
   return formatSnapshotSummary(metrics);
 };
 
-export const buildSmokeReportV1 = ({ verdict, recentEvents = [], runtimeIntegrity, parityEvidence }) => ({
-  schemaVersion: 1,
-  flow: 'smoke',
-  status: verdict.status === PASS ? PASS : FAIL,
-  checks: Array.isArray(verdict.checks) ? verdict.checks : [],
-  snapshotSummary: typeof verdict.snapshotSummary === 'string' ? verdict.snapshotSummary : 'No snapshot summary available.',
-  recentEvents: Array.isArray(recentEvents) ? recentEvents.filter((event) => typeof event === 'string') : [],
-  errors: verdict.status === FAIL
-    ? [verdict.errorSummary ?? 'One or more smoke checks failed.'].filter((entry) => typeof entry === 'string' && entry.trim() !== '')
-    : [],
-  runtimeIntegrity: normalizeRuntimeIntegrity(runtimeIntegrity),
-  parityEvidence: normalizeParityEvidence(parityEvidence),
-});
+export const buildSmokeReportV1 = ({ verdict, recentEvents = [], runtimeIntegrity, parityEvidence, requestEvidence }) => {
+  const hasRequestEvidence = requestEvidence !== undefined;
+  const normalizedRequestEvidence = hasRequestEvidence ? normalizeRequestEvidence(requestEvidence) : undefined;
+  const requestEvidenceChecks = hasRequestEvidence ? createRequestEvidenceChecks(normalizedRequestEvidence) : [];
+  const mergedChecks = [
+    ...(Array.isArray(verdict.checks) ? verdict.checks : []),
+    ...requestEvidenceChecks,
+  ];
+  const statusFromRequestEvidence = hasRequestEvidence ? statusFromChecks(requestEvidenceChecks) : PASS;
+  const baseStatus = verdict.status === PASS ? PASS : FAIL;
+  const finalStatus = baseStatus === PASS && statusFromRequestEvidence === PASS ? PASS : FAIL;
+  const requestEvidenceErrors = requestEvidenceChecks
+    .filter((check) => check.ok === false)
+    .map((check) => check.detail);
+
+  const report = {
+    schemaVersion: 1,
+    flow: 'smoke',
+    status: finalStatus,
+    checks: mergedChecks,
+    snapshotSummary: typeof verdict.snapshotSummary === 'string' ? verdict.snapshotSummary : 'No snapshot summary available.',
+    recentEvents: Array.isArray(recentEvents) ? recentEvents.filter((event) => typeof event === 'string') : [],
+    errors: finalStatus === FAIL
+      ? [
+        ...(baseStatus === FAIL
+          ? [verdict.errorSummary ?? 'One or more smoke checks failed.']
+          : []),
+        ...requestEvidenceErrors,
+      ].filter((entry) => typeof entry === 'string' && entry.trim() !== '')
+      : [],
+    runtimeIntegrity: normalizeRuntimeIntegrity(runtimeIntegrity),
+    parityEvidence: normalizeParityEvidence(parityEvidence),
+  };
+
+  if (normalizedRequestEvidence !== undefined) {
+    report.requestEvidence = normalizedRequestEvidence;
+  }
+
+  return report;
+};
 
 export const createInitialSmokeVerdict = () => ({
   flow: null,

--- a/apps/capacitor-demo/src/smoke-verdict.test.mjs
+++ b/apps/capacitor-demo/src/smoke-verdict.test.mjs
@@ -111,3 +111,51 @@ test('buildSmokeReportV1 includes explicit ios runtime integrity checks payload'
   assert.equal(report.runtimeIntegrity.trackEndTransitionObserved, false);
   assert.equal(report.runtimeIntegrity.snapshotProjectionCoherent, true);
 });
+
+test('buildSmokeReportV1 keeps request evidence payload keyed by runtime + track', () => {
+  const started = reduceSmokeVerdict(createInitialSmokeVerdict(), { type: 'start', flow: 'smoke' });
+  const withSnapshot = reduceSmokeVerdict(started, { type: 'snapshot', snapshot });
+  const completed = reduceSmokeVerdict(withSnapshot, { type: 'complete' });
+
+  const report = buildSmokeReportV1({
+    verdict: completed,
+    recentEvents: ['setup finished', 'smoke flow finished'],
+    requestEvidence: {
+      byRuntime: {
+        android: {
+          byTrack: {
+            'track-auth-a': {
+              requests: [
+                {
+                  requestUrl: 'https://media.example.com/auth-a.m3u8',
+                  requestHeaders: { Authorization: 'Bearer track-a' },
+                },
+              ],
+            },
+            'track-public': {
+              requests: [
+                {
+                  requestUrl: 'https://media.example.com/public.mp3',
+                  requestHeaders: {},
+                },
+              ],
+            },
+          },
+        },
+      },
+      assertions: [
+        {
+          label: 'auth track includes authorization header',
+          ok: true,
+          detail: 'track-auth-a request carried Authorization header',
+        },
+      ],
+    },
+  });
+
+  assert.equal(report.requestEvidence.byRuntime.android.byTrack['track-auth-a'].requests.length, 1);
+  assert.equal(
+    report.requestEvidence.byRuntime.android.byTrack['track-auth-a'].requests[0].requestHeaders.Authorization,
+    'Bearer track-a',
+  );
+});

--- a/docs/architecture/multi-binding-capability-map.md
+++ b/docs/architecture/multi-binding-capability-map.md
@@ -30,3 +30,10 @@
 | `apps/capacitor-demo/**` | Binding-Specific Adapter | Current | Existing host validation harness coupled to Capacitor path. |
 | `packages/react-native/.gitkeep` | Binding-Specific Adapter | Future | Placeholder only for future adapter work. |
 | `packages/flutter/legato/.gitkeep` | Binding-Specific Adapter | Future | Placeholder only for future adapter work. |
+
+## Authenticated media request support boundary (v1)
+
+- **Supported now**: static per-track `Track.headers` applied by Android/iOS native playback transport requests.
+- **Isolation contract**: request headers are bound per track and must not leak to adjacent tracks in queue transitions.
+- **Evidence contract**: smoke/report artifacts can carry request-level records keyed by runtime + track; validators consume these assertions.
+- **Deferred (non-goals in v1)**: DRM/license auth, token refresh/rotation, cookie/session renewal, dynamic auth callbacks.

--- a/native/android/core/src/main/kotlin/io/legato/core/runtime/LegatoAndroidMedia3PlaybackRuntime.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/runtime/LegatoAndroidMedia3PlaybackRuntime.kt
@@ -4,11 +4,14 @@ import android.os.Handler
 import android.os.Looper
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
 import io.legato.core.core.LegatoAndroidPlaybackState
 
 class LegatoAndroidMedia3PlaybackRuntime(
     private val player: Player? = null,
     private val playerCommandExecutor: PlayerCommandExecutor = MainThreadPlayerCommandExecutor,
+    private val requestEvidenceSink: LegatoAndroidRequestEvidenceSink = NoOpLegatoAndroidRequestEvidenceSink,
+    private val trackMediaSourceFactory: LegatoAndroidTrackMediaSourceFactory = DefaultLegatoAndroidTrackMediaSourceFactory(requestEvidenceSink),
 ) : LegatoAndroidPlaybackRuntime {
     private var listener: LegatoAndroidPlaybackRuntimeListener? = null
     private var runtimeSnapshot: LegatoAndroidRuntimeSnapshot = LegatoAndroidRuntimeSnapshot()
@@ -64,11 +67,19 @@ class LegatoAndroidMedia3PlaybackRuntime(
         }
 
         withPlayer { currentPlayer ->
-            currentPlayer.setMediaItems(
-                items.map { source -> MediaItem.fromUri(source.url) },
-                selectedIndex ?: 0,
-                0L,
-            )
+            if (currentPlayer is ExoPlayer) {
+                currentPlayer.setMediaSources(
+                    items.map { source -> trackMediaSourceFactory.create(source) },
+                    selectedIndex ?: 0,
+                    0L,
+                )
+            } else {
+                currentPlayer.setMediaItems(
+                    items.map { source -> MediaItem.fromUri(source.url) },
+                    selectedIndex ?: 0,
+                    0L,
+                )
+            }
         }
 
         runtimeSnapshot = runtimeSnapshot.copy(

--- a/native/android/core/src/main/kotlin/io/legato/core/runtime/LegatoAndroidRequestEvidence.kt
+++ b/native/android/core/src/main/kotlin/io/legato/core/runtime/LegatoAndroidRequestEvidence.kt
@@ -1,0 +1,110 @@
+package io.legato.core.runtime
+
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MimeTypes
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.datasource.ResolvingDataSource
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.exoplayer.source.MediaSource
+import io.legato.core.core.LegatoAndroidTrackType
+
+data class RequestEvidenceRecord(
+    val runtime: String,
+    val trackId: String,
+    val requestUrl: String,
+    val requestHeaders: Map<String, String>,
+)
+
+fun interface LegatoAndroidRequestEvidenceSink {
+    fun record(record: RequestEvidenceRecord)
+}
+
+object NoOpLegatoAndroidRequestEvidenceSink : LegatoAndroidRequestEvidenceSink {
+    override fun record(record: RequestEvidenceRecord) = Unit
+}
+
+class RecordingLegatoAndroidRequestEvidenceSink : LegatoAndroidRequestEvidenceSink {
+    private val mutableRecords = mutableListOf<RequestEvidenceRecord>()
+
+    val records: List<RequestEvidenceRecord>
+        get() = synchronized(this) { mutableRecords.toList() }
+
+    override fun record(record: RequestEvidenceRecord) {
+        synchronized(this) {
+            mutableRecords += record
+        }
+    }
+}
+
+class LegatoAndroidTrackRequestTransformer(
+    private val trackId: String,
+    private val trackHeaders: Map<String, String>,
+    private val evidenceSink: LegatoAndroidRequestEvidenceSink,
+) {
+    fun transform(requestUrl: String, existingHeaders: Map<String, String>): Map<String, String> {
+        val mergedHeaders = if (trackHeaders.isEmpty()) {
+            existingHeaders
+        } else {
+            existingHeaders + trackHeaders
+        }
+
+        evidenceSink.record(
+            RequestEvidenceRecord(
+                runtime = "android",
+                trackId = trackId,
+                requestUrl = requestUrl,
+                requestHeaders = mergedHeaders,
+            ),
+        )
+
+        return mergedHeaders
+    }
+
+    fun apply(dataSpec: DataSpec): DataSpec {
+        val mergedHeaders = transform(dataSpec.uri.toString(), dataSpec.httpRequestHeaders)
+
+        if (mergedHeaders == dataSpec.httpRequestHeaders) {
+            return dataSpec
+        }
+
+        return dataSpec.withRequestHeaders(mergedHeaders)
+    }
+}
+
+interface LegatoAndroidTrackMediaSourceFactory {
+    fun create(source: LegatoAndroidRuntimeTrackSource): MediaSource
+}
+
+class DefaultLegatoAndroidTrackMediaSourceFactory(
+    private val evidenceSink: LegatoAndroidRequestEvidenceSink,
+) : LegatoAndroidTrackMediaSourceFactory {
+    override fun create(source: LegatoAndroidRuntimeTrackSource): MediaSource {
+        val requestTransformer = LegatoAndroidTrackRequestTransformer(
+            trackId = source.id,
+            trackHeaders = source.headers,
+            evidenceSink = evidenceSink,
+        )
+
+        val dataSourceFactory = ResolvingDataSource.Factory(DefaultHttpDataSource.Factory()) { dataSpec ->
+            requestTransformer.apply(dataSpec)
+        }
+
+        val mediaItem = MediaItem.Builder()
+            .setMediaId(source.id)
+            .setUri(source.url)
+            .setMimeType(resolveMimeType(source.type))
+            .build()
+
+        return DefaultMediaSourceFactory(dataSourceFactory).createMediaSource(mediaItem)
+    }
+
+    private fun resolveMimeType(type: LegatoAndroidTrackType?): String? = when (type) {
+        LegatoAndroidTrackType.HLS -> MimeTypes.APPLICATION_M3U8
+        LegatoAndroidTrackType.DASH -> MimeTypes.APPLICATION_MPD
+        LegatoAndroidTrackType.PROGRESSIVE,
+        LegatoAndroidTrackType.FILE,
+        null,
+        -> null
+    }
+}

--- a/native/android/core/src/test/kotlin/io/legato/core/runtime/LegatoAndroidMedia3PlaybackRuntimeTest.kt
+++ b/native/android/core/src/test/kotlin/io/legato/core/runtime/LegatoAndroidMedia3PlaybackRuntimeTest.kt
@@ -9,6 +9,10 @@ import org.junit.Test
 import java.lang.reflect.InvocationHandler
 import java.lang.reflect.Proxy
 
+private const val AUTH_HEADER = "Authorization"
+private const val AUTH_VALUE_A = "Bearer track-a"
+private const val AUTH_VALUE_B = "Bearer track-b"
+
 class LegatoAndroidMedia3PlaybackRuntimeTest {
     @Test
     fun `dispatch progress updates snapshot and emits callback`() {
@@ -133,6 +137,88 @@ class LegatoAndroidMedia3PlaybackRuntimeTest {
         val snapshot = runtime.snapshot()
         assertEquals(null, snapshot.currentIndex)
         assertEquals(0L, snapshot.progress.positionMs)
+    }
+
+    @Test
+    fun `track request transformer injects configured headers and records evidence`() {
+        val sink = RecordingLegatoAndroidRequestEvidenceSink()
+        val transformer = LegatoAndroidTrackRequestTransformer(
+            trackId = "track-auth",
+            trackHeaders = mapOf(AUTH_HEADER to AUTH_VALUE_A),
+            evidenceSink = sink,
+        )
+
+        val transformed = transformer.transform(
+            requestUrl = "https://media.example.com/auth-a.m3u8",
+            existingHeaders = emptyMap(),
+        )
+
+        assertEquals(AUTH_VALUE_A, transformed[AUTH_HEADER])
+        assertEquals(1, sink.records.size)
+        assertEquals("android", sink.records.first().runtime)
+        assertEquals("track-auth", sink.records.first().trackId)
+        assertEquals(AUTH_VALUE_A, sink.records.first().requestHeaders[AUTH_HEADER])
+    }
+
+    @Test
+    fun `track request transformer with empty headers does not inject synthetic auth`() {
+        val sink = RecordingLegatoAndroidRequestEvidenceSink()
+        val transformer = LegatoAndroidTrackRequestTransformer(
+            trackId = "track-public",
+            trackHeaders = emptyMap(),
+            evidenceSink = sink,
+        )
+
+        val transformed = transformer.transform(
+            requestUrl = "https://media.example.com/public.mp3",
+            existingHeaders = emptyMap(),
+        )
+
+        assertTrue(transformed.isEmpty())
+        assertEquals(1, sink.records.size)
+        assertTrue(sink.records.first().requestHeaders.isEmpty())
+    }
+
+    @Test
+    fun `track request transformers keep headers isolated across queue transitions`() {
+        val sink = RecordingLegatoAndroidRequestEvidenceSink()
+        val authTrackTransformer = LegatoAndroidTrackRequestTransformer(
+            trackId = "track-auth-a",
+            trackHeaders = mapOf(AUTH_HEADER to AUTH_VALUE_A),
+            evidenceSink = sink,
+        )
+        val publicTrackTransformer = LegatoAndroidTrackRequestTransformer(
+            trackId = "track-public",
+            trackHeaders = emptyMap(),
+            evidenceSink = sink,
+        )
+        val secondAuthTrackTransformer = LegatoAndroidTrackRequestTransformer(
+            trackId = "track-auth-b",
+            trackHeaders = mapOf(AUTH_HEADER to AUTH_VALUE_B),
+            evidenceSink = sink,
+        )
+
+        val authRequest = authTrackTransformer.transform(
+            requestUrl = "https://media.example.com/auth-a.m3u8",
+            existingHeaders = emptyMap(),
+        )
+        val publicRequest = publicTrackTransformer.transform(
+            requestUrl = "https://media.example.com/public.mp3",
+            existingHeaders = emptyMap(),
+        )
+        val secondAuthRequest = secondAuthTrackTransformer.transform(
+            requestUrl = "https://media.example.com/auth-b.m3u8",
+            existingHeaders = emptyMap(),
+        )
+
+        assertEquals(AUTH_VALUE_A, authRequest[AUTH_HEADER])
+        assertTrue(publicRequest.isEmpty())
+        assertEquals(AUTH_VALUE_B, secondAuthRequest[AUTH_HEADER])
+
+        assertEquals(3, sink.records.size)
+        assertEquals(AUTH_VALUE_A, sink.records[0].requestHeaders[AUTH_HEADER])
+        assertTrue(sink.records[1].requestHeaders.isEmpty())
+        assertEquals(AUTH_VALUE_B, sink.records[2].requestHeaders[AUTH_HEADER])
     }
 }
 

--- a/native/ios/LegatoCore/Sources/LegatoCore/Runtime/LegatoiOSAssetRequestLoader.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCore/Runtime/LegatoiOSAssetRequestLoader.swift
@@ -1,0 +1,174 @@
+import AVFoundation
+import Foundation
+
+public struct LegatoiOSRequestEvidenceRecord: Sendable {
+    public let runtime: String
+    public let trackId: String
+    public let requestURL: String
+    public let requestHeaders: [String: String]
+
+    public init(runtime: String, trackId: String, requestURL: String, requestHeaders: [String: String]) {
+        self.runtime = runtime
+        self.trackId = trackId
+        self.requestURL = requestURL
+        self.requestHeaders = requestHeaders
+    }
+}
+
+public protocol LegatoiOSRequestEvidenceSink {
+    func record(_ record: LegatoiOSRequestEvidenceRecord)
+}
+
+public final class LegatoiOSNoOpRequestEvidenceSink: LegatoiOSRequestEvidenceSink {
+    public init() {}
+    public func record(_ record: LegatoiOSRequestEvidenceRecord) {}
+}
+
+public final class LegatoiOSRecordingRequestEvidenceSink: LegatoiOSRequestEvidenceSink {
+    private let lock = NSLock()
+    private var mutableRecords: [LegatoiOSRequestEvidenceRecord] = []
+
+    public init() {}
+
+    public var records: [LegatoiOSRequestEvidenceRecord] {
+        lock.lock()
+        defer { lock.unlock() }
+        return mutableRecords
+    }
+
+    public func record(_ record: LegatoiOSRequestEvidenceRecord) {
+        lock.lock()
+        mutableRecords.append(record)
+        lock.unlock()
+    }
+}
+
+public protocol LegatoiOSAssetRequestLoaderFactory {
+    func make(
+        trackId: String,
+        headers: [String: String],
+        evidenceSink: LegatoiOSRequestEvidenceSink
+    ) -> LegatoiOSAssetRequestLoaderContext
+}
+
+public protocol LegatoiOSAssetRequestLoaderContext: AnyObject {
+    var trackId: String { get }
+    func makePlayerItem(url: URL) throws -> AVPlayerItem
+    func dispose()
+}
+
+public final class LegatoiOSDefaultAssetRequestLoaderFactory: LegatoiOSAssetRequestLoaderFactory {
+    public init() {}
+
+    public func make(
+        trackId: String,
+        headers: [String: String],
+        evidenceSink: LegatoiOSRequestEvidenceSink
+    ) -> LegatoiOSAssetRequestLoaderContext {
+        LegatoiOSAssetRequestLoaderContextImpl(trackId: trackId, headers: headers, evidenceSink: evidenceSink)
+    }
+}
+
+private final class LegatoiOSAssetRequestLoaderContextImpl: NSObject, LegatoiOSAssetRequestLoaderContext, AVAssetResourceLoaderDelegate {
+    let trackId: String
+    private let headers: [String: String]
+    private let evidenceSink: LegatoiOSRequestEvidenceSink
+
+    init(trackId: String, headers: [String: String], evidenceSink: LegatoiOSRequestEvidenceSink) {
+        self.trackId = trackId
+        self.headers = headers
+        self.evidenceSink = evidenceSink
+        super.init()
+    }
+
+    func makePlayerItem(url: URL) throws -> AVPlayerItem {
+        let proxiedURL = LegatoiOSAssetRequestProxyURL.wrap(url)
+        let asset = AVURLAsset(url: proxiedURL)
+        asset.resourceLoader.setDelegate(self, queue: .main)
+        return AVPlayerItem(asset: asset)
+    }
+
+    func dispose() {}
+
+    func resourceLoader(
+        _ resourceLoader: AVAssetResourceLoader,
+        shouldWaitForLoadingOfRequestedResource loadingRequest: AVAssetResourceLoadingRequest
+    ) -> Bool {
+        guard let incomingURL = loadingRequest.request.url,
+              let targetURL = LegatoiOSAssetRequestProxyURL.unwrap(incomingURL)
+        else {
+            loadingRequest.finishLoading(with: LegatoiOSError(code: .playbackFailed, message: "Invalid proxied URL"))
+            return true
+        }
+
+        evidenceSink.record(
+            LegatoiOSRequestEvidenceRecord(
+                runtime: "ios",
+                trackId: trackId,
+                requestURL: targetURL.absoluteString,
+                requestHeaders: headers
+            )
+        )
+
+        var request = URLRequest(url: targetURL)
+        headers.forEach { key, value in request.setValue(value, forHTTPHeaderField: key) }
+
+        URLSession.shared.dataTask(with: request) { [weak loadingRequest] data, response, error in
+            guard let loadingRequest else {
+                return
+            }
+
+            if let error {
+                loadingRequest.finishLoading(with: error)
+                return
+            }
+
+            if let response {
+                loadingRequest.response = response
+            }
+
+            if let data {
+                loadingRequest.dataRequest?.respond(with: data)
+            }
+            loadingRequest.finishLoading()
+        }.resume()
+
+        return true
+    }
+
+    func resourceLoader(
+        _ resourceLoader: AVAssetResourceLoader,
+        didCancel loadingRequest: AVAssetResourceLoadingRequest
+    ) {
+        loadingRequest.finishLoading(with: LegatoiOSError(code: .playbackFailed, message: "Resource loading cancelled"))
+    }
+}
+
+private enum LegatoiOSAssetRequestProxyURL {
+    private static let scheme = "legato-proxy"
+    private static let targetQueryKey = "target"
+
+    static func wrap(_ url: URL) -> URL {
+        var components = URLComponents()
+        components.scheme = scheme
+        components.host = "request"
+        components.path = "/asset"
+        components.queryItems = [
+            URLQueryItem(name: targetQueryKey, value: url.absoluteString),
+        ]
+
+        return components.url ?? url
+    }
+
+    static func unwrap(_ url: URL) -> URL? {
+        guard url.scheme == scheme,
+              let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let encodedTarget = components.queryItems?.first(where: { $0.name == targetQueryKey })?.value,
+              let target = URL(string: encodedTarget)
+        else {
+            return nil
+        }
+
+        return target
+    }
+}

--- a/native/ios/LegatoCore/Sources/LegatoCore/Runtime/LegatoiOSPlaybackRuntime.swift
+++ b/native/ios/LegatoCore/Sources/LegatoCore/Runtime/LegatoiOSPlaybackRuntime.swift
@@ -140,6 +140,8 @@ public final class LegatoiOSNoopPlaybackRuntime: LegatoiOSPlaybackRuntime {
 /// - no interruptions/remote command orchestration
 public final class LegatoiOSAVPlayerPlaybackRuntime: LegatoiOSPlaybackRuntime {
     private let player: AVPlayer
+    private let assetRequestLoaderFactory: LegatoiOSAssetRequestLoaderFactory
+    private let requestEvidenceSink: LegatoiOSRequestEvidenceSink
     private var trackSources: [LegatoiOSRuntimeTrackSource] = []
     private var currentIndex: Int?
     private weak var observer: LegatoiOSPlaybackRuntimeObserver?
@@ -150,9 +152,20 @@ public final class LegatoiOSAVPlayerPlaybackRuntime: LegatoiOSPlaybackRuntime {
     private var currentItemStatusObservation: NSKeyValueObservation?
     private var didEmitEndForCurrentItem = false
     private var didReceivePlayForCurrentItem = false
+    private var activeRequestLoaderContext: LegatoiOSAssetRequestLoaderContext?
 
-    public init(player: AVPlayer = AVPlayer()) {
+    public init(
+        player: AVPlayer = AVPlayer(),
+        assetRequestLoaderFactory: LegatoiOSAssetRequestLoaderFactory = LegatoiOSDefaultAssetRequestLoaderFactory(),
+        requestEvidenceSink: LegatoiOSRequestEvidenceSink = LegatoiOSNoOpRequestEvidenceSink()
+    ) {
         self.player = player
+        self.assetRequestLoaderFactory = assetRequestLoaderFactory
+        self.requestEvidenceSink = requestEvidenceSink
+    }
+
+    var activeRequestLoaderTrackId: String? {
+        activeRequestLoaderContext?.trackId
     }
 
     public func configure() {
@@ -169,6 +182,7 @@ public final class LegatoiOSAVPlayerPlaybackRuntime: LegatoiOSPlaybackRuntime {
         trackSources = items
 
         guard !items.isEmpty else {
+            disposeActiveRequestLoaderContext()
             currentIndex = nil
             player.replaceCurrentItem(with: nil)
             didEmitEndForCurrentItem = false
@@ -269,6 +283,7 @@ public final class LegatoiOSAVPlayerPlaybackRuntime: LegatoiOSPlaybackRuntime {
         currentItemStatusObservation = nil
 
         observer = nil
+        disposeActiveRequestLoaderContext()
         player.pause()
         player.replaceCurrentItem(with: nil)
         trackSources = []
@@ -287,16 +302,31 @@ public final class LegatoiOSAVPlayerPlaybackRuntime: LegatoiOSPlaybackRuntime {
             throw LegatoiOSError(code: .invalidURL, message: "Track URL is invalid: \(source.url)")
         }
 
-        // Keep the audible-playback MVP on public AVFoundation APIs only.
-        // Demo smoke URLs currently do not require custom headers.
-        let asset = AVURLAsset(url: url)
-        let item = AVPlayerItem(asset: asset)
+        disposeActiveRequestLoaderContext()
+        let item: AVPlayerItem
+        if source.headers.isEmpty {
+            let asset = AVURLAsset(url: url)
+            item = AVPlayerItem(asset: asset)
+        } else {
+            let context = assetRequestLoaderFactory.make(
+                trackId: source.id,
+                headers: source.headers,
+                evidenceSink: requestEvidenceSink
+            )
+            item = try context.makePlayerItem(url: url)
+            activeRequestLoaderContext = context
+        }
 
         player.replaceCurrentItem(with: item)
         currentIndex = index
         didEmitEndForCurrentItem = false
         didReceivePlayForCurrentItem = false
         publishSnapshotUpdate()
+    }
+
+    private func disposeActiveRequestLoaderContext() {
+        activeRequestLoaderContext?.dispose()
+        activeRequestLoaderContext = nil
     }
 
     private func installPeriodicTimeObserverIfNeeded() {

--- a/native/ios/LegatoCore/Tests/LegatoCoreTests/Runtime/LegatoiOSAVPlayerPlaybackRuntimeTests.swift
+++ b/native/ios/LegatoCore/Tests/LegatoCoreTests/Runtime/LegatoiOSAVPlayerPlaybackRuntimeTests.swift
@@ -65,17 +65,104 @@ final class LegatoiOSAVPlayerPlaybackRuntimeTests: XCTestCase {
         XCTAssertEqual(observer.trackEndSnapshots.first?.currentIndex, 0)
     }
 
-    private func makeSource(id: String) -> LegatoiOSRuntimeTrackSource {
+    func testHeaderBearingTrackUsesAssetRequestLoaderContext() throws {
+        let player = AVPlayer()
+        let factory = AssetRequestLoaderFactorySpy()
+        let runtime = LegatoiOSAVPlayerPlaybackRuntime(
+            player: player,
+            assetRequestLoaderFactory: factory,
+            requestEvidenceSink: LegatoiOSRecordingRequestEvidenceSink()
+        )
+        runtime.configure()
+
+        try runtime.replaceQueue(items: [makeSource(id: "track-auth", headers: ["Authorization": "Bearer track-auth"])], startIndex: 0)
+
+        XCTAssertEqual(factory.createdContexts.count, 1)
+        XCTAssertEqual(factory.createdContexts.first?.trackId, "track-auth")
+        XCTAssertEqual(factory.createdContexts.first?.headers["Authorization"], "Bearer track-auth")
+        XCTAssertEqual(runtime.activeRequestLoaderTrackId, "track-auth")
+    }
+
+    func testNoHeaderTrackKeepsPlainAssetPathAndDisposesPreviousLoaderContext() throws {
+        let player = AVPlayer()
+        let factory = AssetRequestLoaderFactorySpy()
+        let runtime = LegatoiOSAVPlayerPlaybackRuntime(
+            player: player,
+            assetRequestLoaderFactory: factory,
+            requestEvidenceSink: LegatoiOSRecordingRequestEvidenceSink()
+        )
+        runtime.configure()
+
+        try runtime.replaceQueue(items: [makeSource(id: "track-auth", headers: ["Authorization": "Bearer track-auth"])], startIndex: 0)
+        let firstContext = try XCTUnwrap(factory.createdContexts.first)
+        try runtime.replaceQueue(items: [makeSource(id: "track-public", headers: [:])], startIndex: 0)
+
+        XCTAssertEqual(factory.createdContexts.count, 1)
+        XCTAssertTrue(firstContext.didDispose)
+        XCTAssertNil(runtime.activeRequestLoaderTrackId)
+    }
+
+    func testQueueTransitionBetweenAuthenticatedTracksDisposesPreviousContextAndKeepsHeadersDistinct() throws {
+        let player = AVPlayer()
+        let factory = AssetRequestLoaderFactorySpy()
+        let runtime = LegatoiOSAVPlayerPlaybackRuntime(
+            player: player,
+            assetRequestLoaderFactory: factory,
+            requestEvidenceSink: LegatoiOSRecordingRequestEvidenceSink()
+        )
+        runtime.configure()
+
+        try runtime.replaceQueue(items: [makeSource(id: "track-auth-a", headers: ["Authorization": "Bearer A"])], startIndex: 0)
+        let firstContext = try XCTUnwrap(factory.createdContexts.first)
+        try runtime.replaceQueue(items: [makeSource(id: "track-auth-b", headers: ["Authorization": "Bearer B"])], startIndex: 0)
+        let secondContext = try XCTUnwrap(factory.createdContexts.last)
+
+        XCTAssertEqual(factory.createdContexts.count, 2)
+        XCTAssertTrue(firstContext.didDispose)
+        XCTAssertEqual(secondContext.headers["Authorization"], "Bearer B")
+        XCTAssertEqual(runtime.activeRequestLoaderTrackId, "track-auth-b")
+    }
+
+    private func makeSource(id: String, headers: [String: String] = [:]) -> LegatoiOSRuntimeTrackSource {
         LegatoiOSRuntimeTrackSource(
             id: id,
             url: "https://samplelib.com/mp3/sample-12s.mp3",
-            headers: [:],
+            headers: headers,
             type: .progressive
         )
     }
 
     private func runMainLoopPulse() {
         RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+    }
+}
+
+private final class AssetRequestLoaderFactorySpy: LegatoiOSAssetRequestLoaderFactory {
+    private(set) var createdContexts: [AssetRequestLoaderContextSpy] = []
+
+    func make(trackId: String, headers: [String : String], evidenceSink: LegatoiOSRequestEvidenceSink) -> LegatoiOSAssetRequestLoaderContext {
+        let context = AssetRequestLoaderContextSpy(trackId: trackId, headers: headers)
+        createdContexts.append(context)
+        return context
+    }
+}
+
+private final class AssetRequestLoaderContextSpy: LegatoiOSAssetRequestLoaderContext {
+    let trackId: String
+    let headers: [String: String]
+    private(set) var didDispose = false
+
+    init(trackId: String, headers: [String: String]) {
+        self.trackId = trackId
+        self.headers = headers
+    }
+
+    func makePlayerItem(url: URL) throws -> AVPlayerItem {
+        AVPlayerItem(url: url)
+    }
+
+    func dispose() {
+        didDispose = true
     }
 }
 

--- a/packages/capacitor/README.md
+++ b/packages/capacitor/README.md
@@ -95,6 +95,19 @@ Compatibility-only (legacy Legato facade): `Legato`, `createLegatoSync`, `LEGATO
 - Android-only telemetry like `playback-interruption` remains intentionally deferred from cross-platform parity assertions in v1.
 - Deep lifecycle/process-death parity redesign is out of scope for this change and tracked as follow-up work.
 
+### Authenticated media request scope (v1)
+
+- `Track.headers` supports **static per-track** HTTP headers for native playback transport requests on Android and iOS.
+- Mixed queues are supported: each track keeps its own header map and must not leak headers across transitions.
+- Validation evidence is request-level (captured request records), not playback-state-only.
+
+Explicit v1 non-goals:
+
+- DRM/license authentication flows.
+- Token refresh/rotation and expiry callbacks.
+- Cookie/session renewal orchestration.
+- Dynamic per-request auth callback hooks.
+
 ```ts
 import {
   addAudioPlayerListener,

--- a/packages/contract/src/track.ts
+++ b/packages/contract/src/track.ts
@@ -10,6 +10,18 @@ export interface Track {
   album?: string;
   artwork?: string;
   duration?: number;
+  /**
+   * Static per-track HTTP headers used by native playback transport.
+   *
+   * v1 support scope:
+   * - Applied by Android/iOS runtime media requests for this track.
+   * - Isolated per track (headers are not shared across queue transitions).
+   *
+   * v1 non-goals:
+   * - DRM/license request auth flows.
+   * - Token refresh/rotation or dynamic auth callbacks.
+   * - Cookie/session renewal orchestration.
+   */
   headers?: Record<string, string>;
   type?: TrackType;
 }


### PR DESCRIPTION
Closes #104

## Summary
- honor static per-track request headers in real Android and iOS playback transports
- add request-level evidence and leakage detection to smoke report/validator contracts
- document the supported v1 auth scope clearly while keeping DRM/refresh/cookie orchestration out of scope

## Changes
| File | Change |
|------|--------|
| `native/android/core/src/main/kotlin/io/legato/core/runtime/LegatoAndroidMedia3PlaybackRuntime.kt` | applies per-track headers in the Media3 request pipeline |
| `native/android/core/src/main/kotlin/io/legato/core/runtime/LegatoAndroidRequestEvidence.kt` | adds Android request-evidence capture primitives |
| `native/android/core/src/test/kotlin/io/legato/core/runtime/LegatoAndroidMedia3PlaybackRuntimeTest.kt` | proves header application and no-leakage behavior on Android |
| `native/ios/LegatoCore/Sources/LegatoCore/Runtime/LegatoiOSAssetRequestLoader.swift` | adds asset-scoped request forwarding for header-bearing tracks |
| `native/ios/LegatoCore/Sources/LegatoCore/Runtime/LegatoiOSPlaybackRuntime.swift` | routes iOS header-bearing playback through the request loader context |
| `native/ios/LegatoCore/Tests/LegatoCoreTests/Runtime/LegatoiOSAVPlayerPlaybackRuntimeTests.swift` | proves header-bearing and no-leakage behavior on iOS |
| `apps/capacitor-demo/src/smoke-verdict.*`, `scripts/report-schema.mjs`, `scripts/validate-smoke-report*`, `src/smoke-report.test.mjs`, `src/main.ts` | adds request-evidence payloads and validator enforcement |
| `packages/contract/src/track.ts`, `packages/capacitor/README.md`, `docs/architecture/multi-binding-capability-map.md` | clarify supported static-header scope and explicit non-goals |

## Test Plan
- [x] `node --test apps/capacitor-demo/src/smoke-verdict.test.mjs apps/capacitor-demo/src/smoke-report.test.mjs apps/capacitor-demo/scripts/validate-smoke-report.test.mjs apps/capacitor-demo/scripts/collect-android-smoke.test.mjs apps/capacitor-demo/scripts/collect-ios-smoke.test.mjs`
- [x] `gradle testDebugUnitTest --tests "io.legato.core.runtime.LegatoAndroidMedia3PlaybackRuntimeTest"` from `native/android/core`
- [x] `swift test --filter "LegatoiOSAVPlayerPlaybackRuntimeTests"` from `native/ios/LegatoCore`
- [x] No shell scripts changed

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Docs updated where public support semantics changed
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers