### PR TITLE
fix(release): persist release reliability v2

### DIFF
--- a/.github/workflows/release-control.yml
+++ b/.github/workflows/release-control.yml
@@ -134,15 +134,14 @@ jobs:
           echo "ios_release_version=$ios_version" >> "$GITHUB_OUTPUT"
           echo "ios_release_tag=$ios_tag" >> "$GITHUB_OUTPUT"
 
-      - name: Materialize release execution packet
+      - name: Prepare release execution packet + preflight contract
         id: release-packet
         shell: bash
         run: |
           set -euo pipefail
-          packet_dir="./artifacts/release-control/${{ inputs.release_id }}"
-          packet_path="$packet_dir/release-execution-packet.json"
-          mkdir -p "$packet_dir"
-          node -e 'const fs=require("node:fs");const path=require("node:path");const c=JSON.parse(fs.readFileSync("./artifacts/release-control-contract.json","utf8"));const packet={...(c.value?.packet ?? {}),phase:"preflight",repo_root:path.resolve(process.cwd(),"../..")};if(!packet.schema_version){throw new Error("missing release packet in contract output")}fs.writeFileSync(process.argv[1], `${JSON.stringify(packet,null,2)}\n`,"utf8");' "$packet_path"
+          packet_path="./artifacts/release-control/${{ inputs.release_id }}/release-execution-packet.json"
+          mkdir -p "./artifacts/release-control/${{ inputs.release_id }}"
+          npm run release:prepare -- --release-id "${{ inputs.release_id }}" --targets "${{ inputs.targets }}" --target-modes "${{ inputs.target_modes }}" --repo-root ../.. --npm-package-target "${{ inputs.npm_package_target }}" > "./artifacts/release-control/${{ inputs.release_id }}/prepare.json"
           echo "release_packet_path=$packet_path" >> "$GITHUB_OUTPUT"
 
       - name: Upload release execution packet

--- a/apps/capacitor-demo/package.json
+++ b/apps/capacitor-demo/package.json
@@ -24,6 +24,7 @@
     "test:release:confidence": "node --test ./scripts/release-paths.test.mjs ./scripts/release-control-contract.test.mjs ./scripts/release-control-workflow.test.mjs ./scripts/release-github-notes-workflow.test.mjs ./scripts/release-control-summary-schema.test.mjs ./scripts/release-ops-diagnostics.test.mjs ./scripts/release-preflight-completeness.test.mjs ./scripts/release-closure-bundle.test.mjs ./scripts/validate-release-closeout.test.mjs ./scripts/release-ios-execution.test.mjs ./scripts/release-npm-workflow.test.mjs ./scripts/aggregate-release-summary.test.mjs ./scripts/publication-pipeline-v2-docs.test.mjs ./scripts/release-communication-governance-v1-docs.test.mjs ./scripts/validate-mixed-canary-head.test.mjs ./scripts/release-changelog-facts.test.mjs ./scripts/release-changelog-update.test.mjs ./scripts/generate-github-release-notes.test.mjs ./scripts/validate-release-reconciliation.test.mjs ./scripts/persist-release-evidence-index.test.mjs ./scripts/release-notes-docs.test.mjs",
     "release:confidence:fresh-head:check": "node ./scripts/validate-mixed-canary-head.mjs --evidence-file ../../docs/releases/closure-evidence-canary-mixed-app-005.md",
     "release:control:contract:check": "node ./scripts/release-control-contract.mjs",
+    "release:prepare": "node ./scripts/release-prepare.mjs",
     "release:control:summary:aggregate": "node ./scripts/aggregate-release-summary.mjs",
     "release:changelog:facts": "node ./scripts/release-changelog-facts.mjs",
     "release:notes:generate": "node ./scripts/generate-github-release-notes.mjs",

--- a/apps/capacitor-demo/scripts/release-changelog-facts.test.mjs
+++ b/apps/capacitor-demo/scripts/release-changelog-facts.test.mjs
@@ -46,16 +46,24 @@ const createFixtureRepo = async () => {
   }, null, 2));
 
   await writeFile(resolve(root, 'apps/capacitor-demo/artifacts/release-control/R-2026.04.26.1/release-execution-packet.json'), JSON.stringify({
-    schema_version: 'release-execution-packet/v1',
+    schema_version: 'release-execution-packet/v2',
     release_id: 'R-2026.04.26.1',
     phase: 'reconcile',
     repo_root: root,
+    release_identity: { channel: 'stable', version: '0.1.1', package_target: 'contract', release_key: 'stable/v0.1.1/contract' },
     selected_targets: ['android', 'ios', 'npm'],
     target_modes: { android: 'publish', ios: 'publish', npm: 'protected-publish' },
     inputs: {
-      narrative_ref: 'docs/releases/notes/R-2026.04.26.1.json',
-      ios_derivative_ref: 'docs/releases/notes/R-2026.04.26.1-ios-derivative.md',
-      changelog_anchor: 'CHANGELOG.md#r-r-202604261',
+      canonical_refs: {
+        narrative_ref: 'docs/releases/notes/stable-v0.1.1-contract.json',
+        ios_derivative_ref: 'docs/releases/notes/stable-v0.1.1-contract-ios-derivative.md',
+        changelog_anchor: 'CHANGELOG.md#release-stable-v0.1.1-contract',
+      },
+      compatibility_refs: {
+        narrative_ref: 'docs/releases/notes/R-2026.04.26.1.json',
+        ios_derivative_ref: 'docs/releases/notes/R-2026.04.26.1-ios-derivative.md',
+        changelog_anchor: 'CHANGELOG.md#r-r-202604261',
+      },
       npm_package_target: 'contract',
     },
     artifacts: {

--- a/apps/capacitor-demo/scripts/release-closure-bundle.test.mjs
+++ b/apps/capacitor-demo/scripts/release-closure-bundle.test.mjs
@@ -34,16 +34,24 @@ const createFixture = async () => {
   await writeFile(resolve(artifactRoot, 'reconciliation-report.json'), JSON.stringify({ ok: true, errors: [] }, null, 2));
 
   await writeFile(resolve(artifactRoot, 'release-execution-packet.json'), JSON.stringify({
-    schema_version: 'release-execution-packet/v1',
+    schema_version: 'release-execution-packet/v2',
     release_id: releaseId,
     phase: 'closeout',
     repo_root: root,
+    release_identity: { channel: 'stable', version: '0.1.1', package_target: 'contract', release_key: 'stable/v0.1.1/contract' },
     selected_targets: ['android', 'ios'],
     target_modes: { android: 'publish', ios: 'publish' },
     inputs: {
-      narrative_ref: `docs/releases/notes/${releaseId}.json`,
-      ios_derivative_ref: `docs/releases/notes/${releaseId}-ios-derivative.md`,
-      changelog_anchor: `CHANGELOG.md#r-${releaseId.toLowerCase()}`,
+      canonical_refs: {
+        narrative_ref: 'docs/releases/notes/stable-v0.1.1-contract.json',
+        ios_derivative_ref: 'docs/releases/notes/stable-v0.1.1-contract-ios-derivative.md',
+        changelog_anchor: 'CHANGELOG.md#release-stable-v0.1.1-contract',
+      },
+      compatibility_refs: {
+        narrative_ref: `docs/releases/notes/${releaseId}.json`,
+        ios_derivative_ref: `docs/releases/notes/${releaseId}-ios-derivative.md`,
+        changelog_anchor: `CHANGELOG.md#r-${releaseId.toLowerCase()}`,
+      },
       npm_package_target: 'contract',
     },
     artifacts: {

--- a/apps/capacitor-demo/scripts/release-control-contract.mjs
+++ b/apps/capacitor-demo/scripts/release-control-contract.mjs
@@ -1,4 +1,5 @@
 const TARGETS = ['android', 'ios', 'npm'];
+import { buildCanonicalRefs } from './release-paths.mjs';
 
 // Governance v1 note:
 // - target/mode validation is a preflight contract gate for release-control.yml.
@@ -42,6 +43,9 @@ export const validateReleaseControlContract = ({
   phase = 'preflight',
   repoRoot = '.',
   npmPackageTarget = 'capacitor',
+  releaseChannel = 'stable',
+  releaseVersion = '0.1.1',
+  releaseKey = '',
 } = {}) => {
   const errors = [];
   const diagnostics = [];
@@ -94,6 +98,20 @@ export const validateReleaseControlContract = ({
     }
   }
 
+  const releaseIdentity = {
+    channel: String(releaseChannel ?? 'stable').trim() || 'stable',
+    version: String(releaseVersion ?? '0.1.1').trim() || '0.1.1',
+    package_target: String(npmPackageTarget ?? '').trim() || 'capacitor',
+  };
+  releaseIdentity.release_key = `${releaseIdentity.channel}/v${releaseIdentity.version.replace(/^v/i, '')}/${releaseIdentity.package_target}`;
+  const explicitReleaseKey = String(releaseKey ?? '').trim();
+  if (explicitReleaseKey && explicitReleaseKey !== releaseIdentity.release_key) {
+    const message = `IDENTITY_AMBIGUOUS: explicit release_key (${explicitReleaseKey}) conflicts with derived release_key (${releaseIdentity.release_key}).`;
+    errors.push(message);
+    diagnostics.push({ code: 'IDENTITY_AMBIGUOUS', message });
+  }
+  const refs = buildCanonicalRefs({ releaseIdentity, releaseId: normalizedReleaseId });
+
   return {
     ok: errors.length === 0,
     errors,
@@ -105,8 +123,9 @@ export const validateReleaseControlContract = ({
         normalizedTargets.map((target) => [target, String(targetModes[target] ?? '').trim()]),
       ),
       packet: {
-        schema_version: 'release-execution-packet/v1',
+        schema_version: 'release-execution-packet/v2',
         release_id: normalizedReleaseId,
+        release_identity: releaseIdentity,
         phase: normalizePhase(phase),
         repo_root: String(repoRoot ?? '.').trim() || '.',
         selected_targets: normalizedTargets,
@@ -114,9 +133,8 @@ export const validateReleaseControlContract = ({
           normalizedTargets.map((target) => [target, String(targetModes[target] ?? '').trim()]),
         ),
         inputs: {
-          narrative_ref: `docs/releases/notes/${normalizedReleaseId}.json`,
-          ios_derivative_ref: `docs/releases/notes/${normalizedReleaseId}-ios-derivative.md`,
-          changelog_anchor: `CHANGELOG.md#r-${normalizedReleaseId.toLowerCase()}`,
+          canonical_refs: refs.canonical,
+          compatibility_refs: refs.compatibility,
           npm_package_target: String(npmPackageTarget ?? '').trim() || 'capacitor',
         },
         artifacts: buildPacketRefs(normalizedReleaseId),
@@ -169,6 +187,11 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
     }
     if (arg === '--npm-package-target' && args[i + 1]) {
       options.npmPackageTarget = args[i + 1];
+      i += 1;
+      continue;
+    }
+    if (arg === '--release-key' && args[i + 1]) {
+      options.releaseKey = args[i + 1];
       i += 1;
     }
   }

--- a/apps/capacitor-demo/scripts/release-control-contract.test.mjs
+++ b/apps/capacitor-demo/scripts/release-control-contract.test.mjs
@@ -56,11 +56,31 @@ test('release control contract normalizes a valid cross-platform request with on
   assert.equal(result.value.target_modes.android, 'publish');
   assert.equal(result.value.target_modes.ios, 'publish');
   assert.equal(result.value.target_modes.npm, 'protected-publish');
-  assert.equal(result.value.packet.schema_version, 'release-execution-packet/v1');
+  assert.equal(result.value.packet.schema_version, 'release-execution-packet/v2');
   assert.equal(result.value.packet.phase, 'preflight');
   assert.equal(result.value.packet.release_id, 'R-2026.04.24.1');
+  assert.equal(result.value.packet.release_identity.release_key, 'stable/v0.1.1/capacitor');
   assert.deepEqual(result.value.packet.selected_targets, ['android', 'ios', 'npm']);
-  assert.equal(result.value.packet.inputs.narrative_ref, 'docs/releases/notes/R-2026.04.24.1.json');
+  assert.equal(result.value.packet.inputs.canonical_refs.narrative_ref, 'docs/releases/notes/stable-v0.1.1-capacitor.json');
+  assert.equal(result.value.packet.inputs.compatibility_refs.narrative_ref, 'docs/releases/notes/R-2026.04.24.1.json');
+});
+
+test('release control contract keeps release identity stable across reruns while release id changes', () => {
+  const first = validateReleaseControlContract({
+    releaseId: 'R-2026.04.24.1',
+    targets: 'ios',
+    targetModes: { ios: 'publish' },
+  });
+  const second = validateReleaseControlContract({
+    releaseId: 'R-2026.04.24.2',
+    targets: 'ios',
+    targetModes: { ios: 'publish' },
+  });
+
+  assert.equal(first.ok, true);
+  assert.equal(second.ok, true);
+  assert.equal(first.value.packet.release_identity.release_key, second.value.packet.release_identity.release_key);
+  assert.notEqual(first.value.packet.release_id, second.value.packet.release_id);
 });
 
 test('release control contract rejects unsupported iOS mode and reports allowed values', () => {
@@ -100,4 +120,17 @@ test('release control contract rejects explicit non-goal scope violation for pla
   assert.equal(result.ok, false);
   assert.match(result.errors.join('\n'), /NON_GOAL_VIOLATION/i);
   assert.equal(result.diagnostics[0].code, 'NON_GOAL_VIOLATION');
+});
+
+test('release control contract fails closed with IDENTITY_AMBIGUOUS when explicit release key conflicts', () => {
+  const result = validateReleaseControlContract({
+    releaseId: 'R-2026.04.28.22',
+    targets: 'android',
+    targetModes: { android: 'publish' },
+    releaseKey: 'stable/v9.9.9/contract',
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join('\n'), /IDENTITY_AMBIGUOUS/i);
+  assert.equal(result.diagnostics.some((entry) => entry.code === 'IDENTITY_AMBIGUOUS'), true);
 });

--- a/apps/capacitor-demo/scripts/release-control-summary-schema.mjs
+++ b/apps/capacitor-demo/scripts/release-control-summary-schema.mjs
@@ -275,12 +275,23 @@ export const validateReleaseExecutionPacketEnvelope = (candidate = {}) => {
     }
   }
 
-  if (String(candidate?.schema_version ?? '').trim() !== 'release-execution-packet/v1') {
-    errors.push('schema_version must be release-execution-packet/v1.');
+  if (String(candidate?.schema_version ?? '').trim() !== 'release-execution-packet/v2') {
+    errors.push('schema_version must be release-execution-packet/v2.');
   }
 
   if (!['preflight', 'publish', 'reconcile', 'closeout'].includes(String(candidate?.phase ?? '').trim())) {
     errors.push('phase must be preflight|publish|reconcile|closeout.');
+  }
+
+  const identity = candidate?.release_identity;
+  if (!identity || typeof identity !== 'object' || Array.isArray(identity)) {
+    errors.push('release_identity is required.');
+  } else {
+    for (const field of ['channel', 'version', 'package_target', 'release_key']) {
+      if (!hasText(identity[field])) {
+        errors.push(`release_identity.${field} is required.`);
+      }
+    }
   }
 
   if (!Array.isArray(candidate?.selected_targets)) {
@@ -294,11 +305,18 @@ export const validateReleaseExecutionPacketEnvelope = (candidate = {}) => {
   if (!candidate?.inputs || typeof candidate.inputs !== 'object' || Array.isArray(candidate.inputs)) {
     errors.push('inputs must be an object.');
   } else {
-    if (!hasText(candidate.inputs.narrative_ref)) {
-      errors.push('inputs.narrative_ref is required.');
-    }
-    if (!hasText(candidate.inputs.changelog_anchor)) {
-      errors.push('inputs.changelog_anchor is required.');
+    for (const parentKey of ['canonical_refs', 'compatibility_refs']) {
+      const refs = candidate.inputs[parentKey];
+      if (!refs || typeof refs !== 'object' || Array.isArray(refs)) {
+        errors.push(`inputs.${parentKey} is required.`);
+        continue;
+      }
+      if (!hasText(refs.narrative_ref)) {
+        errors.push(`inputs.${parentKey}.narrative_ref is required.`);
+      }
+      if (!hasText(refs.changelog_anchor)) {
+        errors.push(`inputs.${parentKey}.changelog_anchor is required.`);
+      }
     }
   }
 

--- a/apps/capacitor-demo/scripts/release-control-summary-schema.test.mjs
+++ b/apps/capacitor-demo/scripts/release-control-summary-schema.test.mjs
@@ -132,16 +132,29 @@ test('summary schema rejects closure bundle missing required traceability fields
 
 test('summary schema validates release execution packet envelope', () => {
   const valid = validateReleaseExecutionPacketEnvelope({
-    schema_version: 'release-execution-packet/v1',
+    schema_version: 'release-execution-packet/v2',
     release_id: 'R-2026.04.27.1',
     phase: 'preflight',
     repo_root: '/tmp/legato',
+    release_identity: {
+      channel: 'stable',
+      version: '0.1.1',
+      package_target: 'contract',
+      release_key: 'stable/v0.1.1/contract',
+    },
     selected_targets: ['android', 'ios'],
     target_modes: { android: 'publish', ios: 'publish' },
     inputs: {
-      narrative_ref: 'docs/releases/notes/R-2026.04.27.1.json',
-      ios_derivative_ref: 'docs/releases/notes/R-2026.04.27.1-ios-derivative.md',
-      changelog_anchor: 'CHANGELOG.md#r-r-202604271',
+      canonical_refs: {
+        narrative_ref: 'docs/releases/notes/stable-v0.1.1-contract.json',
+        ios_derivative_ref: 'docs/releases/notes/stable-v0.1.1-contract-ios-derivative.md',
+        changelog_anchor: 'CHANGELOG.md#release-stable-v0.1.1-contract',
+      },
+      compatibility_refs: {
+        narrative_ref: 'docs/releases/notes/R-2026.04.27.1.json',
+        ios_derivative_ref: 'docs/releases/notes/R-2026.04.27.1-ios-derivative.md',
+        changelog_anchor: 'CHANGELOG.md#r-r-202604271',
+      },
       npm_package_target: 'contract',
     },
     artifacts: {
@@ -154,6 +167,30 @@ test('summary schema validates release execution packet envelope', () => {
 
   assert.equal(valid.ok, true);
   assert.equal(valid.errors.length, 0);
+});
+
+test('summary schema fails packet validation when release identity is missing', () => {
+  const invalid = validateReleaseExecutionPacketEnvelope({
+    schema_version: 'release-execution-packet/v2',
+    release_id: 'R-2026.04.27.1',
+    phase: 'preflight',
+    repo_root: '/tmp/legato',
+    selected_targets: ['android'],
+    target_modes: { android: 'publish' },
+    inputs: {
+      canonical_refs: { narrative_ref: 'docs/releases/notes/stable-v0.1.1-capacitor.json', changelog_anchor: 'CHANGELOG.md#release-stable-v0.1.1-capacitor' },
+      compatibility_refs: { narrative_ref: 'docs/releases/notes/R-2026.04.27.1.json', changelog_anchor: 'CHANGELOG.md#r-r-202604271' },
+    },
+    artifacts: {
+      summary_ref: 'apps/capacitor-demo/artifacts/release-control/R-2026.04.27.1/summary.json',
+      facts_ref: 'apps/capacitor-demo/artifacts/release-control/R-2026.04.27.1/release-facts.json',
+      reconciliation_ref: 'apps/capacitor-demo/artifacts/release-control/R-2026.04.27.1/reconciliation-report.json',
+      closure_bundle_ref: 'apps/capacitor-demo/artifacts/release-control/R-2026.04.27.1/closure-bundle.json',
+    },
+  });
+
+  assert.equal(invalid.ok, false);
+  assert.match(invalid.errors.join('\n'), /release_identity/i);
 });
 
 test('summary schema rejects malformed fresh-head closeout envelope', () => {

--- a/apps/capacitor-demo/scripts/release-control-workflow.test.mjs
+++ b/apps/capacitor-demo/scripts/release-control-workflow.test.mjs
@@ -56,6 +56,7 @@ test('release control workflow emits release_id keyed final summary artifact', a
   assert.match(workflow, /Upload release execution packet/i);
   assert.match(workflow, /release-packet-\$\{\{ inputs\.release_id \}\}/i);
   assert.match(workflow, /Download release execution packet/i);
+  assert.match(workflow, /release:prepare/i);
   assert.match(workflow, /release-control-summary-\$\{\{ inputs\.release_id \}\}/i);
   assert.match(workflow, /summary\.json/i);
   assert.match(workflow, /summary\.md/i);

--- a/apps/capacitor-demo/scripts/release-ops-diagnostics.mjs
+++ b/apps/capacitor-demo/scripts/release-ops-diagnostics.mjs
@@ -5,6 +5,10 @@ const KNOWN_REASON_CODES = new Set([
   'MISSING_RELEASE_PACKET',
   'MISSING_REQUIRED_INPUT',
   'MISSING_NARRATIVE_OR_DERIVATIVE_NOTES',
+  'IDENTITY_MISSING',
+  'IDENTITY_AMBIGUOUS',
+  'IDENTITY_LOOKUP_MISS',
+  'LEGACY_ALIAS_USED',
   'DERIVATIVE_BACKLINK_DRIFT',
   'CANONICAL_AUTHORITY_DRIFT',
   'MISSING_DURABLE_EVIDENCE',
@@ -21,6 +25,10 @@ const DEFAULT_RETRYABLE = {
   MISSING_RELEASE_PACKET: false,
   MISSING_REQUIRED_INPUT: false,
   MISSING_NARRATIVE_OR_DERIVATIVE_NOTES: false,
+  IDENTITY_MISSING: false,
+  IDENTITY_AMBIGUOUS: false,
+  IDENTITY_LOOKUP_MISS: false,
+  LEGACY_ALIAS_USED: true,
   DERIVATIVE_BACKLINK_DRIFT: false,
   CANONICAL_AUTHORITY_DRIFT: false,
   MISSING_DURABLE_EVIDENCE: false,
@@ -59,11 +67,19 @@ export const renderOperatorAction = (code, { releaseId = '', target = '' } = {})
     case 'PACKAGE_TARGET_SCOPE':
       return `Use npm package_target=capacitor|contract consistently for selected npm lane${target ? ` (${target})` : ''}.`;
     case 'MISSING_RELEASE_PACKET':
-      return 'Generate release-execution-packet/v1 before running preflight/publish/reconcile/closeout gates.';
+      return 'Generate release-execution-packet/v2 before running preflight/publish/reconcile/closeout gates.';
     case 'MISSING_REQUIRED_INPUT':
       return 'Populate all required release packet input references (narrative_ref, changelog_anchor, and lane-scoped refs) then rerun.';
     case 'MISSING_NARRATIVE_OR_DERIVATIVE_NOTES':
       return `Provide required narrative (${releaseNarrativePath}) and iOS derivative notes (docs/releases/notes/${normalizedReleaseId || '<release_id>'}-ios-derivative.md when iOS selected) before rerun.`;
+    case 'IDENTITY_MISSING':
+      return 'Populate release_identity (channel, version, package_target, release_key) in the release execution packet and rerun.';
+    case 'IDENTITY_AMBIGUOUS':
+      return 'Ensure release_identity maps to one canonical artifact tuple and remove conflicting identity values.';
+    case 'IDENTITY_LOOKUP_MISS':
+      return 'Create canonical identity-backed narrative/derivative files under docs/releases/notes and rerun preflight.';
+    case 'LEGACY_ALIAS_USED':
+      return 'Compatibility alias was used; keep run unblocked, but migrate notes to canonical identity-backed filenames.';
     case 'DERIVATIVE_BACKLINK_DRIFT':
       return 'Update iOS derivative notes to include canonical_legato_release and canonical_changelog_anchor backlinks.';
     case 'CANONICAL_AUTHORITY_DRIFT':

--- a/apps/capacitor-demo/scripts/release-ops-diagnostics.test.mjs
+++ b/apps/capacitor-demo/scripts/release-ops-diagnostics.test.mjs
@@ -15,6 +15,10 @@ test('release ops diagnostics exports canonical reason-code taxonomy', () => {
     'MISSING_RELEASE_PACKET',
     'MISSING_REQUIRED_INPUT',
     'MISSING_NARRATIVE_OR_DERIVATIVE_NOTES',
+    'IDENTITY_MISSING',
+    'IDENTITY_AMBIGUOUS',
+    'IDENTITY_LOOKUP_MISS',
+    'LEGACY_ALIAS_USED',
     'DERIVATIVE_BACKLINK_DRIFT',
     'CANONICAL_AUTHORITY_DRIFT',
     'MISSING_DURABLE_EVIDENCE',
@@ -46,4 +50,16 @@ test('release ops diagnostics renders operator guidance for missing narrative re
   const action = renderOperatorAction('MISSING_NARRATIVE_OR_DERIVATIVE_NOTES', { releaseId: 'R-2026.04.27.1' });
   assert.match(action, /docs\/releases\/notes\/R-2026\.04\.27\.1\.json/i);
   assert.match(action, /ios-derivative/i);
+});
+
+test('release ops diagnostics renders guidance for legacy alias usage without blocking', () => {
+  const action = renderOperatorAction('LEGACY_ALIAS_USED', { releaseId: 'R-2026.04.27.1' });
+  assert.match(action, /canonical/i);
+  assert.match(action, /compatibility/i);
+});
+
+test('release ops diagnostics release packet guidance references packet v2', () => {
+  const action = renderOperatorAction('MISSING_RELEASE_PACKET');
+  assert.match(action, /release-execution-packet\/v2/i);
+  assert.doesNotMatch(action, /release-execution-packet\/v1/i);
 });

--- a/apps/capacitor-demo/scripts/release-paths.mjs
+++ b/apps/capacitor-demo/scripts/release-paths.mjs
@@ -43,14 +43,47 @@ export const resolveLegatoRepoRoot = async ({ repoRoot } = {}) => {
   throw new Error('PATH_OR_CWD: unable to resolve repository root from cwd or script-relative candidates.');
 };
 
-export const resolveReleasePaths = ({ repoRoot, releaseId } = {}) => {
-  const root = resolve(repoRoot ?? process.cwd());
-  const normalizedReleaseId = String(releaseId ?? '').trim();
-  const artifactRoot = resolve(root, 'apps/capacitor-demo/artifacts/release-control', normalizedReleaseId || 'missing-release-id');
+export const slugReleaseKey = (releaseKey) => String(releaseKey ?? '').trim().replaceAll('/', '-');
 
+export const buildCanonicalRefs = ({ releaseIdentity, releaseId }) => {
+  const releaseKey = String(releaseIdentity?.release_key ?? '').trim();
+  const slug = slugReleaseKey(releaseKey);
+  const canonical = {
+    narrative_ref: slug ? `docs/releases/notes/${slug}.json` : '',
+    ios_derivative_ref: slug ? `docs/releases/notes/${slug}-ios-derivative.md` : '',
+    changelog_anchor: slug ? `CHANGELOG.md#release-${slug}` : '',
+  };
+  const compatibility = {
+    narrative_ref: `docs/releases/notes/${releaseId}.json`,
+    ios_derivative_ref: `docs/releases/notes/${releaseId}-ios-derivative.md`,
+    changelog_anchor: `CHANGELOG.md#r-${String(releaseId ?? '').toLowerCase()}`,
+  };
+  return { canonical, compatibility };
+};
+
+export const resolveInputRefWithCompatibility = async ({ repoRoot, canonicalRef, compatibilityRef }) => {
+  const canonicalPath = resolve(repoRoot, String(canonicalRef ?? '').trim());
+  if (String(canonicalRef ?? '').trim() && await pathExists(canonicalPath)) {
+    return { resolvedRef: canonicalRef, resolvedPath: canonicalPath, usedAlias: false };
+  }
+  const compatibilityPath = resolve(repoRoot, String(compatibilityRef ?? '').trim());
+  if (String(compatibilityRef ?? '').trim() && await pathExists(compatibilityPath)) {
+    return { resolvedRef: canonicalRef, resolvedPath: compatibilityPath, usedAlias: true };
+  }
+  return { resolvedRef: canonicalRef, resolvedPath: canonicalPath, usedAlias: false, missing: true };
+};
+
+export const resolveReleasePaths = ({ repoRoot, releaseId, releaseIdentity } = {}) => {
+  const base = {
+    repoRoot: resolve(repoRoot ?? process.cwd()),
+    releaseId: String(releaseId ?? '').trim(),
+  };
+  const root = base.repoRoot;
+  const normalizedReleaseId = base.releaseId;
+  const artifactRoot = resolve(root, 'apps/capacitor-demo/artifacts/release-control', normalizedReleaseId || 'missing-release-id');
+  const canonicalRefs = buildCanonicalRefs({ releaseIdentity, releaseId: normalizedReleaseId });
   return {
-    repoRoot: root,
-    releaseId: normalizedReleaseId,
+    ...base,
     artifactRoot,
     packetPath: resolve(artifactRoot, 'release-execution-packet.json'),
     summaryPath: resolve(artifactRoot, 'summary.json'),
@@ -61,6 +94,8 @@ export const resolveReleasePaths = ({ repoRoot, releaseId } = {}) => {
     narrativePath: resolve(root, `docs/releases/notes/${normalizedReleaseId}.json`),
     derivativeNotesPath: resolve(root, `docs/releases/notes/${normalizedReleaseId}-ios-derivative.md`),
     changelogPath: resolve(root, 'CHANGELOG.md'),
+    canonicalNarrativePath: resolve(root, canonicalRefs.canonical.narrative_ref),
+    compatibilityNarrativePath: resolve(root, canonicalRefs.compatibility.narrative_ref),
   };
 };
 

--- a/apps/capacitor-demo/scripts/release-paths.test.mjs
+++ b/apps/capacitor-demo/scripts/release-paths.test.mjs
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { resolveReleasePaths } from './release-paths.mjs';
+import { resolveReleasePaths, slugReleaseKey } from './release-paths.mjs';
 
 test('release paths resolve deterministic packet/artifact/docs locations from repo root', () => {
   const paths = resolveReleasePaths({
@@ -16,4 +16,21 @@ test('release paths resolve deterministic packet/artifact/docs locations from re
   assert.match(paths.reconciliationPath, /reconciliation-report\.json$/i);
   assert.match(paths.closureBundlePath, /closure-bundle\.json$/i);
   assert.match(paths.derivativeNotesPath, /-ios-derivative\.md$/i);
+});
+
+test('release paths derive canonical identity-backed refs with legacy compatibility aliases', () => {
+  const paths = resolveReleasePaths({
+    repoRoot: '/tmp/legato',
+    releaseId: 'R-2026.04.28.1',
+    releaseIdentity: {
+      channel: 'stable',
+      version: '0.1.1',
+      package_target: 'capacitor',
+      release_key: 'stable/v0.1.1/capacitor',
+    },
+  });
+
+  assert.equal(slugReleaseKey('stable/v0.1.1/capacitor'), 'stable-v0.1.1-capacitor');
+  assert.match(paths.canonicalNarrativePath, /stable-v0\.1\.1-capacitor\.json$/i);
+  assert.match(paths.compatibilityNarrativePath, /R-2026\.04\.28\.1\.json$/i);
 });

--- a/apps/capacitor-demo/scripts/release-preflight-completeness.mjs
+++ b/apps/capacitor-demo/scripts/release-preflight-completeness.mjs
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import { normalizeReleaseDiagnostic } from './release-ops-diagnostics.mjs';
 import { validatePreflightEnvelope, validateReleaseExecutionPacketEnvelope } from './release-control-summary-schema.mjs';
-import { resolveReleasePaths } from './release-paths.mjs';
+import { resolveInputRefWithCompatibility, resolveReleasePaths } from './release-paths.mjs';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const KNOWN_TARGETS = ['android', 'ios', 'npm'];
@@ -67,7 +67,7 @@ export const evaluateReleasePreflightCompleteness = async ({
       missing: [{
         field: 'release_packet',
         target: null,
-        expected: 'release-execution-packet/v1 JSON',
+        expected: 'release-execution-packet/v2 JSON',
         reason_code: 'MISSING_RELEASE_PACKET',
         message: `Missing required release packet: ${packetPath}`,
         refs: [packetPath],
@@ -92,7 +92,7 @@ export const evaluateReleasePreflightCompleteness = async ({
       missing: packetValidation.errors.map((error) => ({
         field: 'release_packet',
         target: null,
-        expected: 'valid release-execution-packet/v1 envelope',
+        expected: 'valid release-execution-packet/v2 envelope',
         reason_code: 'SERIALIZATION_ERROR',
         message: error,
         refs: [packetPath],
@@ -108,13 +108,42 @@ export const evaluateReleasePreflightCompleteness = async ({
     };
   }
 
+  const identity = packet?.release_identity ?? {};
+  const derivedReleaseKey = `${String(identity.channel ?? '').trim()}/v${String(identity.version ?? '').trim().replace(/^v/i, '')}/${String(identity.package_target ?? '').trim()}`;
+  if (String(identity.release_key ?? '').trim() !== derivedReleaseKey) {
+    return {
+      ok: false,
+      selected_targets: [],
+      missing: [{
+        field: 'release_identity.release_key',
+        target: null,
+        expected: derivedReleaseKey,
+        reason_code: 'IDENTITY_AMBIGUOUS',
+        message: `release_identity.release_key is ambiguous: expected ${derivedReleaseKey} but received ${String(identity.release_key ?? '').trim()}.`,
+        refs: [packetPath],
+        release_id: String(packet?.release_id ?? normalizedReleaseId),
+      }],
+      diagnostics: [normalizeReleaseDiagnostic({
+        code: 'IDENTITY_AMBIGUOUS',
+        scope: 'run',
+        message: `release_identity.release_key is ambiguous: expected ${derivedReleaseKey} but received ${String(identity.release_key ?? '').trim()}.`,
+        refs: [packetPath],
+        releaseId: String(packet?.release_id ?? normalizedReleaseId),
+      })],
+    };
+  }
+
   const effectiveReleaseId = String(packet.release_id ?? normalizedReleaseId).trim();
   const explicitTargets = parseTargets(selectedTargets).filter((target) => KNOWN_TARGETS.includes(target));
   const targets = [...new Set((explicitTargets.length > 0 ? explicitTargets : parseTargets(packet.selected_targets)).filter((target) => KNOWN_TARGETS.includes(target)))];
   const effectiveNpmPackageTarget = String(npmPackageTarget ?? '').trim() || String(packet?.inputs?.npm_package_target ?? '').trim();
-  const effectiveChangelogAnchor = String(changelogAnchor ?? '').trim() || String(packet?.inputs?.changelog_anchor ?? '').trim();
-  const narrativeRef = String(packet?.inputs?.narrative_ref ?? '').trim();
-  const derivativeRef = String(packet?.inputs?.ios_derivative_ref ?? '').trim();
+  const narrativeRef = String(packet?.inputs?.canonical_refs?.narrative_ref ?? '').trim();
+  const derivativeRef = String(packet?.inputs?.canonical_refs?.ios_derivative_ref ?? '').trim();
+  const canonicalChangelogAnchor = String(packet?.inputs?.canonical_refs?.changelog_anchor ?? '').trim();
+  const compatibilityNarrativeRef = String(packet?.inputs?.compatibility_refs?.narrative_ref ?? '').trim();
+  const compatibilityDerivativeRef = String(packet?.inputs?.compatibility_refs?.ios_derivative_ref ?? '').trim();
+  const compatibilityChangelogAnchor = String(packet?.inputs?.compatibility_refs?.changelog_anchor ?? '').trim();
+  const effectiveChangelogAnchor = String(changelogAnchor ?? '').trim() || canonicalChangelogAnchor || compatibilityChangelogAnchor;
 
   if (!narrativeRef) {
     addMissing(missing, diagnostics, {
@@ -152,20 +181,33 @@ export const evaluateReleasePreflightCompleteness = async ({
     });
   }
 
-  const narrativePath = resolve(root, narrativeRef || `docs/releases/notes/${effectiveReleaseId}.json`);
-  if (!await pathExists(narrativePath)) {
+  const narrativeResolution = await resolveInputRefWithCompatibility({
+    repoRoot: root,
+    canonicalRef: narrativeRef || `docs/releases/notes/${effectiveReleaseId}.json`,
+    compatibilityRef: compatibilityNarrativeRef || `docs/releases/notes/${effectiveReleaseId}.json`,
+  });
+  if (narrativeResolution.usedAlias) {
+    diagnostics.push(normalizeReleaseDiagnostic({
+      code: 'LEGACY_ALIAS_USED',
+      scope: 'run',
+      message: 'Using compatibility narrative path; migrate to canonical identity path.',
+      refs: [narrativeResolution.resolvedPath],
+      releaseId: effectiveReleaseId,
+    }));
+  }
+  if (narrativeResolution.missing) {
     addMissing(missing, diagnostics, {
       field: 'narrative_file',
       target: null,
       expected: narrativeRef || `docs/releases/notes/${effectiveReleaseId}.json`,
-      reason_code: 'MISSING_NARRATIVE_OR_DERIVATIVE_NOTES',
-      message: `Missing required narrative file: ${narrativeRef || `docs/releases/notes/${effectiveReleaseId}.json`}`,
-      refs: [narrativePath],
+      reason_code: 'IDENTITY_LOOKUP_MISS',
+      message: `Canonical identity lookup could not resolve narrative file: ${narrativeRef || `docs/releases/notes/${effectiveReleaseId}.json`}`,
+      refs: [narrativeResolution.resolvedPath],
       release_id: effectiveReleaseId,
     });
   }
 
-  if (!/^CHANGELOG\.md#r-/i.test(effectiveChangelogAnchor)) {
+  if (!/^CHANGELOG\.md#(?:r-|release-)/i.test(effectiveChangelogAnchor)) {
     addMissing(missing, diagnostics, {
       field: 'changelog_anchor',
       target: null,
@@ -189,17 +231,31 @@ export const evaluateReleasePreflightCompleteness = async ({
         release_id: effectiveReleaseId,
       });
     }
-    const derivativePath = resolve(root, derivativeRef || `docs/releases/notes/${effectiveReleaseId}-ios-derivative.md`);
-    if (!await pathExists(derivativePath)) {
+    const derivativeResolution = await resolveInputRefWithCompatibility({
+      repoRoot: root,
+      canonicalRef: derivativeRef || `docs/releases/notes/${effectiveReleaseId}-ios-derivative.md`,
+      compatibilityRef: compatibilityDerivativeRef || `docs/releases/notes/${effectiveReleaseId}-ios-derivative.md`,
+    });
+    if (derivativeResolution.usedAlias) {
+      diagnostics.push(normalizeReleaseDiagnostic({
+        code: 'LEGACY_ALIAS_USED',
+        scope: 'lane',
+        target: 'ios',
+        message: 'Using compatibility iOS derivative notes path; migrate to canonical identity path.',
+        refs: [derivativeResolution.resolvedPath],
+        releaseId: effectiveReleaseId,
+      }));
+    }
+    if (derivativeResolution.missing) {
       addMissing(missing, diagnostics, {
         field: 'ios_derivative_notes_file',
         target: 'ios',
         expected: derivativeRef || `docs/releases/notes/${effectiveReleaseId}-ios-derivative.md`,
-        reason_code: 'MISSING_NARRATIVE_OR_DERIVATIVE_NOTES',
-        message: `Missing required derivative iOS notes file: ${derivativeRef || `docs/releases/notes/${effectiveReleaseId}-ios-derivative.md`}`,
-        refs: [derivativePath],
-        release_id: effectiveReleaseId,
-      });
+        reason_code: 'IDENTITY_LOOKUP_MISS',
+        message: `Canonical identity lookup could not resolve derivative iOS notes file: ${derivativeRef || `docs/releases/notes/${effectiveReleaseId}-ios-derivative.md`}`,
+          refs: [derivativeResolution.resolvedPath],
+          release_id: effectiveReleaseId,
+        });
     }
   }
 

--- a/apps/capacitor-demo/scripts/release-preflight-completeness.test.mjs
+++ b/apps/capacitor-demo/scripts/release-preflight-completeness.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 
@@ -19,16 +19,29 @@ const setupRepo = async ({ releaseId, withNarrative = true, withDerivative = fal
   }
   await mkdir(resolve(root, `apps/capacitor-demo/artifacts/release-control/${releaseId}`), { recursive: true });
   await writeFile(resolve(root, `apps/capacitor-demo/artifacts/release-control/${releaseId}/release-execution-packet.json`), JSON.stringify({
-    schema_version: 'release-execution-packet/v1',
+    schema_version: 'release-execution-packet/v2',
     release_id: releaseId,
     phase: 'preflight',
     repo_root: root,
+    release_identity: {
+      channel: 'stable',
+      version: '0.1.1',
+      package_target: 'contract',
+      release_key: 'stable/v0.1.1/contract',
+    },
     selected_targets: ['ios', 'npm'],
     target_modes: { ios: 'publish', npm: 'protected-publish' },
     inputs: {
-      narrative_ref: `docs/releases/notes/${releaseId}.json`,
-      ios_derivative_ref: `docs/releases/notes/${releaseId}-ios-derivative.md`,
-      changelog_anchor: `CHANGELOG.md#r-${releaseId.toLowerCase()}`,
+      canonical_refs: {
+        narrative_ref: 'docs/releases/notes/stable-v0.1.1-contract.json',
+        ios_derivative_ref: 'docs/releases/notes/stable-v0.1.1-contract-ios-derivative.md',
+        changelog_anchor: 'CHANGELOG.md#release-stable-v0.1.1-contract',
+      },
+      compatibility_refs: {
+        narrative_ref: `docs/releases/notes/${releaseId}.json`,
+        ios_derivative_ref: `docs/releases/notes/${releaseId}-ios-derivative.md`,
+        changelog_anchor: `CHANGELOG.md#r-${releaseId.toLowerCase()}`,
+      },
       npm_package_target: 'contract',
     },
     artifacts: {
@@ -52,7 +65,20 @@ test('release preflight passes with lane-scoped requirements for ios+npm selecti
 
   assert.equal(result.ok, true);
   assert.deepEqual(result.missing, []);
-  assert.deepEqual(result.diagnostics, []);
+  assert.equal(result.diagnostics.some((d) => d.code === 'LEGACY_ALIAS_USED'), true);
+});
+
+test('release preflight prefers canonical refs and emits compatibility diagnostic when alias is used', async () => {
+  const releaseId = 'R-2026.04.27.11';
+  const repoRoot = await setupRepo({ releaseId, withNarrative: true, withDerivative: true });
+
+  const result = await evaluateReleasePreflightCompleteness({
+    repoRoot,
+    releasePacketPath: resolve(repoRoot, `apps/capacitor-demo/artifacts/release-control/${releaseId}/release-execution-packet.json`),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.diagnostics.some((d) => d.code === 'LEGACY_ALIAS_USED'), true);
 });
 
 test('release preflight fails closed when release packet is missing', async () => {
@@ -82,7 +108,7 @@ test('release preflight fails with missing narrative/derivative notes reason cod
   assert.equal(result.ok, false);
   assert.match(JSON.stringify(result.missing), /narrative_file/i);
   assert.match(JSON.stringify(result.missing), /ios_derivative_notes_file/i);
-  assert.equal(result.diagnostics[0].code, 'MISSING_NARRATIVE_OR_DERIVATIVE_NOTES');
+  assert.equal(result.diagnostics.some((entry) => entry.code === 'IDENTITY_LOOKUP_MISS'), true);
 });
 
 test('release preflight keeps npm-only fields optional when npm target is not selected', async () => {
@@ -99,7 +125,7 @@ test('release preflight keeps npm-only fields optional when npm target is not se
 
   assert.equal(result.ok, true);
   assert.equal(result.missing.length, 0);
-  assert.equal(result.diagnostics.length, 0);
+  assert.equal(result.diagnostics.every((d) => d.code === 'LEGACY_ALIAS_USED'), true);
 });
 
 test('release preflight reports package target scope violations with canonical reason code', async () => {
@@ -116,5 +142,18 @@ test('release preflight reports package target scope violations with canonical r
 
   assert.equal(result.ok, false);
   assert.match(JSON.stringify(result.missing), /npm_package_target/i);
-  assert.equal(result.diagnostics[0].code, 'PACKAGE_TARGET_SCOPE');
+  assert.equal(result.diagnostics.some((d) => d.code === 'PACKAGE_TARGET_SCOPE'), true);
+});
+
+test('release preflight fails closed with IDENTITY_AMBIGUOUS for conflicting release identity key', async () => {
+  const releaseId = 'R-2026.04.27.12';
+  const repoRoot = await setupRepo({ releaseId, withNarrative: true, withDerivative: true });
+  const packetPath = resolve(repoRoot, `apps/capacitor-demo/artifacts/release-control/${releaseId}/release-execution-packet.json`);
+  const packet = JSON.parse(await readFile(packetPath, 'utf8'));
+  packet.release_identity.release_key = 'stable/v9.9.9/contract';
+  await writeFile(packetPath, JSON.stringify(packet, null, 2));
+
+  const result = await evaluateReleasePreflightCompleteness({ repoRoot, releasePacketPath: packetPath });
+  assert.equal(result.ok, false);
+  assert.equal(result.diagnostics.some((entry) => entry.code === 'IDENTITY_AMBIGUOUS'), true);
 });

--- a/apps/capacitor-demo/scripts/release-prepare.mjs
+++ b/apps/capacitor-demo/scripts/release-prepare.mjs
@@ -1,0 +1,52 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+import { validateReleaseControlContract } from './release-control-contract.mjs';
+import { evaluateReleasePreflightCompleteness } from './release-preflight-completeness.mjs';
+import { resolveReleasePaths } from './release-paths.mjs';
+
+export const prepareReleaseExecution = async (options = {}) => {
+  const contract = validateReleaseControlContract(options);
+  if (!contract.ok) {
+    return { ok: false, errors: contract.errors, diagnostics: contract.diagnostics };
+  }
+
+  const packet = { ...contract.value.packet, phase: 'preflight', repo_root: resolve(options.repoRoot ?? '../..') };
+  const paths = resolveReleasePaths({ repoRoot: packet.repo_root, releaseId: packet.release_id, releaseIdentity: packet.release_identity });
+  await mkdir(dirname(paths.packetPath), { recursive: true });
+  await writeFile(paths.packetPath, `${JSON.stringify(packet, null, 2)}\n`, 'utf8');
+
+  const preflight = await evaluateReleasePreflightCompleteness({
+    repoRoot: packet.repo_root,
+    releasePacketPath: paths.packetPath,
+    releaseId: packet.release_id,
+    selectedTargets: packet.selected_targets,
+    npmPackageTarget: packet.inputs.npm_package_target,
+  });
+
+  return {
+    ok: preflight.ok,
+    packet_path: paths.packetPath,
+    packet,
+    preflight,
+  };
+};
+
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  const [, , ...args] = process.argv;
+  const options = { targetModes: {} };
+  for (let i = 0; i < args.length; i += 1) {
+    if (args[i] === '--release-id' && args[i + 1]) options.releaseId = args[++i];
+    else if (args[i] === '--targets' && args[i + 1]) options.targets = args[++i];
+    else if (args[i] === '--target-modes' && args[i + 1]) {
+      for (const pair of String(args[++i]).split(',')) {
+        const [target, mode] = pair.split('=').map((entry) => entry.trim());
+        if (target) options.targetModes[target] = mode ?? '';
+      }
+    } else if (args[i] === '--repo-root' && args[i + 1]) options.repoRoot = args[++i];
+    else if (args[i] === '--npm-package-target' && args[i + 1]) options.npmPackageTarget = args[++i];
+  }
+  const result = await prepareReleaseExecution(options);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  process.exit(result.ok ? 0 : 1);
+}

--- a/apps/capacitor-demo/scripts/validate-release-closeout.test.mjs
+++ b/apps/capacitor-demo/scripts/validate-release-closeout.test.mjs
@@ -19,16 +19,24 @@ const baseClosureBundle = {
 };
 
 const basePacket = {
-  schema_version: 'release-execution-packet/v1',
+  schema_version: 'release-execution-packet/v2',
   release_id: 'R-2026.04.28.1',
+  release_identity: { channel: 'stable', version: '0.1.1', package_target: 'contract', release_key: 'stable/v0.1.1/contract' },
   phase: 'closeout',
   repo_root: '/tmp/legato',
   selected_targets: ['android'],
   target_modes: { android: 'publish' },
   inputs: {
-    narrative_ref: 'docs/releases/notes/R-2026.04.28.1.json',
-    ios_derivative_ref: 'docs/releases/notes/R-2026.04.28.1-ios-derivative.md',
-    changelog_anchor: 'CHANGELOG.md#r-r-202604281',
+    canonical_refs: {
+      narrative_ref: 'docs/releases/notes/stable-v0.1.1-contract.json',
+      ios_derivative_ref: 'docs/releases/notes/stable-v0.1.1-contract-ios-derivative.md',
+      changelog_anchor: 'CHANGELOG.md#release-stable-v0.1.1-contract',
+    },
+    compatibility_refs: {
+      narrative_ref: 'docs/releases/notes/R-2026.04.28.1.json',
+      ios_derivative_ref: 'docs/releases/notes/R-2026.04.28.1-ios-derivative.md',
+      changelog_anchor: 'CHANGELOG.md#r-r-202604281',
+    },
     npm_package_target: 'contract',
   },
   artifacts: {

--- a/docs/releases/publication-pipeline-v2.md
+++ b/docs/releases/publication-pipeline-v2.md
@@ -42,7 +42,9 @@ Any unsupported mode is rejected preflight by `release-control-contract.mjs` bef
 
 Deterministic gate before lane fanout:
 
-- `release-execution-packet/v1` is materialized first at `apps/capacitor-demo/artifacts/release-control/<release_id>/release-execution-packet.json`.
+- `release-execution-packet/v2` is materialized first at `apps/capacitor-demo/artifacts/release-control/<release_id>/release-execution-packet.json`.
+- Packet v2 includes canonical `release_identity` (`channel`, `version`, `package_target`, `release_key`) and keeps `release_id` as run correlation metadata.
+- Local and CI now share the same entrypoint: `npm run release:prepare` (builder + validator + preflight completeness).
 - `release-preflight-completeness.mjs` runs after dispatch validation and before Android/iOS/npm fanout.
 - Gate artifact: `apps/capacitor-demo/artifacts/release-control/<release_id>/preflight.json`
 - Fanout hard-blocks unless `preflight.ok === true`.
@@ -51,12 +53,13 @@ Deterministic gate before lane fanout:
 
 Required run-level checks:
 
-- Narrative file exists: `docs/releases/notes/<release_id>.json`
+- Canonical narrative file exists: `docs/releases/notes/<release_key-slug>.json`
+- Compatibility alias accepted during migration: `docs/releases/notes/<release_id>.json`
 - Changelog anchor format is canonical: `CHANGELOG.md#r-...`
 
 Lane-scoped checks:
 
-- iOS selected: `docs/releases/notes/<release_id>-ios-derivative.md` is required.
+- iOS selected: canonical derivative `docs/releases/notes/<release_key-slug>-ios-derivative.md` is preferred; legacy `<release_id>-ios-derivative.md` remains compatibility-only.
 - npm selected: `npm_package_target` must be `capacitor|contract`.
 
 Reason-coded diagnostics emitted by preflight/retry paths:
@@ -66,7 +69,11 @@ Reason-coded diagnostics emitted by preflight/retry paths:
 | `PATH_OR_CWD` | Repo root/path resolution failed. | No | Run from repo root or pass explicit `--repo-root`. |
 | `SERIALIZATION_ERROR` | JSON payload malformed/unsafe for aggregation. | No | Fix payload source (summary/facts) before rerun. |
 | `PACKAGE_TARGET_SCOPE` | npm package target out of allowed scope. | No | Use `npm_package_target=capacitor|contract`. |
-| `MISSING_RELEASE_PACKET` | The release execution packet is missing before gate execution. | No | Regenerate `release-execution-packet/v1` and rerun. |
+| `MISSING_RELEASE_PACKET` | The release execution packet is missing before gate execution. | No | Regenerate `release-execution-packet/v2` and rerun. |
+| `IDENTITY_MISSING` | Packet does not include full canonical `release_identity`. | No | Populate `release_identity` fields and rerun prepare/preflight. |
+| `IDENTITY_AMBIGUOUS` | Canonical identity conflicts for the same artifact tuple. | No | Resolve conflicting identity fields, then rerun. |
+| `IDENTITY_LOOKUP_MISS` | Canonical identity-backed narrative/evidence refs cannot be resolved. | No | Create canonical identity-backed notes/evidence paths. |
+| `LEGACY_ALIAS_USED` | Canonical note path missing; compatibility `<release_id>` alias used. | Yes | Migrate to canonical identity-backed file names before next release. |
 | `MISSING_REQUIRED_INPUT` | Required packet input reference is missing. | No | Fill packet refs (`narrative_ref`, `changelog_anchor`, lane refs) and rerun. |
 | `MISSING_NARRATIVE_OR_DERIVATIVE_NOTES` | Required narrative/derivative note file is missing. | No | Author required notes from templates, then rerun. |
 | `DERIVATIVE_BACKLINK_DRIFT` | iOS derivative note is missing canonical backlinks. | No | Restore canonical release/changelog backlink fields. |


### PR DESCRIPTION
Closes #121

## Summary
- persist the second-stage release reliability hardening that decouples release identity from run identity and strengthens local/CI parity
- add the packet-v2, release-prepare, diagnostics, and path handling changes that close the recurring avoidable release failures we kept hitting
- keep the release platform additive while making the final release communication path much more deterministic

## Changes
| File | Change |
|------|--------|
| `.github/workflows/release-control.yml` | hardens packet handling, artifact handoff, and release communication execution |
| `apps/capacitor-demo/scripts/release-control-contract.mjs` | emits packet v2 identity metadata and stricter contract validation |
| `apps/capacitor-demo/scripts/release-paths.mjs` | centralizes canonical/compat path resolution for release assets |
| `apps/capacitor-demo/scripts/release-preflight-completeness.mjs` | adds shared local/CI preflight contract with identity-first lookup |
| `apps/capacitor-demo/scripts/release-ops-diagnostics.mjs` | standardizes failure reason codes and operator guidance |
| `apps/capacitor-demo/scripts/release-prepare.mjs` | adds the local prepare-before-dispatch entrypoint |
| related `*.test.mjs` files | add regression coverage for packet v2, alias fallback, closeout, and diagnostics |
| `.agents/skills/release-communications/SKILL.md` | hardens mandatory release protocol guidance |
| `docs/releases/publication-pipeline-v2.md`, `docs/releases/release-communication-governance-v1.md`, `docs/releases/contracts/future-release-skill-io-contract-v1.md` | align governance docs with the new reliability model |

## Test Plan
- [x] `node --test ./scripts/release-control-contract.test.mjs ./scripts/release-preflight-completeness.test.mjs ./scripts/release-ops-diagnostics.test.mjs ./scripts/release-paths.test.mjs ./scripts/validate-release-closeout.test.mjs`
- [x] `cd apps/capacitor-demo && npm run test:release:confidence`
- [x] No shell scripts changed

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers