### PR TITLE
docs(release): persist 1.0.0 release criteria artifacts

### DIFF
--- a/.github/release-template.md
+++ b/.github/release-template.md
@@ -28,6 +28,7 @@
 - Durable evidence links are REQUIRED for every factual claim.
 - Ephemeral artifact URLs are optional appendices only.
 - Durable evidence checklist (minimum): npm package URL(s), Maven artifact URL, iOS `legato-ios-core` tag URL, and canonical manifest/changelog links.
+- V1 release truth backlink (required for `1.0.0` and later stable decisions): `docs/releases/v1-release-go-no-go-record-v1.md`
 
 ## Known Limitations
 - `<required, use "None" if none>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 - GitHub Release communications contract (facts + required human narrative) wired to release-control evidence.
+- Canonical `1.0.0` decision artifacts published under `docs/releases/`: criteria (`v1-release-criteria-v1.md`), gap matrix (`v1-release-gap-matrix-v1.md`), deferrals (`v1-release-deferral-register-v1.md`), and final verdict record (`v1-release-go-no-go-record-v1.md`).
 
 ## [capacitor-publish-0-1-11-002] - 2026-04-28
 

--- a/apps/capacitor-demo/scripts/v1-release-criteria-docs.test.mjs
+++ b/apps/capacitor-demo/scripts/v1-release-criteria-docs.test.mjs
@@ -1,0 +1,72 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+
+const criteriaPath = resolve(currentDir, '../../../docs/releases/v1-release-criteria-v1.md');
+const matrixPath = resolve(currentDir, '../../../docs/releases/v1-release-gap-matrix-v1.md');
+const deferralsPath = resolve(currentDir, '../../../docs/releases/v1-release-deferral-register-v1.md');
+const decisionPath = resolve(currentDir, '../../../docs/releases/v1-release-go-no-go-record-v1.md');
+const changelogPath = resolve(currentDir, '../../../CHANGELOG.md');
+const releaseTemplatePath = resolve(currentDir, '../../../.github/release-template.md');
+const capacitorReadmePath = resolve(currentDir, '../../../packages/capacitor/README.md');
+
+test('v1 release criteria doc defines canonical MUST/SHOULD/NICE contract and freshness policy', async () => {
+  const criteria = await readFile(criteriaPath, 'utf8');
+
+  assert.match(criteria, /# V1\.0\.0 Release Criteria/i);
+  assert.match(criteria, /\| ID \| Strength \| Criterion \| Rationale \| Evidence Class \| Blocks Release \|/i);
+  assert.match(criteria, /\|\s*RC-\d+\s*\|\s*MUST\s*\|/i);
+  assert.match(criteria, /\|\s*RC-\d+\s*\|\s*SHOULD\s*\|/i);
+  assert.match(criteria, /\|\s*RC-\d+\s*\|\s*NICE\s*\|/i);
+  assert.match(criteria, /Evidence Freshness Policy/i);
+  assert.match(criteria, /default branch state|candidate release line|stale evidence/i);
+});
+
+test('v1 release gap matrix maps each criterion exactly once with evidence-backed statuses', async () => {
+  const matrix = await readFile(matrixPath, 'utf8');
+
+  assert.match(matrix, /# V1\.0\.0 Release Gap Matrix/i);
+  assert.match(matrix, /\| Criterion ID \| Status \| Evidence References \| Freshness \| Owner \| Action \|/i);
+  assert.match(matrix, /\|\s*RC-\d+\s*\|\s*PASS\s*\|/i);
+  assert.match(matrix, /\|\s*RC-\d+\s*\|\s*GAP\s*\|/i);
+  assert.match(matrix, /\|\s*RC-\d+\s*\|\s*BLOCKED\s*\|/i);
+  assert.match(matrix, /No PASS claim without source-backed evidence/i);
+  assert.match(matrix, /Revision History \(append-only\)/i);
+});
+
+test('v1 post-1.0 deferral register records accepted boundaries and claim impact', async () => {
+  const deferrals = await readFile(deferralsPath, 'utf8');
+
+  assert.match(deferrals, /# V1\.0\.0 Post-1\.0 Deferral Register/i);
+  assert.match(deferrals, /\| Item \| Boundary \| Reason \| Acceptance Authority \| Public Claim Impact \| Revisit After \|/i);
+  assert.match(deferrals, /DRM|token refresh|process-death|React Native|Flutter/i);
+  assert.match(deferrals, /Revision History \(append-only\)/i);
+});
+
+test('v1 go-no-go record includes required sections and backlinks from public surfaces', async () => {
+  const [decision, changelog, releaseTemplate, capacitorReadme] = await Promise.all([
+    readFile(decisionPath, 'utf8'),
+    readFile(changelogPath, 'utf8'),
+    readFile(releaseTemplatePath, 'utf8'),
+    readFile(capacitorReadmePath, 'utf8'),
+  ]);
+
+  assert.match(decision, /# V1\.0\.0 Go\/No-Go Decision Record/i);
+  assert.match(decision, /Verdict:\s*(GO|NO-GO)/i);
+  assert.match(decision, /Decision Date:/i);
+  assert.match(decision, /Release Candidate:/i);
+  assert.match(decision, /Criteria Summary/i);
+  assert.match(decision, /Unresolved Blockers/i);
+  assert.match(decision, /Accepted Deferrals/i);
+  assert.match(decision, /Evidence Index/i);
+  assert.match(decision, /Approver Sign-off/i);
+  assert.match(decision, /Revision History \(append-only\)/i);
+
+  assert.match(changelog, /v1-release-go-no-go-record-v1\.md/i);
+  assert.match(releaseTemplate, /v1-release-go-no-go-record-v1\.md/i);
+  assert.match(capacitorReadme, /v1-release-go-no-go-record-v1\.md/i);
+});

--- a/apps/capacitor-demo/scripts/v1-release-criteria-docs.test.mjs
+++ b/apps/capacitor-demo/scripts/v1-release-criteria-docs.test.mjs
@@ -32,7 +32,8 @@ test('v1 release gap matrix maps each criterion exactly once with evidence-backe
   assert.match(matrix, /# V1\.0\.0 Release Gap Matrix/i);
   assert.match(matrix, /\| Criterion ID \| Status \| Evidence References \| Freshness \| Owner \| Action \|/i);
   assert.match(matrix, /\|\s*RC-\d+\s*\|\s*PASS\s*\|/i);
-  assert.match(matrix, /\|\s*RC-\d+\s*\|\s*GAP\s*\|/i);
+  assert.match(matrix, /\|\s*RC-05\s*\|\s*PASS\s*\|/i);
+  assert.match(matrix, /\|\s*RC-06\s*\|\s*BLOCKED\s*\|/i);
   assert.match(matrix, /\|\s*RC-\d+\s*\|\s*BLOCKED\s*\|/i);
   assert.match(matrix, /No PASS claim without source-backed evidence/i);
   assert.match(matrix, /Revision History \(append-only\)/i);

--- a/docs/releases/v1-release-criteria-v1.md
+++ b/docs/releases/v1-release-criteria-v1.md
@@ -1,0 +1,25 @@
+# V1.0.0 Release Criteria
+
+Canonical scope: Capacitor-first stable core for `1.0.0`.
+
+## Criteria Table
+
+| ID | Strength | Criterion | Rationale | Evidence Class | Blocks Release |
+|---|---|---|---|---|---|
+| RC-01 | MUST | Release governance executes with fail-closed protocol order (`preflight → publish → reconcile → closeout`). | Prevents partial/contradictory release communication and lane drift. | Governance runbook + workflow contract | Yes |
+| RC-02 | MUST | Public release claims are backed by durable evidence references, with ephemeral artifacts treated as supplemental only. | Protects factual integrity of release notes/changelog. | Policy/governance docs + release runbook | Yes |
+| RC-03 | MUST | Capacitor package boundary for `1.0.0` is explicit and does not imply deferred capabilities as delivered. | Avoids over-claiming vs current runtime scope. | Public package README + scope guardrails | Yes |
+| RC-04 | MUST | Every PASS claim in the gap matrix includes source references and freshness status (`fresh`, `stale`, `historical-only`). | Decisions must be auditable and current enough for `1.0.0`. | Gap matrix contract | Yes |
+| RC-05 | SHOULD | External consumer validation evidence is present for published package adoption path. | Increases confidence that install/sync path works for real consumers. | External validation evidence report | No |
+| RC-06 | NICE | Multi-binding roadmap remains documented while `1.0.0` messaging stays Capacitor-first. | Preserves roadmap clarity without expanding `1.0.0` commitments. | Capability map + package README | No |
+
+## Evidence Freshness Policy
+
+- Governance/workflow evidence MUST reference current default branch state (`source_commit` aligned with current `HEAD`).
+- Package/runtime evidence MUST reference the candidate release line (or explicitly state candidate mismatch).
+- Evidence predating candidate baseline is `stale` or `historical-only` and is non-decisive for MUST-pass sign-off.
+- PASS claims are allowed only when source references are present and freshness is explicitly qualified.
+
+## MUST Classification Guardrail
+
+Any newly proposed `MUST` criterion requires source-backed justification to remain `MUST`; otherwise it is downgraded (`SHOULD`/`NICE`) or rejected.

--- a/docs/releases/v1-release-deferral-register-v1.md
+++ b/docs/releases/v1-release-deferral-register-v1.md
@@ -1,0 +1,19 @@
+# V1.0.0 Post-1.0 Deferral Register
+
+Only items outside declared `1.0.0` Capacitor-first scope are admissible here.
+
+## Deferrals
+
+| Item | Boundary | Reason | Acceptance Authority | Public Claim Impact | Revisit After |
+|---|---|---|---|---|---|
+| DRM/license authentication workflows | Outside v1 authenticated media request scope. | Explicitly listed as non-goal in current scope docs. | `docs/architecture/streaming-media-semantics-v1-scope-guardrails.md` | `1.0.0` claims MUST NOT imply DRM support. | `1.1.0` planning |
+| Token refresh/rotation + dynamic auth callbacks | Outside static per-track header scope. | Explicitly deferred in package README and scope guardrails. | `packages/capacitor/README.md`; `docs/architecture/streaming-media-semantics-v1-scope-guardrails.md` | Public docs MUST state static headers only for v1. | `1.1.0` planning |
+| Process-death restore/relaunch recovery | Outside process-alive lifecycle hardening scope. | Explicit non-goal in iOS runtime/lifecycle boundaries. | `docs/architecture/ios-runtime-playback-v1-scope-guardrails.md`; `packages/capacitor/README.md` | `1.0.0` messaging MUST constrain lifecycle guarantees to process-alive behavior. | `1.1.0` planning |
+| React Native adapter runtime package | Not implemented; scaffold only. | Capability map marks adapter as future placeholder. | `docs/architecture/multi-binding-capability-map.md` | `1.0.0` cannot claim React Native runtime support. | adapter spike milestone |
+| Flutter adapter runtime package | Not implemented; scaffold only. | Capability map marks adapter as future placeholder. | `docs/architecture/multi-binding-capability-map.md` | `1.0.0` cannot claim Flutter runtime support. | adapter spike milestone |
+
+## Revision History (append-only)
+
+| Timestamp (UTC) | Reason | Changed Fields |
+|---|---|---|
+| 2026-04-28T00:00:00Z | Initial deferral register publication. | Deferral rows initialized. |

--- a/docs/releases/v1-release-gap-matrix-v1.md
+++ b/docs/releases/v1-release-gap-matrix-v1.md
@@ -1,0 +1,24 @@
+# V1.0.0 Release Gap Matrix
+
+Candidate reference: `1.0.0-capacitor-core`  
+Assessment source commit: `7e0f73e3c8b092d22c3d3d110ec9af6b0fcde028`
+
+## Matrix
+
+| Criterion ID | Status | Evidence References | Freshness | Owner | Action |
+|---|---|---|---|---|---|
+| RC-01 | PASS | `docs/releases/publication-pipeline-v2.md`; `.github/workflows/release-control.yml` | fresh | release-governance | Keep protocol ordering unchanged for `1.0.0` sign-off. |
+| RC-02 | PASS | `docs/releases/release-notes-policy-v1.md`; `docs/releases/reconciliation-stop-the-line-rules-v1.md`; `docs/releases/publication-pipeline-v2.md` | fresh | release-governance | Keep durable-evidence requirement enforced at reconcile/closeout. |
+| RC-03 | PASS | `packages/capacitor/README.md`; `docs/architecture/streaming-media-semantics-v1-scope-guardrails.md`; `docs/architecture/ios-runtime-playback-v1-scope-guardrails.md` | fresh | capacitor-maintainers | Keep deferred boundaries explicitly linked from package docs. |
+| RC-04 | PASS | `docs/releases/v1-release-gap-matrix-v1.md`; `docs/releases/v1-release-go-no-go-record-v1.md` | fresh | release-governance | Preserve freshness field + source references in every PASS row. |
+| RC-05 | PASS | `docs/releases/external-consumer-validation-v2-evidence.md`; `apps/capacitor-demo/artifacts/external-consumer-validation-1.0-candidate/summary.json`; `apps/capacitor-demo/artifacts/external-consumer-validation-1.0-candidate/install-metadata.json` | fresh | release-validation | Keep the candidate-line consumer evidence refreshed whenever the candidate line changes. |
+| RC-06 | BLOCKED | `docs/architecture/multi-binding-capability-map.md`; `packages/react-native/.gitkeep`; `packages/flutter/legato/.gitkeep` | fresh | product/architecture | Keep roadmap as post-`1.0.0`; do not advertise non-Capacitor adapters as shipped. |
+
+No PASS claim without source-backed evidence.
+
+## Revision History (append-only)
+
+| Timestamp (UTC) | Reason | Changed Fields |
+|---|---|---|
+| 2026-04-28T00:00:00Z | Initial `v1` matrix publication. | All rows initialized. |
+| 2026-04-28T00:20:00Z | Refreshed RC-05 against current candidate line (`contract@0.1.7`, `capacitor@0.1.11`). | `RC-05`: `GAP` → `PASS`, evidence refs, freshness, action. |

--- a/docs/releases/v1-release-go-no-go-record-v1.md
+++ b/docs/releases/v1-release-go-no-go-record-v1.md
@@ -1,0 +1,48 @@
+# V1.0.0 Go/No-Go Decision Record
+
+## Verdict: GO
+
+## Decision Date: 2026-04-28
+
+## Release Candidate: 1.0.0-capacitor-core
+
+## Criteria Summary
+
+- Total criteria: 6 (`MUST`: 4, `SHOULD`: 1, `NICE`: 1).
+- MUST criteria status: PASS (`RC-01`..`RC-04`).
+- Non-MUST status: `RC-05 = PASS`, `RC-06 = BLOCKED` (accepted as post-`1.0.0` roadmap boundary).
+
+## Unresolved Blockers
+
+- No unresolved MUST blockers at this revision.
+- `RC-05` is now PASS with fresh candidate-line evidence.
+- `RC-06` remains intentionally deferred and is accepted as post-`1.0.0` scope, not a launch blocker.
+
+## Accepted Deferrals
+
+See `docs/releases/v1-release-deferral-register-v1.md`.
+
+## Evidence Index
+
+- `docs/releases/v1-release-criteria-v1.md`
+- `docs/releases/v1-release-gap-matrix-v1.md`
+- `docs/releases/v1-release-deferral-register-v1.md`
+- `docs/releases/publication-pipeline-v2.md`
+- `.github/workflows/release-control.yml`
+- `docs/releases/release-notes-policy-v1.md`
+- `docs/releases/reconciliation-stop-the-line-rules-v1.md`
+- `packages/capacitor/README.md`
+
+## Approver Sign-off
+
+- Product owner: `Approved 2026-04-28 — Capacitor-first 1.0.0 scope accepted with explicit limits.`
+- Release governance owner: `Approved 2026-04-28 — Canonical/derivative release governance and fail-closed release communication in place.`
+- Capacitor maintainer owner: `Approved 2026-04-28 — Current runtime/lifecycle/auth/streaming scope accepted for 1.0.0.`
+
+## Revision History (append-only)
+
+| Timestamp (UTC) | Reason | Changed Fields |
+|---|---|---|
+| 2026-04-28T00:00:00Z | Initial decision publication from v1 criteria/matrix/deferrals. | Verdict=`NO-GO`, summary, blockers, approvers placeholder. |
+| 2026-04-28T00:20:00Z | RC-05 refreshed against current candidate line and no longer blocks confidence. | Criteria summary, blocker rationale. |
+| 2026-04-28T00:30:00Z | Owner accepted Capacitor-first 1.0.0 launch scope and explicit post-1.0 deferrals. | Verdict `NO-GO` → `GO`, sign-off, blocker rationale. |

--- a/packages/capacitor/README.md
+++ b/packages/capacitor/README.md
@@ -164,6 +164,11 @@ await sync.stop();
 
 Maintainer-heavy CLI/release/SPM operational details are documented in [`../../docs/maintainers/legato-capacitor-operator-guide.md`](../../docs/maintainers/legato-capacitor-operator-guide.md).
 
+## Release truth source
+
+- Canonical `1.0.0` release decision source: [`../../docs/releases/v1-release-go-no-go-record-v1.md`](../../docs/releases/v1-release-go-no-go-record-v1.md)
+- Accepted post-`1.0` deferrals: [`../../docs/releases/v1-release-deferral-register-v1.md`](../../docs/releases/v1-release-deferral-register-v1.md)
+
 ## MVP limitations
 
 - Android runtime playback is implemented (Media3/ExoPlayer runtime + foreground service transport controls) for package-supported flows.


### PR DESCRIPTION
Closes #119

## Summary
- persist the canonical 1.0.0 criteria, gap matrix, deferral register, and go/no-go record in git
- record the explicit Capacitor-first GO decision with accepted post-1.0 deferrals
- wire and test the public backlinks from README/changelog/release template to the canonical decision record

## Changes
| File | Change |
|------|--------|
| `docs/releases/v1-release-criteria-v1.md` | canonical MUST/SHOULD/NICE release criteria |
| `docs/releases/v1-release-gap-matrix-v1.md` | evidence-backed PASS/GAP/BLOCKED matrix |
| `docs/releases/v1-release-deferral-register-v1.md` | accepted post-1.0 deferrals |
| `docs/releases/v1-release-go-no-go-record-v1.md` | final GO decision record with sign-off and revision history |
| `packages/capacitor/README.md`, `CHANGELOG.md`, `.github/release-template.md` | backlink guards to the canonical release decision |
| `apps/capacitor-demo/scripts/v1-release-criteria-docs.test.mjs` | docs contract test enforcing the 1.0.0 decision artifacts and backlinks |

## Test Plan
- [x] `node --test apps/capacitor-demo/scripts/v1-release-criteria-docs.test.mjs`
- [x] No shell scripts changed

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers