### PR TITLE
docs(api): complete public JSDoc coverage

### DIFF
--- a/docs/maintainers/package-documentation-foundation-v1-source-map.md
+++ b/docs/maintainers/package-documentation-foundation-v1-source-map.md
@@ -2,6 +2,22 @@
 
 Verified documentation claims MUST map to source files below.
 
+## JSDoc completeness validator ownership
+
+Source: `packages/capacitor/scripts/assert-package-entries.mjs`
+
+- `collectRootExportInventory` resolves root exports from each package `src/index.ts` using TypeScript symbol resolution.
+- `validateDeclarationJsdocCoverage` validates retained docs in emitted `dist/index.d.ts` and linked declaration files.
+- Failure output includes `symbol`, `category`, `declFile`, `sourceFile`, and `missing[]` fields.
+- `sourceFile` comes from `.d.ts.map` sources when available.
+
+Allowed evidence sources for public API documentation claims:
+
+- Public type signatures in `packages/*/src/**/*.ts`.
+- Runtime behavior directly observable in `packages/capacitor/src/{plugin,events,sync}.ts`.
+- Contract semantics and invariants in `packages/contract/src/**/*.ts`.
+- Existing maintainer source-map files under `docs/maintainers/`.
+
 ## Contract package export map
 
 Source: `packages/contract/src/index.ts`
@@ -22,6 +38,13 @@ Source: `packages/contract/package.json`
 - Public package boundary is root-only via `exports["."]`.
 - Undocumented deep import subpaths are intentionally unsupported.
 
+Triage flow for JSDoc readiness failures in contract package:
+
+1. Run `npm run build && npm run readiness:entries` in `packages/contract`.
+2. Read failing `symbol`/`missing[]` entries.
+3. Open `sourceFile` from failure output and add source-backed JSDoc.
+4. Rebuild and rerun readiness until `documentedSymbols === totalSymbols`.
+
 Source: `apps/capacitor-demo/scripts/run-external-consumer-validation.mjs`
 
 - Packed/runtime proof executes `import('@ddgutierrezc/legato-contract')` and requires success.
@@ -39,6 +62,13 @@ Source: `packages/capacitor/src/index.ts`
 Source: `packages/capacitor/src/plugin.ts`
 
 - Confirms `audioPlayer` and `mediaSession` boundaries route through shared plugin delegate.
+
+Triage flow for JSDoc readiness failures in capacitor package:
+
+1. Run `npm run build && npm run readiness:entries` in `packages/capacitor`.
+2. Use failure `declFile`/`sourceFile` to locate missing docs.
+3. Update source JSDoc in `src/{definitions,plugin,events,sync}.ts` or contract aliases exposed through `definitions.ts`.
+4. Rebuild and rerun readiness until `documentedSymbols === totalSymbols`.
 
 ## CLI command map
 

--- a/docs/maintainers/public-api-jsdoc-completeness-v1.md
+++ b/docs/maintainers/public-api-jsdoc-completeness-v1.md
@@ -1,0 +1,67 @@
+# Public API JSDoc completeness v1
+
+This document defines the declaration-level JSDoc closure rules for:
+
+- `@ddgutierrezc/legato-contract`
+- `@ddgutierrezc/legato-capacitor`
+
+## Scope boundaries
+
+The required symbol set is the root-exported surface resolved from each package entrypoint:
+
+- `packages/contract/src/index.ts`
+- `packages/capacitor/src/index.ts`
+
+Deep-import-only symbols are out of scope.
+
+## Validation command
+
+Run per package:
+
+```bash
+npm run build && npm run readiness:entries
+```
+
+The readiness validator executes `packages/capacitor/scripts/assert-package-entries.mjs` and enforces declaration-level docs against emitted `.d.ts` output.
+
+## Category rules
+
+- `functions/methods`
+  - summary sentence
+  - `@param` for each public parameter
+  - `@returns` when return type is non-`void`
+- `types/interfaces`
+  - summary sentence
+  - property docs for externally consumed option/snapshot/event-map members (where enforced by validator heuristics)
+- `constants/enums`
+  - summary sentence
+- `event maps/payload types`
+  - summary sentence
+  - property/key docs on payload map members
+
+## Staged rollout closure
+
+- Stage 1 (contract): `documentedSymbols === totalSymbols` for contract root exports.
+- Stage 2 (capacitor): `documentedSymbols === totalSymbols` for capacitor root exports.
+- Stage 3 (global): both package readiness commands pass with zero uncovered symbols.
+
+## Failure remediation workflow
+
+Validator failures include:
+
+- `symbol`
+- `category`
+- `declFile`
+- `sourceFile` (from `.d.ts.map` when available)
+- `missing[]`
+
+Fix loop:
+
+1. Open `sourceFile` and add or adjust JSDoc.
+2. Rebuild package to emit updated declarations.
+3. Rerun readiness.
+4. Repeat until no failures remain.
+
+## Current closure target
+
+Global closure is complete only when both packages report `status: "PASS"` and every root-exported symbol is documented in emitted declaration output.

--- a/packages/capacitor/scripts/__tests__/jsdoc-completeness.test.mjs
+++ b/packages/capacitor/scripts/__tests__/jsdoc-completeness.test.mjs
@@ -8,6 +8,7 @@ import {
   collectRootExportInventory,
   evaluateJsdocClaimEvidence,
   evaluateStageClosure,
+  resolveTypeScriptRuntime,
   validateDeclarationJsdocCoverage,
 } from '../assert-package-entries.mjs';
 
@@ -204,4 +205,43 @@ test('evaluateStageClosure passes partial completion when scoped closure metadat
 
   assert.equal(result.status, 'PASS');
   assert.equal(result.failures.length, 0);
+});
+
+test('resolveTypeScriptRuntime prefers package-root node_modules when available', async () => {
+  const packageRoot = await createFixturePackage({
+    srcIndex: 'export {}\n',
+    distIndex: 'export {}\n',
+  });
+
+  const fakeTypescriptRoot = join(packageRoot, 'node_modules', 'typescript');
+  await mkdir(fakeTypescriptRoot, { recursive: true });
+  await writeJson(join(fakeTypescriptRoot, 'package.json'), {
+    name: 'typescript',
+    version: '0.0.0-fixture',
+    main: 'index.cjs',
+  });
+  await writeFile(join(fakeTypescriptRoot, 'index.cjs'), 'module.exports = { __fixtureMarker: "package-root" };\n', 'utf8');
+
+  try {
+    const runtime = resolveTypeScriptRuntime({ packageRoot });
+    assert.equal(runtime.ts.__fixtureMarker, 'package-root');
+    assert.match(runtime.modulePath, /node_modules\/typescript\/index\.cjs$/);
+  } finally {
+    await rm(packageRoot, { recursive: true, force: true });
+  }
+});
+
+test('resolveTypeScriptRuntime falls back when package-root has no TypeScript install', async () => {
+  const packageRoot = await createFixturePackage({
+    srcIndex: 'export {}\n',
+    distIndex: 'export {}\n',
+  });
+
+  try {
+    const runtime = resolveTypeScriptRuntime({ packageRoot });
+    assert.equal(typeof runtime.ts.createProgram, 'function');
+    assert.equal(runtime.modulePath.startsWith(join(packageRoot, 'node_modules')), false);
+  } finally {
+    await rm(packageRoot, { recursive: true, force: true });
+  }
 });

--- a/packages/capacitor/scripts/__tests__/jsdoc-completeness.test.mjs
+++ b/packages/capacitor/scripts/__tests__/jsdoc-completeness.test.mjs
@@ -1,0 +1,207 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  collectRootExportInventory,
+  evaluateJsdocClaimEvidence,
+  evaluateStageClosure,
+  validateDeclarationJsdocCoverage,
+} from '../assert-package-entries.mjs';
+
+const writeJson = (path, value) => writeFile(path, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+
+const createFixturePackage = async ({ srcIndex, srcModules = {}, distIndex, distModules = {}, mapSources = [] }) => {
+  const packageRoot = await mkdtemp(join(tmpdir(), 'legato-jsdoc-coverage-'));
+  await mkdir(join(packageRoot, 'src'), { recursive: true });
+  await mkdir(join(packageRoot, 'dist'), { recursive: true });
+
+  await writeFile(join(packageRoot, 'src', 'index.ts'), srcIndex, 'utf8');
+  for (const [relativePath, content] of Object.entries(srcModules)) {
+    const targetPath = join(packageRoot, 'src', relativePath);
+    await mkdir(join(targetPath, '..'), { recursive: true });
+    await writeFile(targetPath, content, 'utf8');
+  }
+
+  await writeFile(join(packageRoot, 'dist', 'index.d.ts'), distIndex, 'utf8');
+  for (const [relativePath, content] of Object.entries(distModules)) {
+    const targetPath = join(packageRoot, 'dist', relativePath);
+    await mkdir(join(targetPath, '..'), { recursive: true });
+    await writeFile(targetPath, content, 'utf8');
+  }
+
+  await writeJson(join(packageRoot, 'dist', 'index.d.ts.map'), {
+    version: 3,
+    file: 'index.d.ts',
+    sources: mapSources,
+    names: [],
+    mappings: '',
+  });
+
+  await writeJson(join(packageRoot, 'package.json'), {
+    name: '@fixture/legato-jsdoc',
+    type: 'module',
+    exports: {
+      '.': {
+        default: './dist/index.js',
+        types: './dist/index.d.ts',
+      },
+    },
+    main: './dist/index.js',
+    types: './dist/index.d.ts',
+  });
+  await writeFile(join(packageRoot, 'dist', 'index.js'), 'export {}\n', 'utf8');
+
+  return packageRoot;
+};
+
+test('collectRootExportInventory resolves star exports, type aliases, and constants from src index', async () => {
+  const packageRoot = await createFixturePackage({
+    srcIndex: "export * from './track.js';\nexport type { Queue } from './queue.js';\nexport { API_VERSION as VERSION } from './constants.js';\n",
+    srcModules: {
+      'track.ts': 'export interface Track { id: string; }\n',
+      'queue.ts': 'export interface Queue { size: number; }\n',
+      'constants.ts': 'export const API_VERSION = 1 as const;\n',
+    },
+    distIndex: 'export {}\n',
+  });
+
+  try {
+    const inventory = await collectRootExportInventory({ packageRoot });
+    const names = new Set(inventory.map((entry) => entry.symbol));
+    assert.deepEqual(names, new Set(['Track', 'Queue', 'VERSION']));
+    assert.equal(inventory.find((entry) => entry.symbol === 'Track')?.category, 'types/interfaces');
+    assert.equal(inventory.find((entry) => entry.symbol === 'VERSION')?.category, 'constants/enums');
+  } finally {
+    await rm(packageRoot, { recursive: true, force: true });
+  }
+});
+
+test('validateDeclarationJsdocCoverage reports missing symbol docs and source-map provenance', async () => {
+  const packageRoot = await createFixturePackage({
+    srcIndex: "export { setup } from './api.js';\n",
+    srcModules: {
+      'api.ts': 'export function setup(value: string): number { return value.length; }\n',
+    },
+    distIndex: "export { setup } from './api.js';\n",
+    distModules: {
+      'api.d.ts': 'export declare function setup(value: string): number;\n',
+    },
+    mapSources: ['../src/api.ts'],
+  });
+
+  try {
+    const result = await validateDeclarationJsdocCoverage({ packageRoot, profile: 'contract' });
+    assert.equal(result.status, 'FAIL');
+    assert.ok(result.failures.some((failure) => failure.symbol === 'setup'));
+    const setupFailure = result.failures.find((failure) => failure.symbol === 'setup');
+    assert.deepEqual(setupFailure?.missing, ['summary', '@param value', '@returns']);
+    assert.equal(setupFailure?.sourceFile, '../src/api.ts');
+  } finally {
+    await rm(packageRoot, { recursive: true, force: true });
+  }
+});
+
+test('validateDeclarationJsdocCoverage passes when function and interface docs are retained in dist d.ts', async () => {
+  const packageRoot = await createFixturePackage({
+    srcIndex: "export { setup } from './api.js';\nexport type { SetupOptions } from './api.js';\n",
+    srcModules: {
+      'api.ts': [
+        '/** Setup options. */',
+        'export interface SetupOptions {',
+        '  /** Playlist to enqueue before setup resolves. */',
+        '  tracks: string[];',
+        '}',
+        '/** Initializes playback and returns queued track count. */',
+        'export function setup(options: SetupOptions): number { return options.tracks.length; }',
+        '',
+      ].join('\n'),
+    },
+    distIndex: "export { setup } from './api.js';\nexport type { SetupOptions } from './api.js';\n",
+    distModules: {
+      'api.d.ts': [
+        '/** Setup options. */',
+        'export interface SetupOptions {',
+        '  /** Playlist to enqueue before setup resolves. */',
+        '  tracks: string[];',
+        '}',
+        '/** Initializes playback and returns queued track count.',
+        ' * @param options Setup options for initial queue seeding.',
+        ' * @returns Number of tracks queued by setup.',
+        ' */',
+        'export declare function setup(options: SetupOptions): number;',
+        '',
+      ].join('\n'),
+    },
+    mapSources: ['../src/api.ts'],
+  });
+
+  try {
+    const result = await validateDeclarationJsdocCoverage({ packageRoot, profile: 'capacitor' });
+    assert.equal(result.status, 'PASS');
+    assert.equal(result.failures.length, 0);
+  } finally {
+    await rm(packageRoot, { recursive: true, force: true });
+  }
+});
+
+test('evaluateJsdocClaimEvidence fails unsupported behavioral claims without accepted evidence', () => {
+  const result = evaluateJsdocClaimEvidence({
+    packageName: 'contract',
+    claims: [
+      {
+        symbol: 'setup',
+        claim: 'Always retries playback three times before failing.',
+        evidence: [],
+      },
+    ],
+  });
+
+  assert.equal(result.status, 'FAIL');
+  assert.equal(result.failures.length, 1);
+  assert.match(result.failures[0].missing.join(' '), /source-backed evidence/i);
+});
+
+test('evaluateJsdocClaimEvidence passes behavioral claims when accepted evidence is supplied', () => {
+  const result = evaluateJsdocClaimEvidence({
+    packageName: 'contract',
+    claims: [
+      {
+        symbol: 'setup',
+        claim: 'Returns snapshot from adapter response.',
+        evidence: [{ kind: 'implementation', source: 'src/plugin.ts' }],
+      },
+    ],
+  });
+
+  assert.equal(result.status, 'PASS');
+  assert.equal(result.failures.length, 0);
+});
+
+test('evaluateStageClosure blocks partial stage completion without scoped closure metadata', () => {
+  const result = evaluateStageClosure({
+    stageName: 'stage-1-contract',
+    documentedSymbols: 10,
+    totalSymbols: 38,
+  });
+
+  assert.equal(result.status, 'FAIL');
+  assert.match(result.failures.join('\n'), /scoped closure metadata/i);
+});
+
+test('evaluateStageClosure passes partial completion when scoped closure metadata is complete', () => {
+  const result = evaluateStageClosure({
+    stageName: 'stage-1-contract',
+    documentedSymbols: 10,
+    totalSymbols: 38,
+    scopedClosure: {
+      documentedSymbols: 10,
+      totalSymbols: 10,
+    },
+  });
+
+  assert.equal(result.status, 'PASS');
+  assert.equal(result.failures.length, 0);
+});

--- a/packages/capacitor/scripts/assert-package-entries.mjs
+++ b/packages/capacitor/scripts/assert-package-entries.mjs
@@ -1,6 +1,7 @@
 import { readFile, lstat } from 'node:fs/promises';
 import { dirname, isAbsolute, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const defaultPackageRoot = resolve(scriptDir, '..');
@@ -67,6 +68,423 @@ const detectProfile = ({ profile, packageJson }) => {
 };
 
 const mentionsLegatoCli = (readmeRaw) => /`?legato`?\s+native|\blegato\s+native\b/i.test(readmeRaw);
+
+const DEFAULT_TYPESCRIPT_COMPILER_OPTIONS = {
+  target: ts.ScriptTarget.ES2022,
+  module: ts.ModuleKind.NodeNext,
+  moduleResolution: ts.ModuleResolutionKind.NodeNext,
+  skipLibCheck: true,
+  strict: false,
+};
+
+const DEFAULT_ALLOWED_EVIDENCE_KINDS = new Set([
+  'signature',
+  'implementation',
+  'test',
+  'maintainer-source-map',
+]);
+
+const declarationKindSets = {
+  functionLike: new Set([
+    ts.SyntaxKind.FunctionDeclaration,
+    ts.SyntaxKind.MethodDeclaration,
+    ts.SyntaxKind.MethodSignature,
+  ]),
+  typeLike: new Set([
+    ts.SyntaxKind.InterfaceDeclaration,
+    ts.SyntaxKind.TypeAliasDeclaration,
+  ]),
+  constantLike: new Set([
+    ts.SyntaxKind.VariableDeclaration,
+    ts.SyntaxKind.VariableStatement,
+    ts.SyntaxKind.EnumDeclaration,
+    ts.SyntaxKind.EnumMember,
+  ]),
+};
+
+const toRelativeFromPackageRoot = (packageRoot, absolutePath) => normalizeRelativePath(absolutePath.slice(packageRoot.length + 1));
+
+const normalizeCommentText = (comment) => {
+  if (typeof comment === 'string') {
+    return comment.trim();
+  }
+  if (Array.isArray(comment)) {
+    return comment.map((piece) => String(piece.text ?? '')).join('').trim();
+  }
+  return '';
+};
+
+const resolveAliasedSymbol = (checker, symbol) => {
+  if ((symbol.flags & ts.SymbolFlags.Alias) !== 0) {
+    return checker.getAliasedSymbol(symbol);
+  }
+  return symbol;
+};
+
+export const evaluateJsdocClaimEvidence = ({ packageName, claims = [], allowedEvidenceKinds } = {}) => {
+  const allowedKinds = new Set(
+    Array.isArray(allowedEvidenceKinds) && allowedEvidenceKinds.length > 0
+      ? allowedEvidenceKinds.map((kind) => normalizeKeyword(kind))
+      : [...DEFAULT_ALLOWED_EVIDENCE_KINDS],
+  );
+  const failures = [];
+
+  for (const claimEntry of claims) {
+    const normalizedClaim = String(claimEntry?.claim ?? '').trim();
+    if (normalizedClaim.length === 0) {
+      continue;
+    }
+    const evidences = Array.isArray(claimEntry?.evidence) ? claimEntry.evidence : [];
+    const hasAllowedEvidence = evidences.some((evidenceEntry) => {
+      const evidenceKind = normalizeKeyword(
+        typeof evidenceEntry === 'string'
+          ? evidenceEntry
+          : evidenceEntry?.kind,
+      );
+      return allowedKinds.has(evidenceKind);
+    });
+
+    if (!hasAllowedEvidence) {
+      failures.push({
+        packageName,
+        symbol: claimEntry?.symbol ?? '<unknown>',
+        claim: normalizedClaim,
+        missing: ['source-backed evidence'],
+      });
+    }
+  }
+
+  const status = failures.length === 0 ? 'PASS' : 'FAIL';
+  return {
+    status,
+    exitCode: status === 'PASS' ? 0 : 1,
+    packageName,
+    failures,
+  };
+};
+
+export const evaluateStageClosure = ({
+  stageName,
+  documentedSymbols,
+  totalSymbols,
+  scopedClosure,
+} = {}) => {
+  const failures = [];
+  const documentedCount = Number(documentedSymbols ?? 0);
+  const totalCount = Number(totalSymbols ?? 0);
+  const stageLabel = String(stageName ?? 'unnamed-stage');
+
+  if (documentedCount >= totalCount) {
+    return {
+      status: 'PASS',
+      exitCode: 0,
+      stageName: stageLabel,
+      failures,
+    };
+  }
+
+  if (!scopedClosure || typeof scopedClosure !== 'object') {
+    failures.push(
+      `Stage ${stageLabel} is partially complete (${documentedCount}/${totalCount}) and must declare scoped closure metadata.`,
+    );
+  } else {
+    const scopedDocumented = Number(scopedClosure.documentedSymbols ?? NaN);
+    const scopedTotal = Number(scopedClosure.totalSymbols ?? NaN);
+    if (!Number.isFinite(scopedDocumented) || !Number.isFinite(scopedTotal)) {
+      failures.push(`Stage ${stageLabel} scoped closure metadata must include numeric documentedSymbols/totalSymbols.`);
+    } else if (scopedDocumented < scopedTotal) {
+      failures.push(
+        `Stage ${stageLabel} scoped closure is incomplete (${scopedDocumented}/${scopedTotal}).`,
+      );
+    }
+  }
+
+  const status = failures.length === 0 ? 'PASS' : 'FAIL';
+  return {
+    status,
+    exitCode: status === 'PASS' ? 0 : 1,
+    stageName: stageLabel,
+    failures,
+  };
+};
+
+const classifyExportCategory = (symbol) => {
+  const declarations = symbol.getDeclarations() ?? [];
+  const symbolName = symbol.getName();
+  const hasKind = (set) => declarations.some((declaration) => set.has(declaration.kind));
+
+  if (
+    symbolName.endsWith('EventPayloadMap')
+    || symbolName.endsWith('EventPayload')
+    || symbolName.endsWith('EventName')
+    || symbolName.endsWith('EVENT_NAMES')
+  ) {
+    return 'event maps/payload types';
+  }
+  if (hasKind(declarationKindSets.functionLike)) {
+    return 'functions/methods';
+  }
+  if (hasKind(declarationKindSets.typeLike)) {
+    return 'types/interfaces';
+  }
+  if (hasKind(declarationKindSets.constantLike)) {
+    return 'constants/enums';
+  }
+  return 'types/interfaces';
+};
+
+const loadPackageCompilerOptions = (packageRoot) => {
+  const configPath = ts.findConfigFile(packageRoot, ts.sys.fileExists, 'tsconfig.json');
+  if (!configPath) {
+    return DEFAULT_TYPESCRIPT_COMPILER_OPTIONS;
+  }
+
+  const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
+  if (configFile.error) {
+    return DEFAULT_TYPESCRIPT_COMPILER_OPTIONS;
+  }
+
+  const parsed = ts.parseJsonConfigFileContent(
+    configFile.config,
+    ts.sys,
+    dirname(configPath),
+    undefined,
+    configPath,
+  );
+  return {
+    ...DEFAULT_TYPESCRIPT_COMPILER_OPTIONS,
+    ...parsed.options,
+  };
+};
+
+const createCheckerForEntrypoint = (entrypointPath, packageRoot) => {
+  const program = ts.createProgram([entrypointPath], loadPackageCompilerOptions(packageRoot));
+  const checker = program.getTypeChecker();
+  const sourceFile = program.getSourceFile(entrypointPath);
+  if (!sourceFile) {
+    throw new Error(`Unable to load TypeScript source file: ${entrypointPath}`);
+  }
+  const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
+  if (!moduleSymbol) {
+    throw new Error(`Unable to resolve module symbol for: ${entrypointPath}`);
+  }
+  return { checker, moduleSymbol };
+};
+
+export const collectRootExportInventory = async ({ packageRoot, sourceEntrypoint = 'src/index.ts' } = {}) => {
+  const resolvedPackageRoot = resolve(packageRoot ?? defaultPackageRoot);
+  const entrypointPath = resolve(resolvedPackageRoot, sourceEntrypoint);
+  const { checker, moduleSymbol } = createCheckerForEntrypoint(entrypointPath, resolvedPackageRoot);
+  const exports = checker.getExportsOfModule(moduleSymbol);
+
+  return exports
+    .map((symbol) => {
+      const resolvedSymbol = resolveAliasedSymbol(checker, symbol);
+      const declaration = resolvedSymbol.getDeclarations()?.[0];
+      return {
+        symbol: symbol.getName(),
+        category: classifyExportCategory(resolvedSymbol),
+        sourceFile: declaration?.getSourceFile()?.fileName
+          ? toRelativeFromPackageRoot(resolvedPackageRoot, declaration.getSourceFile().fileName)
+          : undefined,
+      };
+    })
+    .sort((left, right) => left.symbol.localeCompare(right.symbol));
+};
+
+const getPrimaryDeclaration = (symbol) => {
+  const declarations = symbol.getDeclarations() ?? [];
+  return declarations.find((declaration) => declaration.kind !== ts.SyntaxKind.ExportSpecifier) ?? declarations[0];
+};
+
+const getTagValues = (declaration) => {
+  const tags = ts.getJSDocTags(declaration);
+  const paramTags = new Set();
+  let hasReturns = false;
+
+  for (const tag of tags) {
+    const tagName = tag.tagName.getText();
+    if (tagName === 'param' && tag.name && ts.isIdentifier(tag.name)) {
+      paramTags.add(tag.name.text);
+    }
+    if (tagName === 'returns' || tagName === 'return') {
+      hasReturns = true;
+    }
+  }
+
+  return {
+    paramTags,
+    hasReturns,
+  };
+};
+
+const declarationHasSummary = (checker, symbol, declaration) => {
+  const symbolSummary = ts.displayPartsToString(symbol.getDocumentationComment(checker)).trim();
+  if (symbolSummary.length > 0) {
+    return true;
+  }
+  const jsdocNodes = ts.getJSDocCommentsAndTags(declaration).filter((node) => node.kind === ts.SyntaxKind.JSDoc);
+  return jsdocNodes.some((node) => normalizeCommentText(node.comment).length > 0);
+};
+
+const declarationNeedsPropertyDocs = (symbol, category, declaration) => {
+  const name = symbol.getName();
+  if (category === 'event maps/payload types') {
+    return true;
+  }
+  if (name.endsWith('Options') || name.endsWith('PayloadMap')) {
+    return true;
+  }
+  return ts.isInterfaceDeclaration(declaration) && declaration.members.length > 0 && name.endsWith('Snapshot');
+};
+
+const collectMissingPropertyDocs = (declaration) => {
+  if (!ts.isInterfaceDeclaration(declaration) && !ts.isTypeLiteralNode(declaration)) {
+    return [];
+  }
+
+  const members = ts.isInterfaceDeclaration(declaration) ? declaration.members : declaration.members;
+  const missing = [];
+
+  for (const member of members) {
+    if (!('name' in member) || !member.name) {
+      continue;
+    }
+    const summaryNodes = ts.getJSDocCommentsAndTags(member).filter((node) => node.kind === ts.SyntaxKind.JSDoc);
+    const hasSummary = summaryNodes.some((node) => normalizeCommentText(node.comment).length > 0);
+    if (!hasSummary) {
+      const memberName = member.name.getText();
+      missing.push(`property ${memberName}`);
+    }
+  }
+
+  return missing;
+};
+
+const resolveDeclarationSourceFromMap = async (declFilePath, packageRoot) => {
+  const mapPaths = [
+    `${declFilePath}.map`,
+    resolve(packageRoot, 'dist/index.d.ts.map'),
+  ];
+  for (const mapPath of mapPaths) {
+  try {
+    const raw = await readFile(mapPath, 'utf8');
+    const parsed = JSON.parse(raw);
+    const source = Array.isArray(parsed.sources) ? parsed.sources.find((item) => hasString(item)) : undefined;
+      if (source) {
+        return source;
+      }
+  } catch {
+      // Continue scanning fallback maps.
+    }
+  }
+  return undefined;
+};
+
+export const validateDeclarationJsdocCoverage = async ({ packageRoot, profile } = {}) => {
+  const resolvedPackageRoot = resolve(packageRoot ?? defaultPackageRoot);
+  const sourceEntrypointPath = resolve(resolvedPackageRoot, 'src/index.ts');
+  const declarationEntrypoint = resolve(resolvedPackageRoot, 'dist/index.d.ts');
+  if (!await pathExists(sourceEntrypointPath) || !await pathExists(declarationEntrypoint)) {
+    return {
+      status: 'PASS',
+      exitCode: 0,
+      profile,
+      packageRoot: resolvedPackageRoot,
+      totalSymbols: 0,
+      documentedSymbols: 0,
+      failures: [],
+      skipped: 'source-or-declaration-entrypoint-missing',
+    };
+  }
+
+  const sourceInventory = await collectRootExportInventory({ packageRoot: resolvedPackageRoot });
+  const { checker, moduleSymbol } = createCheckerForEntrypoint(declarationEntrypoint, resolvedPackageRoot);
+  const declarationExports = new Map(
+    checker
+      .getExportsOfModule(moduleSymbol)
+      .map((symbol) => [symbol.getName(), resolveAliasedSymbol(checker, symbol)]),
+  );
+
+  const failures = [];
+
+  for (const inventoryEntry of sourceInventory) {
+    const symbol = declarationExports.get(inventoryEntry.symbol);
+    if (!symbol) {
+      failures.push({
+        packageName: profile,
+        symbol: inventoryEntry.symbol,
+        category: inventoryEntry.category,
+        declFile: 'dist/index.d.ts',
+        sourceFile: inventoryEntry.sourceFile,
+        missing: ['declaration export'],
+      });
+      continue;
+    }
+
+    const declaration = getPrimaryDeclaration(symbol);
+    if (!declaration) {
+      failures.push({
+        packageName: profile,
+        symbol: inventoryEntry.symbol,
+        category: inventoryEntry.category,
+        declFile: 'dist/index.d.ts',
+        sourceFile: inventoryEntry.sourceFile,
+        missing: ['declaration node'],
+      });
+      continue;
+    }
+
+    const missing = [];
+    const hasSummary = declarationHasSummary(checker, symbol, declaration);
+    if (!hasSummary) {
+      missing.push('summary');
+    }
+
+    if (inventoryEntry.category === 'functions/methods') {
+      const { paramTags, hasReturns } = getTagValues(declaration);
+      const parameters = 'parameters' in declaration ? declaration.parameters : [];
+      for (const parameter of parameters) {
+        if (ts.isIdentifier(parameter.name) && !paramTags.has(parameter.name.text)) {
+          missing.push(`@param ${parameter.name.text}`);
+        }
+      }
+      const returnType = 'type' in declaration ? declaration.type : undefined;
+      const hasVoidReturn = returnType?.kind === ts.SyntaxKind.VoidKeyword;
+      if (!hasVoidReturn && parameters.length >= 0 && !hasReturns) {
+        missing.push('@returns');
+      }
+    }
+
+    if (declarationNeedsPropertyDocs(symbol, inventoryEntry.category, declaration)) {
+      missing.push(...collectMissingPropertyDocs(declaration));
+    }
+
+    if (missing.length > 0) {
+      const declarationFilePath = declaration.getSourceFile().fileName;
+      const sourceFile = await resolveDeclarationSourceFromMap(declarationFilePath, resolvedPackageRoot);
+      failures.push({
+        packageName: profile,
+        symbol: inventoryEntry.symbol,
+        category: inventoryEntry.category,
+        declFile: toRelativeFromPackageRoot(resolvedPackageRoot, declarationFilePath),
+        sourceFile,
+        missing,
+      });
+    }
+  }
+
+  const status = failures.length === 0 ? 'PASS' : 'FAIL';
+  return {
+    status,
+    exitCode: status === 'PASS' ? 0 : 1,
+    profile,
+    packageRoot: resolvedPackageRoot,
+    totalSymbols: sourceInventory.length,
+    documentedSymbols: sourceInventory.length - failures.length,
+    failures,
+  };
+};
 
 export const validatePackageErgonomics = async ({ packageRoot, profile } = {}) => {
   const resolvedPackageRoot = resolve(packageRoot ?? defaultPackageRoot);
@@ -218,7 +636,12 @@ export const validatePackageEntrypoints = async ({ packageRoot, requireDistPrefi
 
   const status = failures.length === 0 ? 'PASS' : 'FAIL';
   const ergonomics = await validatePackageErgonomics({ packageRoot: resolvedPackageRoot, profile });
-  const mergedFailures = [...failures, ...ergonomics.failures];
+  const jsdocCoverage = await validateDeclarationJsdocCoverage({ packageRoot: resolvedPackageRoot, profile: ergonomics.profile });
+  const jsdocFailures = jsdocCoverage.failures.map((failure) => {
+    const sourceSuffix = failure.sourceFile ? ` sourceFile=${failure.sourceFile}` : '';
+    return `JSDoc coverage missing for ${failure.symbol} (${failure.category}) in ${failure.declFile}${sourceSuffix}: ${failure.missing.join(', ')}`;
+  });
+  const mergedFailures = [...failures, ...ergonomics.failures, ...jsdocFailures];
   const mergedStatus = mergedFailures.length === 0 ? 'PASS' : 'FAIL';
   return {
     status: mergedStatus,
@@ -227,6 +650,7 @@ export const validatePackageEntrypoints = async ({ packageRoot, requireDistPrefi
     packageRoot: resolvedPackageRoot,
     entrypoints,
     profile: ergonomics.profile,
+    jsdocCoverage,
     failures: mergedFailures,
   };
 };

--- a/packages/capacitor/scripts/assert-package-entries.mjs
+++ b/packages/capacitor/scripts/assert-package-entries.mjs
@@ -1,11 +1,63 @@
 import { readFile, lstat } from 'node:fs/promises';
 import { dirname, isAbsolute, resolve } from 'node:path';
+import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
-import ts from 'typescript';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const defaultPackageRoot = resolve(scriptDir, '..');
+const requireFromScript = createRequire(import.meta.url);
 const VALID_PROFILES = new Set(['capacitor', 'contract']);
+const typescriptRuntimeCache = new Map();
+
+const collectTypeScriptCandidateRoots = ({ packageRoot } = {}) => {
+  const candidates = [
+    packageRoot,
+    defaultPackageRoot,
+    process.cwd(),
+    scriptDir,
+  ]
+    .filter((value) => typeof value === 'string' && value.trim().length > 0)
+    .map((value) => resolve(value));
+  return [...new Set(candidates)];
+};
+
+const resolveTypeScriptModulePath = ({ packageRoot } = {}) => {
+  const candidateRoots = collectTypeScriptCandidateRoots({ packageRoot });
+  for (const candidateRoot of candidateRoots) {
+    try {
+      const requireFromCandidate = createRequire(resolve(candidateRoot, 'package.json'));
+      const modulePath = requireFromCandidate.resolve('typescript');
+      if (modulePath) {
+        return modulePath;
+      }
+    } catch {
+      // Continue through fallback roots.
+    }
+  }
+
+  try {
+    return requireFromScript.resolve('typescript');
+  } catch {
+    const fallbackSummary = candidateRoots.length > 0
+      ? candidateRoots.join(', ')
+      : '<none>';
+    throw new Error(`Unable to resolve TypeScript runtime. Tried package-root and fallbacks: ${fallbackSummary}`);
+  }
+};
+
+export const resolveTypeScriptRuntime = ({ packageRoot } = {}) => {
+  const modulePath = resolveTypeScriptModulePath({ packageRoot });
+  if (!typescriptRuntimeCache.has(modulePath)) {
+    const loadedModule = requireFromScript(modulePath);
+    const tsRuntime = loadedModule?.default ?? loadedModule;
+    typescriptRuntimeCache.set(modulePath, tsRuntime);
+  }
+
+  return {
+    ts: typescriptRuntimeCache.get(modulePath),
+    modulePath,
+  };
+};
 
 const normalizeRelativePath = (value) => value.replaceAll('\\', '/').replace(/^\.\//, '');
 
@@ -69,13 +121,13 @@ const detectProfile = ({ profile, packageJson }) => {
 
 const mentionsLegatoCli = (readmeRaw) => /`?legato`?\s+native|\blegato\s+native\b/i.test(readmeRaw);
 
-const DEFAULT_TYPESCRIPT_COMPILER_OPTIONS = {
+const createDefaultTypescriptCompilerOptions = (ts) => ({
   target: ts.ScriptTarget.ES2022,
   module: ts.ModuleKind.NodeNext,
   moduleResolution: ts.ModuleResolutionKind.NodeNext,
   skipLibCheck: true,
   strict: false,
-};
+});
 
 const DEFAULT_ALLOWED_EVIDENCE_KINDS = new Set([
   'signature',
@@ -84,7 +136,7 @@ const DEFAULT_ALLOWED_EVIDENCE_KINDS = new Set([
   'maintainer-source-map',
 ]);
 
-const declarationKindSets = {
+const createDeclarationKindSets = (ts) => ({
   functionLike: new Set([
     ts.SyntaxKind.FunctionDeclaration,
     ts.SyntaxKind.MethodDeclaration,
@@ -100,7 +152,7 @@ const declarationKindSets = {
     ts.SyntaxKind.EnumDeclaration,
     ts.SyntaxKind.EnumMember,
   ]),
-};
+});
 
 const toRelativeFromPackageRoot = (packageRoot, absolutePath) => normalizeRelativePath(absolutePath.slice(packageRoot.length + 1));
 
@@ -114,7 +166,7 @@ const normalizeCommentText = (comment) => {
   return '';
 };
 
-const resolveAliasedSymbol = (checker, symbol) => {
+const resolveAliasedSymbol = (checker, symbol, ts) => {
   if ((symbol.flags & ts.SymbolFlags.Alias) !== 0) {
     return checker.getAliasedSymbol(symbol);
   }
@@ -208,7 +260,7 @@ export const evaluateStageClosure = ({
   };
 };
 
-const classifyExportCategory = (symbol) => {
+const classifyExportCategory = (symbol, declarationKindSets) => {
   const declarations = symbol.getDeclarations() ?? [];
   const symbolName = symbol.getName();
   const hasKind = (set) => declarations.some((declaration) => set.has(declaration.kind));
@@ -233,15 +285,15 @@ const classifyExportCategory = (symbol) => {
   return 'types/interfaces';
 };
 
-const loadPackageCompilerOptions = (packageRoot) => {
+const loadPackageCompilerOptions = (packageRoot, ts) => {
   const configPath = ts.findConfigFile(packageRoot, ts.sys.fileExists, 'tsconfig.json');
   if (!configPath) {
-    return DEFAULT_TYPESCRIPT_COMPILER_OPTIONS;
+    return createDefaultTypescriptCompilerOptions(ts);
   }
 
   const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
   if (configFile.error) {
-    return DEFAULT_TYPESCRIPT_COMPILER_OPTIONS;
+    return createDefaultTypescriptCompilerOptions(ts);
   }
 
   const parsed = ts.parseJsonConfigFileContent(
@@ -252,13 +304,13 @@ const loadPackageCompilerOptions = (packageRoot) => {
     configPath,
   );
   return {
-    ...DEFAULT_TYPESCRIPT_COMPILER_OPTIONS,
+    ...createDefaultTypescriptCompilerOptions(ts),
     ...parsed.options,
   };
 };
 
-const createCheckerForEntrypoint = (entrypointPath, packageRoot) => {
-  const program = ts.createProgram([entrypointPath], loadPackageCompilerOptions(packageRoot));
+const createCheckerForEntrypoint = (entrypointPath, packageRoot, ts) => {
+  const program = ts.createProgram([entrypointPath], loadPackageCompilerOptions(packageRoot, ts));
   const checker = program.getTypeChecker();
   const sourceFile = program.getSourceFile(entrypointPath);
   if (!sourceFile) {
@@ -273,17 +325,19 @@ const createCheckerForEntrypoint = (entrypointPath, packageRoot) => {
 
 export const collectRootExportInventory = async ({ packageRoot, sourceEntrypoint = 'src/index.ts' } = {}) => {
   const resolvedPackageRoot = resolve(packageRoot ?? defaultPackageRoot);
+  const { ts } = resolveTypeScriptRuntime({ packageRoot: resolvedPackageRoot });
   const entrypointPath = resolve(resolvedPackageRoot, sourceEntrypoint);
-  const { checker, moduleSymbol } = createCheckerForEntrypoint(entrypointPath, resolvedPackageRoot);
+  const { checker, moduleSymbol } = createCheckerForEntrypoint(entrypointPath, resolvedPackageRoot, ts);
+  const declarationKindSets = createDeclarationKindSets(ts);
   const exports = checker.getExportsOfModule(moduleSymbol);
 
   return exports
     .map((symbol) => {
-      const resolvedSymbol = resolveAliasedSymbol(checker, symbol);
+      const resolvedSymbol = resolveAliasedSymbol(checker, symbol, ts);
       const declaration = resolvedSymbol.getDeclarations()?.[0];
       return {
         symbol: symbol.getName(),
-        category: classifyExportCategory(resolvedSymbol),
+        category: classifyExportCategory(resolvedSymbol, declarationKindSets),
         sourceFile: declaration?.getSourceFile()?.fileName
           ? toRelativeFromPackageRoot(resolvedPackageRoot, declaration.getSourceFile().fileName)
           : undefined,
@@ -292,12 +346,12 @@ export const collectRootExportInventory = async ({ packageRoot, sourceEntrypoint
     .sort((left, right) => left.symbol.localeCompare(right.symbol));
 };
 
-const getPrimaryDeclaration = (symbol) => {
+const getPrimaryDeclaration = (symbol, ts) => {
   const declarations = symbol.getDeclarations() ?? [];
   return declarations.find((declaration) => declaration.kind !== ts.SyntaxKind.ExportSpecifier) ?? declarations[0];
 };
 
-const getTagValues = (declaration) => {
+const getTagValues = (declaration, ts) => {
   const tags = ts.getJSDocTags(declaration);
   const paramTags = new Set();
   let hasReturns = false;
@@ -318,7 +372,7 @@ const getTagValues = (declaration) => {
   };
 };
 
-const declarationHasSummary = (checker, symbol, declaration) => {
+const declarationHasSummary = (checker, symbol, declaration, ts) => {
   const symbolSummary = ts.displayPartsToString(symbol.getDocumentationComment(checker)).trim();
   if (symbolSummary.length > 0) {
     return true;
@@ -327,7 +381,7 @@ const declarationHasSummary = (checker, symbol, declaration) => {
   return jsdocNodes.some((node) => normalizeCommentText(node.comment).length > 0);
 };
 
-const declarationNeedsPropertyDocs = (symbol, category, declaration) => {
+const declarationNeedsPropertyDocs = (symbol, category, declaration, ts) => {
   const name = symbol.getName();
   if (category === 'event maps/payload types') {
     return true;
@@ -338,7 +392,7 @@ const declarationNeedsPropertyDocs = (symbol, category, declaration) => {
   return ts.isInterfaceDeclaration(declaration) && declaration.members.length > 0 && name.endsWith('Snapshot');
 };
 
-const collectMissingPropertyDocs = (declaration) => {
+const collectMissingPropertyDocs = (declaration, ts) => {
   if (!ts.isInterfaceDeclaration(declaration) && !ts.isTypeLiteralNode(declaration)) {
     return [];
   }
@@ -383,6 +437,7 @@ const resolveDeclarationSourceFromMap = async (declFilePath, packageRoot) => {
 
 export const validateDeclarationJsdocCoverage = async ({ packageRoot, profile } = {}) => {
   const resolvedPackageRoot = resolve(packageRoot ?? defaultPackageRoot);
+  const { ts } = resolveTypeScriptRuntime({ packageRoot: resolvedPackageRoot });
   const sourceEntrypointPath = resolve(resolvedPackageRoot, 'src/index.ts');
   const declarationEntrypoint = resolve(resolvedPackageRoot, 'dist/index.d.ts');
   if (!await pathExists(sourceEntrypointPath) || !await pathExists(declarationEntrypoint)) {
@@ -399,11 +454,11 @@ export const validateDeclarationJsdocCoverage = async ({ packageRoot, profile } 
   }
 
   const sourceInventory = await collectRootExportInventory({ packageRoot: resolvedPackageRoot });
-  const { checker, moduleSymbol } = createCheckerForEntrypoint(declarationEntrypoint, resolvedPackageRoot);
+  const { checker, moduleSymbol } = createCheckerForEntrypoint(declarationEntrypoint, resolvedPackageRoot, ts);
   const declarationExports = new Map(
     checker
       .getExportsOfModule(moduleSymbol)
-      .map((symbol) => [symbol.getName(), resolveAliasedSymbol(checker, symbol)]),
+      .map((symbol) => [symbol.getName(), resolveAliasedSymbol(checker, symbol, ts)]),
   );
 
   const failures = [];
@@ -422,7 +477,7 @@ export const validateDeclarationJsdocCoverage = async ({ packageRoot, profile } 
       continue;
     }
 
-    const declaration = getPrimaryDeclaration(symbol);
+    const declaration = getPrimaryDeclaration(symbol, ts);
     if (!declaration) {
       failures.push({
         packageName: profile,
@@ -436,13 +491,13 @@ export const validateDeclarationJsdocCoverage = async ({ packageRoot, profile } 
     }
 
     const missing = [];
-    const hasSummary = declarationHasSummary(checker, symbol, declaration);
+    const hasSummary = declarationHasSummary(checker, symbol, declaration, ts);
     if (!hasSummary) {
       missing.push('summary');
     }
 
     if (inventoryEntry.category === 'functions/methods') {
-      const { paramTags, hasReturns } = getTagValues(declaration);
+      const { paramTags, hasReturns } = getTagValues(declaration, ts);
       const parameters = 'parameters' in declaration ? declaration.parameters : [];
       for (const parameter of parameters) {
         if (ts.isIdentifier(parameter.name) && !paramTags.has(parameter.name.text)) {
@@ -456,8 +511,8 @@ export const validateDeclarationJsdocCoverage = async ({ packageRoot, profile } 
       }
     }
 
-    if (declarationNeedsPropertyDocs(symbol, inventoryEntry.category, declaration)) {
-      missing.push(...collectMissingPropertyDocs(declaration));
+    if (declarationNeedsPropertyDocs(symbol, inventoryEntry.category, declaration, ts)) {
+      missing.push(...collectMissingPropertyDocs(declaration, ts));
     }
 
     if (missing.length > 0) {

--- a/packages/capacitor/src/definitions.ts
+++ b/packages/capacitor/src/definitions.ts
@@ -2,71 +2,140 @@ import type {
   Capability,
   LegatoEventName as ContractLegatoEventName,
   LegatoEventPayloadMap as ContractLegatoEventPayloadMap,
-  LegatoError,
+  LegatoError as ContractLegatoError,
   MediaSessionEventName as ContractMediaSessionEventName,
   MediaSessionEventPayloadMap as ContractMediaSessionEventPayloadMap,
-  PlaybackSnapshot,
-  PlaybackState,
+  PlaybackSnapshot as ContractPlaybackSnapshot,
+  PlaybackState as ContractPlaybackState,
   PlayerEventName as ContractPlayerEventName,
   PlayerEventPayloadMap as ContractPlayerEventPayloadMap,
-  QueueSnapshot,
-  Track,
+  QueueSnapshot as ContractQueueSnapshot,
+  Track as ContractTrack,
 } from '@ddgutierrezc/legato-contract';
 
-export type {
-  LegatoError,
-  PlaybackSnapshot,
-  PlaybackState,
-  QueueSnapshot,
-  Track,
-};
+/**
+ * Error payload type re-exported from the contract package.
+ */
+export type LegatoError = ContractLegatoError;
+/**
+ * Playback snapshot type re-exported from the contract package.
+ */
+export type PlaybackSnapshot = ContractPlaybackSnapshot;
+/**
+ * Playback state type re-exported from the contract package.
+ */
+export type PlaybackState = ContractPlaybackState;
+/**
+ * Queue snapshot type re-exported from the contract package.
+ */
+export type QueueSnapshot = ContractQueueSnapshot;
+/**
+ * Track type re-exported from the contract package.
+ */
+export type Track = ContractTrack;
 
+/**
+ * Player lifecycle event-name union exposed by the Capacitor package.
+ */
 export type AudioPlayerEventName = ContractPlayerEventName;
+/**
+ * Media session event-name union exposed by the Capacitor package.
+ */
 export type MediaSessionEventName = ContractMediaSessionEventName;
+/**
+ * Unified Legato event-name union exposed by the Capacitor package.
+ */
 export type LegatoEventName = ContractLegatoEventName;
 
+/**
+ * Player lifecycle payload map exposed by the Capacitor package.
+ */
 export type AudioPlayerEventPayloadMap = ContractPlayerEventPayloadMap;
+/**
+ * Media session payload map exposed by the Capacitor package.
+ */
 export type MediaSessionEventPayloadMap = ContractMediaSessionEventPayloadMap;
+/**
+ * Unified Legato payload map exposed by the Capacitor package.
+ */
 export type LegatoEventPayloadMap = ContractLegatoEventPayloadMap;
 
+/**
+ * Listener signature for player lifecycle events.
+ */
 export type AudioPlayerListener<E extends AudioPlayerEventName> = (
   payload: AudioPlayerEventPayloadMap[E],
 ) => void;
 
+/**
+ * Listener signature for media session events.
+ */
 export type MediaSessionListener<E extends MediaSessionEventName> = (
   payload: MediaSessionEventPayloadMap[E],
 ) => void;
 
+/**
+ * Listener signature for unified Legato events.
+ */
 export type LegatoListener<E extends LegatoEventName> = (
   payload: LegatoEventPayloadMap[E],
 ) => void;
 
+/**
+ * Listener handle returned by add-listener calls.
+ */
 export interface BindingListenerHandle {
+  /** Detaches the listener from the underlying native plugin. */
   remove(): Promise<void> | void;
 }
 
+/**
+ * Snapshot of runtime-supported playback capabilities.
+ */
 export interface BindingCapabilitiesSnapshot {
+  /** Capabilities currently supported by the plugin runtime. */
   supported: Capability[];
 }
 
+/**
+ * Options for appending tracks to the queue.
+ */
 export interface AddOptions {
+  /** Tracks to append in insertion order. */
   tracks: Track[];
+  /** Optional queue index to activate after insertion. */
   startIndex?: number;
 }
 
+/**
+ * Options for removing queue entries.
+ */
 export interface RemoveOptions {
+  /** Optional track identifier target. */
   id?: string;
+  /** Optional queue index target. */
   index?: number;
 }
 
+/**
+ * Options for seek operations.
+ */
 export interface SeekToOptions {
+  /** Target playback position in seconds. */
   position: number;
 }
 
+/**
+ * Options for absolute queue skip operations.
+ */
 export interface SkipToOptions {
+  /** Queue index to activate. */
   index: number;
 }
 
+/**
+ * Full adapter boundary mirrored by the Capacitor plugin API.
+ */
 export interface BindingAdapter {
   setup(): Promise<void>;
   add(options: AddOptions): Promise<PlaybackSnapshot>;
@@ -115,6 +184,9 @@ type BindingAdapterPlaybackSurface = Pick<
   | 'getCapabilities'
 >;
 
+/**
+ * Playback-facing API surface for the audio player namespace.
+ */
 export interface AudioPlayerApi extends BindingAdapterPlaybackSurface {
   addListener<E extends AudioPlayerEventName>(
     eventName: E,
@@ -123,6 +195,9 @@ export interface AudioPlayerApi extends BindingAdapterPlaybackSurface {
   removeAllListeners(): Promise<void>;
 }
 
+/**
+ * Media-session command API surface.
+ */
 export interface MediaSessionApi {
   setup(): Promise<void>;
   addListener<E extends MediaSessionEventName>(
@@ -132,8 +207,14 @@ export interface MediaSessionApi {
   removeAllListeners(): Promise<void>;
 }
 
+/**
+ * Unified API that combines audio-player and media-session surfaces.
+ */
 export type LegatoApi = AudioPlayerApi & MediaSessionApi;
 
+/**
+ * Unified listener API over all Legato event names.
+ */
 export interface LegatoEventApi {
   addListener<E extends LegatoEventName>(
     eventName: E,

--- a/packages/capacitor/src/events.ts
+++ b/packages/capacitor/src/events.ts
@@ -9,14 +9,35 @@ import type {
 } from './definitions';
 import { Legato, audioPlayer, mediaSession } from './plugin';
 
+/**
+ * Player lifecycle event-name tuple.
+ */
 export const AUDIO_PLAYER_EVENTS = PLAYER_EVENT_NAMES;
+/**
+ * Media-session event-name tuple.
+ */
 export const MEDIA_SESSION_EVENTS = MEDIA_SESSION_EVENT_NAMES;
 
+/**
+ * Unified Legato event-name tuple.
+ */
 export const LEGATO_EVENTS = LEGATO_EVENT_NAMES;
 
+/**
+ * Registers a listener for player lifecycle events.
+ */
 export const addAudioPlayerListener = audioPlayer.addListener.bind(audioPlayer);
+/**
+ * Registers a listener for media-session events.
+ */
 export const addMediaSessionListener = mediaSession.addListener.bind(mediaSession);
 
+/**
+ * Registers a listener for any Legato event name.
+ * @param eventName Event name to subscribe to.
+ * @param listener Callback invoked with the typed event payload.
+ * @returns Listener handle that can remove the subscription.
+ */
 export function addLegatoListener<E extends LegatoEventName>(
   eventName: E,
   listener: (payload: LegatoEventPayloadMap[E]) => void,
@@ -24,46 +45,79 @@ export function addLegatoListener<E extends LegatoEventName>(
   return Legato.addListener(eventName, listener);
 }
 
+/**
+ * Registers a listener for `playback-state-changed` events.
+ */
 export const onPlaybackStateChanged = (
   listener: (payload: LegatoEventPayloadMap['playback-state-changed']) => void,
 ) => addLegatoListener('playback-state-changed', listener);
 
+/**
+ * Registers a listener for `playback-active-track-changed` events.
+ */
 export const onPlaybackActiveTrackChanged = (
   listener: (payload: LegatoEventPayloadMap['playback-active-track-changed']) => void,
 ) => addLegatoListener('playback-active-track-changed', listener);
 
+/**
+ * Registers a listener for `playback-queue-changed` events.
+ */
 export const onPlaybackQueueChanged = (
   listener: (payload: LegatoEventPayloadMap['playback-queue-changed']) => void,
 ) => addLegatoListener('playback-queue-changed', listener);
 
+/**
+ * Registers a listener for `playback-progress` events.
+ */
 export const onPlaybackProgress = (
   listener: (payload: LegatoEventPayloadMap['playback-progress']) => void,
 ) => addLegatoListener('playback-progress', listener);
 
+/**
+ * Registers a listener for `playback-ended` events.
+ */
 export const onPlaybackEnded = (
   listener: (payload: LegatoEventPayloadMap['playback-ended']) => void,
 ) => addLegatoListener('playback-ended', listener);
 
+/**
+ * Registers a listener for `playback-error` events.
+ */
 export const onPlaybackError = (
   listener: (payload: LegatoEventPayloadMap['playback-error']) => void,
 ) => addLegatoListener('playback-error', listener);
 
+/**
+ * Registers a listener for `remote-play` events.
+ */
 export const onRemotePlay = (
   listener: (payload: LegatoEventPayloadMap['remote-play']) => void,
 ) => addLegatoListener('remote-play', listener);
 
+/**
+ * Registers a listener for `remote-pause` events.
+ */
 export const onRemotePause = (
   listener: (payload: LegatoEventPayloadMap['remote-pause']) => void,
 ) => addLegatoListener('remote-pause', listener);
 
+/**
+ * Registers a listener for `remote-next` events.
+ */
 export const onRemoteNext = (
   listener: (payload: LegatoEventPayloadMap['remote-next']) => void,
 ) => addLegatoListener('remote-next', listener);
 
+/**
+ * Registers a listener for `remote-previous` events.
+ */
 export const onRemotePrevious = (
   listener: (payload: LegatoEventPayloadMap['remote-previous']) => void,
 ) => addLegatoListener('remote-previous', listener);
 
+/**
+ * Registers a listener for `remote-seek` events.
+ */
 export const onRemoteSeek = (
   listener: (payload: LegatoEventPayloadMap['remote-seek']) => void,
 ) => addLegatoListener('remote-seek', listener);

--- a/packages/capacitor/src/plugin.ts
+++ b/packages/capacitor/src/plugin.ts
@@ -75,6 +75,9 @@ interface LegatoCapacitorPlugin extends Plugin {
   getCapabilities(): Promise<CapabilitiesResult>;
 }
 
+/**
+ * Low-level Capacitor plugin registration handle for the native Legato plugin.
+ */
 export const LegatoCapacitor = registerPlugin<LegatoCapacitorPlugin>('Legato');
 
 const sharedDelegate = {
@@ -163,6 +166,9 @@ const addLegatoListener: LegatoEventApi['addListener'] = <E extends LegatoEventN
   listener: LegatoListener<E>,
 ) => LegatoCapacitor.addListener(eventName, listener);
 
+/**
+ * Playback command namespace backed by the Legato Capacitor plugin.
+ */
 export const audioPlayer: AudioPlayerApi = {
   setup: sharedDelegate.setup,
   add: sharedDelegate.add,
@@ -186,12 +192,18 @@ export const audioPlayer: AudioPlayerApi = {
   removeAllListeners: sharedDelegate.removeAllListeners,
 };
 
+/**
+ * Media-session command namespace backed by the Legato Capacitor plugin.
+ */
 export const mediaSession: MediaSessionApi = {
   setup: sharedDelegate.setup,
   addListener: addMediaSessionListener,
   removeAllListeners: sharedDelegate.removeAllListeners,
 };
 
+/**
+ * Unified runtime facade combining playback, media-session, and listener APIs.
+ */
 export const Legato: LegatoApi & LegatoEventApi = {
   ...audioPlayer,
   ...mediaSession,

--- a/packages/capacitor/src/sync.ts
+++ b/packages/capacitor/src/sync.ts
@@ -10,12 +10,21 @@ import { Legato } from './plugin';
 
 type SyncClient = AudioPlayerApi;
 
+/**
+ * Configuration options for sync-controller creation.
+ */
 export interface LegatoSyncOptions {
+  /** Optional playback client override; defaults to the exported `Legato` facade. */
   client?: SyncClient;
+  /** Optional callback invoked when local snapshot state changes. */
   onSnapshot?: (snapshot: PlaybackSnapshot) => void;
+  /** Optional callback invoked for each received event payload. */
   onEvent?: <E extends LegatoEventName>(eventName: E, payload: LegatoEventPayloadMap[E]) => void;
 }
 
+/**
+ * Controller API for maintaining a local playback snapshot mirror.
+ */
 export interface LegatoSyncController {
   start(): Promise<PlaybackSnapshot>;
   resync(): Promise<PlaybackSnapshot>;
@@ -23,12 +32,24 @@ export interface LegatoSyncController {
   stop(): Promise<void>;
 }
 
+/**
+ * Alias for clients accepted by audio-player sync helpers.
+ */
 export type AudioPlayerSyncClient = AudioPlayerApi;
 
+/**
+ * Audio-player-specific options for sync-controller creation.
+ */
 export interface AudioPlayerSyncOptions extends LegatoSyncOptions {
+  /** Optional playback client override constrained to the audio-player surface. */
   client?: AudioPlayerSyncClient;
 }
 
+/**
+ * Creates a snapshot sync controller driven by Legato playback events.
+ * @param options Optional sync hooks and client override.
+ * @returns Controller that starts, resyncs, inspects, and stops snapshot synchronization.
+ */
 export function createLegatoSync(options: LegatoSyncOptions = {}): LegatoSyncController {
   const client = options.client ?? Legato;
   const handles: BindingListenerHandle[] = [];
@@ -133,6 +154,11 @@ export function createLegatoSync(options: LegatoSyncOptions = {}): LegatoSyncCon
   };
 }
 
+/**
+ * Creates a sync controller using the audio-player client surface.
+ * @param options Optional sync hooks and client override.
+ * @returns Controller delegating to `createLegatoSync`.
+ */
 export function createAudioPlayerSync(options: AudioPlayerSyncOptions = {}): LegatoSyncController {
   return createLegatoSync(options);
 }

--- a/packages/contract/src/binding-adapter.ts
+++ b/packages/contract/src/binding-adapter.ts
@@ -6,36 +6,69 @@ import type { PlaybackSnapshot } from './snapshot.js';
 import type { PlaybackState } from './state.js';
 import type { Track } from './track.js';
 
+/**
+ * Listener registration handle returned by adapter listener APIs.
+ */
 export interface BindingListenerHandle {
+  /** Detaches the listener from the underlying adapter implementation. */
   remove(): Promise<void> | void;
 }
 
+/**
+ * Snapshot of currently supported runtime capabilities.
+ */
 export interface BindingCapabilitiesSnapshot {
+  /** Capability identifiers currently supported by the runtime. */
   supported: Capability[];
 }
 
+/**
+ * Adapter error payload enriched with optional source metadata.
+ */
 export interface BindingAdapterError extends LegatoError {
+  /** Optional source subsystem that produced the error. */
   source?: string;
 }
 
+/**
+ * Options for adding one or more tracks to the queue.
+ */
 export interface AddOptions {
+  /** Tracks to append to the runtime queue. */
   tracks: Track[];
+  /** Optional index to start playback from after insertion. */
   startIndex?: number;
 }
 
+/**
+ * Options for removing tracks from the queue.
+ */
 export interface RemoveOptions {
+  /** Optional track identifier target for removal. */
   id?: string;
+  /** Optional queue index target for removal. */
   index?: number;
 }
 
+/**
+ * Options for seeking playback position.
+ */
 export interface SeekToOptions {
+  /** Target playback position in seconds. */
   position: number;
 }
 
+/**
+ * Options for skipping to an absolute queue index.
+ */
 export interface SkipToOptions {
+  /** Queue index to activate. */
   index: number;
 }
 
+/**
+ * Runtime-agnostic adapter contract implemented by host bindings.
+ */
 export interface BindingAdapter {
   setup(): Promise<void>;
   add(options: AddOptions): Promise<PlaybackSnapshot>;

--- a/packages/contract/src/capability.ts
+++ b/packages/contract/src/capability.ts
@@ -1,3 +1,6 @@
+/**
+ * Runtime capability literals projected by the adapter boundary.
+ */
 export const CAPABILITIES = [
   'play',
   'pause',
@@ -8,4 +11,7 @@ export const CAPABILITIES = [
   'skip-previous'
 ] as const;
 
+/**
+ * Union of runtime capability values.
+ */
 export type Capability = (typeof CAPABILITIES)[number];

--- a/packages/contract/src/errors.ts
+++ b/packages/contract/src/errors.ts
@@ -1,3 +1,6 @@
+/**
+ * Stable error code literals emitted by the Legato boundary.
+ */
 export const LEGATO_ERROR_CODES = [
   'player_not_setup',
   'invalid_index',
@@ -11,10 +14,19 @@ export const LEGATO_ERROR_CODES = [
   'platform_error'
 ] as const;
 
+/**
+ * Union of Legato error code values.
+ */
 export type LegatoErrorCode = (typeof LEGATO_ERROR_CODES)[number];
 
+/**
+ * Error payload shape used by playback-error events and API failures.
+ */
 export interface LegatoError {
+  /** Stable machine-readable code. */
   code: LegatoErrorCode;
+  /** Human-readable error message from adapter/runtime. */
   message: string;
+  /** Optional transport-specific details. */
   details?: unknown;
 }

--- a/packages/contract/src/events.ts
+++ b/packages/contract/src/events.ts
@@ -4,6 +4,9 @@ import type { PlaybackState } from './state.js';
 import type { QueueSnapshot } from './queue.js';
 import type { Track } from './track.js';
 
+/**
+ * Playback lifecycle event names published by the player surface.
+ */
 export const PLAYER_EVENT_NAMES = [
   'playback-state-changed',
   'playback-active-track-changed',
@@ -13,6 +16,9 @@ export const PLAYER_EVENT_NAMES = [
   'playback-error',
 ] as const;
 
+/**
+ * Remote command event names published by media session controls.
+ */
 export const MEDIA_SESSION_EVENT_NAMES = [
   'remote-play',
   'remote-pause',
@@ -21,36 +27,70 @@ export const MEDIA_SESSION_EVENT_NAMES = [
   'remote-seek',
 ] as const;
 
+/**
+ * Legacy composite event list preserving player and media session names.
+ */
 export const LEGACY_PLAYER_EVENT_NAMES = [
   ...PLAYER_EVENT_NAMES,
   ...MEDIA_SESSION_EVENT_NAMES,
 ] as const;
 
+/**
+ * Canonical event-name tuple used by the unified Legato surface.
+ */
 export const LEGATO_EVENT_NAMES = LEGACY_PLAYER_EVENT_NAMES;
 
+/**
+ * Union of player lifecycle event names.
+ */
 export type PlayerEventName = (typeof PLAYER_EVENT_NAMES)[number];
+/**
+ * Union of media session event names.
+ */
 export type MediaSessionEventName = (typeof MEDIA_SESSION_EVENT_NAMES)[number];
+/**
+ * Union of legacy player and media session event names.
+ */
 export type LegacyPlayerEventName = (typeof LEGACY_PLAYER_EVENT_NAMES)[number];
 
+/**
+ * Union of canonical Legato event names.
+ */
 export type LegatoEventName = LegacyPlayerEventName;
 
+/**
+ * Payload map keyed by player lifecycle event name.
+ */
 export interface PlayerEventPayloadMap {
+  /** Player state transition payload. */
   'playback-state-changed': { state: PlaybackState };
+  /** Active track/index transition payload. */
   'playback-active-track-changed': { track: Track | null; index: number | null };
+  /** Queue projection update payload. */
   'playback-queue-changed': { queue: QueueSnapshot };
+  /** Position/duration/buffer progress payload. */
   'playback-progress': {
     position: number;
     duration: number | null;
     bufferedPosition: number | null;
   };
+  /** Terminal playback snapshot payload. */
   'playback-ended': { snapshot: PlaybackSnapshot };
+  /** Error payload emitted by playback boundary. */
   'playback-error': { error: LegatoError };
 }
 
+/**
+ * Payload map keyed by media session remote command name.
+ */
 export interface MediaSessionEventPayloadMap {
+  /** Remote play command payload. */
   'remote-play': Record<string, never>;
+  /** Remote pause command payload. */
   'remote-pause': Record<string, never>;
+  /** Remote next command payload. */
   'remote-next': Record<string, never>;
+  /** Remote previous command payload. */
   'remote-previous': Record<string, never>;
   /**
    * Emitted only when runtime-projected seek capability is enabled (`getCapabilities().supported` includes `seek`).
@@ -58,12 +98,30 @@ export interface MediaSessionEventPayloadMap {
   'remote-seek': { position: number };
 }
 
+/**
+ * Composite payload map for the legacy event namespace.
+ */
 export type LegacyPlayerEventPayloadMap = PlayerEventPayloadMap & MediaSessionEventPayloadMap;
 
+/**
+ * Composite payload map for the canonical Legato event namespace.
+ */
 export type LegatoEventPayloadMap = LegacyPlayerEventPayloadMap;
 
+/**
+ * Payload type for a specific player lifecycle event name.
+ */
 export type PlayerEventPayload<E extends PlayerEventName> = PlayerEventPayloadMap[E];
+/**
+ * Payload type for a specific media session event name.
+ */
 export type MediaSessionEventPayload<E extends MediaSessionEventName> = MediaSessionEventPayloadMap[E];
+/**
+ * Payload type for a specific legacy event name.
+ */
 export type LegacyPlayerEventPayload<E extends LegacyPlayerEventName> = LegacyPlayerEventPayloadMap[E];
 
+/**
+ * Payload type for a specific canonical Legato event name.
+ */
 export type LegatoEventPayload<E extends LegatoEventName> = LegacyPlayerEventPayload<E>;

--- a/packages/contract/src/invariants.ts
+++ b/packages/contract/src/invariants.ts
@@ -1,5 +1,11 @@
+/**
+ * Minimum allowed playback position value.
+ */
 export const POSITION_MIN = 0;
 
+/**
+ * String constants describing invariant expectations enforced across snapshots.
+ */
 export const LEGATO_INVARIANTS = {
   TRACK_ID_MUST_BE_NON_EMPTY: 'track.id must be a non-empty string',
   TRACK_URL_MUST_BE_NON_EMPTY: 'track.url must be a non-empty string',

--- a/packages/contract/src/queue.ts
+++ b/packages/contract/src/queue.ts
@@ -1,6 +1,11 @@
 import type { Track } from './track.js';
 
+/**
+ * Serializable queue projection used by contract snapshots and events.
+ */
 export interface QueueSnapshot {
+  /** Ordered queue items. */
   items: Track[];
+  /** Active queue index, or `null` when no active item exists. */
   currentIndex: number | null;
 }

--- a/packages/contract/src/snapshot.ts
+++ b/packages/contract/src/snapshot.ts
@@ -2,10 +2,17 @@ import type { QueueSnapshot } from './queue.js';
 import type { PlaybackState } from './state.js';
 import type { Track } from './track.js';
 
+/**
+ * Playback snapshot contract returned by adapter read APIs and events.
+ */
 export interface PlaybackSnapshot {
+  /** Current playback state. */
   state: PlaybackState;
+  /** Current active track, or `null` when none is active. */
   currentTrack: Track | null;
+  /** Current active queue index, or `null` when none is active. */
   currentIndex: number | null;
+  /** Playback position in seconds. */
   position: number;
   /**
    * Nullable duration semantics:
@@ -15,6 +22,8 @@ export interface PlaybackSnapshot {
    * Consumers should combine duration with projected `canSeek` capability.
    */
   duration: number | null;
+  /** Buffered position in seconds when provided by runtime. */
   bufferedPosition?: number | null;
+  /** Queue projection associated with the snapshot. */
   queue: QueueSnapshot;
 }

--- a/packages/contract/src/state.ts
+++ b/packages/contract/src/state.ts
@@ -1,3 +1,6 @@
+/**
+ * Canonical playback state literals emitted by Legato runtimes.
+ */
 export const PLAYBACK_STATES = [
   'idle',
   'loading',
@@ -9,4 +12,7 @@ export const PLAYBACK_STATES = [
   'error'
 ] as const;
 
+/**
+ * Union of playback state values.
+ */
 export type PlaybackState = (typeof PLAYBACK_STATES)[number];

--- a/packages/contract/src/track.ts
+++ b/packages/contract/src/track.ts
@@ -1,14 +1,30 @@
+/**
+ * Supported media track kinds accepted by the Legato contract.
+ */
 export const TRACK_TYPES = ['file', 'progressive', 'hls', 'dash'] as const;
 
+/**
+ * Union of supported track kind literals.
+ */
 export type TrackType = (typeof TRACK_TYPES)[number];
 
+/**
+ * Queue item shape shared across adapter and consumer boundaries.
+ */
 export interface Track {
+  /** Stable track identifier used by remove/skip operations. */
   id: string;
+  /** Playback URL consumed by the native media transport. */
   url: string;
+  /** Optional display title metadata. */
   title?: string;
+  /** Optional display artist metadata. */
   artist?: string;
+  /** Optional display album metadata. */
   album?: string;
+  /** Optional artwork URL for lockscreen/notification surfaces. */
   artwork?: string;
+  /** Optional track duration in seconds when known. */
   duration?: number;
   /**
    * Declared media semantics used by native capability projectors.


### PR DESCRIPTION
Closes #108

## Summary
- complete JSDoc coverage for all root-exported public API in `@ddgutierrezc/legato-contract` and `@ddgutierrezc/legato-capacitor`
- add declaration-level validator logic so documentation completeness is enforced against emitted `.d.ts` artifacts
- add maintainer-facing guidance for how to keep public API docs complete and source-backed

## Changes
| File | Change |
|------|--------|
| `packages/contract/src/*.ts` | adds/expands JSDoc across all root-exported public symbols |
| `packages/capacitor/src/{definitions,events,plugin,sync}.ts` | adds/expands JSDoc for the public Capacitor surface |
| `packages/capacitor/scripts/assert-package-entries.mjs` | adds root-export inventory + emitted declaration JSDoc validation |
| `packages/capacitor/scripts/__tests__/jsdoc-completeness.test.mjs` | proves inventory, missing-doc failure paths, and closure-stage policy checks |
| `docs/maintainers/public-api-jsdoc-completeness-v1.md` | documents the completeness rules and maintainer workflow |
| `docs/maintainers/package-documentation-foundation-v1-source-map.md` | extends source-map/troubleshooting guidance for API JSDoc enforcement |

## Test Plan
- [x] `node --test packages/capacitor/scripts/__tests__/jsdoc-completeness.test.mjs packages/capacitor/scripts/__tests__/package-ergonomics.test.mjs`
- [x] `cd packages/contract && npm run readiness:entries`
- [x] `cd packages/capacitor && npm run readiness:entries`
- [x] No shell scripts changed

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Documentation updated intentionally for public API DX
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers