### PR TITLE
docs(capacitor): expand API reference and guides

### DIFF
--- a/apps/docs-site/astro.config.mjs
+++ b/apps/docs-site/astro.config.mjs
@@ -4,6 +4,7 @@ import starlight from '@astrojs/starlight';
 
 // https://astro.build/config
 export default defineConfig({
+	site: 'https://legato-docs.netlify.app',
 	integrations: [
 		starlight({
 			title: 'Legato Docs',

--- a/apps/docs-site/src/content/docs/packages/capacitor/how-to/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/how-to/index.mdx
@@ -1,0 +1,27 @@
+---
+title: How-to Guides
+description: Task-oriented guides for common legato-capacitor integration patterns.
+---
+
+import { Card, CardGrid } from '@astrojs/starlight/components';
+
+This section provides step-by-step guides for the most common integration tasks.
+
+<CardGrid>
+  <Card title="Set Up" icon="setting">
+    **[Set Up Legato Capacitor](./set-up/)**
+    Install and initialize the plugin for iOS and Android.
+  </Card>
+  <Card title="Play a Track" icon="play">
+    **[Play a Track](./play-track/)**
+    Add tracks to the queue and start playback.
+  </Card>
+  <Card title="Listen to Events" icon="signal">
+    **[Listen to Events](./listen-events/)**
+    Register and manage event listeners for playback and remote control.
+  </Card>
+  <Card title="Use Sync Controllers" icon="sync">
+    **[Use Sync Controllers](./use-sync/)**
+    Create and use sync controllers for local snapshot mirroring.
+  </Card>
+</CardGrid>

--- a/apps/docs-site/src/content/docs/packages/capacitor/how-to/listen-events.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/how-to/listen-events.mdx
@@ -156,5 +156,5 @@ await mediaSession.removeAllListeners();
 
 ## Related pages
 
-- [Events Reference](../reference/events.mdx) — for full payload documentation
-- [Reference: Audio Player](../reference/audio-player.mdx) — for player API details
+- [Events Reference](../reference/events/) — for full payload documentation
+- [Reference: Audio Player](../reference/audio-player/) — for player API details

--- a/apps/docs-site/src/content/docs/packages/capacitor/how-to/listen-events.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/how-to/listen-events.mdx
@@ -1,0 +1,160 @@
+---
+title: Listen to Events
+description: How to register and manage event listeners for playback and remote control.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+This guide covers how to subscribe to playback lifecycle events and remote control events.
+
+## Event categories
+
+| Category | Namespace | Description |
+|----------|-----------|-------------|
+| Player events | `audioPlayer` | Playback state, track changes, progress, errors |
+| Remote events | `mediaSession` | Lock screen, Bluetooth, headphone controls |
+
+## Registering listeners
+
+### Using shortcut helpers (recommended)
+
+```ts
+import {
+  onPlaybackStateChanged,
+  onPlaybackEnded,
+  onPlaybackProgress,
+  onPlaybackError,
+} from '@ddgutierrezc/legato-capacitor';
+
+// State changes
+const unsubState = onPlaybackStateChanged(({ state }) => {
+  console.log('State:', state);
+});
+
+// Progress updates
+const unsubProgress = onPlaybackProgress(({ position, duration, bufferedPosition }) => {
+  console.log(`Position: ${position.toFixed(1)}s / ${duration}s`);
+});
+
+// Playback ended
+const unsubEnded = onPlaybackEnded(({ snapshot }) => {
+  console.log('Playback ended. Final state:', snapshot.state);
+});
+
+// Errors
+const unsubError = onPlaybackError(({ error }) => {
+  console.error('Error:', error.code, error.message);
+});
+
+// Clean up
+await unsubState.remove();
+await unsubProgress.remove();
+await unsubEnded.remove();
+await unsubError.remove();
+```
+
+<Aside type="tip">
+Shortcut helpers return a listener handle with a `remove()` method for cleanup.
+</Aside>
+
+### Using direct listener APIs
+
+```ts
+import { audioPlayer, mediaSession, LEGATO_EVENTS } from '@ddgutierrezc/legato-capacitor';
+
+// Player events via audioPlayer
+const playerHandle = await audioPlayer.addListener('playback-state-changed', (payload) => {
+  console.log('State:', payload.state);
+});
+
+// Remote events via mediaSession
+const remoteHandle = await mediaSession.addListener('remote-play', () => {
+  console.log('User pressed play');
+});
+
+// Clean up via handle
+await playerHandle.remove();
+await remoteHandle.remove();
+```
+
+### Using generic listener helpers
+
+```ts
+import { addLegatoListener, addAudioPlayerListener, addMediaSessionListener } from '@ddgutierrezc/legato-capacitor';
+
+// Any Legato event
+const handle1 = await addLegatoListener('playback-progress', (payload) => {
+  console.log('Progress:', payload.position);
+});
+
+// Player event only
+const handle2 = await addAudioPlayerListener('playback-active-track-changed', (payload) => {
+  console.log('Track:', payload.track?.title);
+});
+
+// Media session only
+const handle3 = await addMediaSessionListener('remote-seek', (payload) => {
+  console.log('Seek to:', payload.position);
+});
+```
+
+## Remote control listeners
+
+Subscribe to system media control events:
+
+```ts
+import { onRemotePlay, onRemotePause, onRemoteNext, onRemotePrevious } from '@ddgutierrezc/legato-capacitor';
+
+// Handle remote commands
+onRemotePlay(() => {
+  audioPlayer.play();
+});
+
+onRemotePause(() => {
+  audioPlayer.pause();
+});
+
+onRemoteNext(() => {
+  audioPlayer.skipToNext();
+});
+
+onRemotePrevious(() => {
+  audioPlayer.skipToPrevious();
+});
+```
+
+<Aside type="note">
+Remote events are only available on devices with system media controls. Desktop web browsers may not emit these events.
+</Aside>
+
+## Removing all listeners
+
+```ts
+// Remove all player listeners
+await audioPlayer.removeAllListeners();
+
+// Remove all media session listeners
+await mediaSession.removeAllListeners();
+```
+
+## Expected result
+
+| Action | Result |
+|--------|--------|
+| `onPlaybackStateChanged(...)` | Listener fires on every state transition |
+| `onPlaybackProgress(...)` | Listener fires periodically during playback |
+| `onPlaybackError(...)` | Listener fires when playback encounters an error |
+| `onRemotePlay(...)` | Listener fires when user taps play on remote control |
+| `.remove()` | Listener is detached and stops firing |
+| `removeAllListeners()` | All listeners for the namespace are removed |
+
+## Best practices
+
+1. **Always clean up** — Remove listeners in component unmount handlers or when no longer needed
+2. **Use handles** — Store handles from `addListener()` for manual removal
+3. **Check capabilities** — `remote-seek` only fires when runtime supports seek
+
+## Related pages
+
+- [Events Reference](../reference/events.mdx) — for full payload documentation
+- [Reference: Audio Player](../reference/audio-player.mdx) — for player API details

--- a/apps/docs-site/src/content/docs/packages/capacitor/how-to/play-track.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/how-to/play-track.mdx
@@ -101,5 +101,5 @@ playTrack('https://example.com/audio/demo.mp3', 'Demo Track');
 
 ## Next steps
 
-- [Listen to Events](./listen-events.mdx) — for more event subscriptions
-- [Use Sync](./use-sync.mdx) — for local snapshot mirroring
+- [Listen to Events](./listen-events/) — for more event subscriptions
+- [Use Sync](./use-sync/) — for local snapshot mirroring

--- a/apps/docs-site/src/content/docs/packages/capacitor/how-to/play-track.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/how-to/play-track.mdx
@@ -1,0 +1,105 @@
+---
+title: Play a Track
+description: How to add tracks to the queue and start playback.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+This guide covers the basic flow to add tracks and start playback.
+
+## Basic flow
+
+### 1. Add tracks to the queue
+
+```ts
+import { audioPlayer } from '@ddgutierrezc/legato-capacitor';
+
+const snapshot = await audioPlayer.add({
+  tracks: [
+    {
+      id: 'track-1',
+      url: 'https://example.com/audio/song-1.mp3',
+      title: 'Song One',
+      artist: 'Example Artist',
+    },
+    {
+      id: 'track-2',
+      url: 'https://example.com/audio/song-2.mp3',
+      title: 'Song Two',
+      artist: 'Example Artist',
+    },
+  ],
+  startIndex: 0, // optional: sets the active track
+});
+```
+
+### 2. Start playback
+
+```ts
+await audioPlayer.play();
+```
+
+### 3. Inspect state
+
+```ts
+const state = await audioPlayer.getState();
+console.log('State:', state); // 'playing'
+
+const position = await audioPlayer.getPosition();
+console.log('Position:', position, 'seconds');
+
+const track = await audioPlayer.getCurrentTrack();
+console.log('Now playing:', track?.title);
+```
+
+<Aside type="note">
+The queue is managed by the native runtime. Use `audioPlayer.reset()` to clear it when needed.
+</Aside>
+
+## Full example
+
+```ts
+import { audioPlayer, onPlaybackStateChanged, onPlaybackProgress } from '@ddgutierrezc/legato-capacitor';
+
+async function playTrack(url: string, title: string) {
+  // Subscribe to state changes
+  const unsubState = onPlaybackStateChanged(({ state }) => {
+    console.log('Playback state:', state);
+  });
+
+  // Subscribe to progress updates
+  const unsubProgress = onPlaybackProgress(({ position, duration }) => {
+    console.log(`${position.toFixed(1)}s / ${duration}s`);
+  });
+
+  // Add the track
+  await audioPlayer.add({
+    tracks: [{ id: 'demo', url, title }],
+    startIndex: 0,
+  });
+
+  // Start playback
+  await audioPlayer.play();
+
+  // Cleanup when done
+  await unsubState.remove();
+  await unsubProgress.remove();
+}
+
+playTrack('https://example.com/audio/demo.mp3', 'Demo Track');
+```
+
+## Expected result
+
+| Step | Result |
+|------|--------|
+| `add()` | Queue contains track(s); `snapshot.queue.items` has entries |
+| `play()` | Native playback starts |
+| `getState()` | Returns `playing` |
+| `getPosition()` | Returns current position in seconds |
+| `getCurrentTrack()` | Returns active track object |
+
+## Next steps
+
+- [Listen to Events](./listen-events.mdx) — for more event subscriptions
+- [Use Sync](./use-sync.mdx) — for local snapshot mirroring

--- a/apps/docs-site/src/content/docs/packages/capacitor/how-to/set-up.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/how-to/set-up.mdx
@@ -67,5 +67,5 @@ console.log('Player state:', state); // 'idle'
 
 ## Next steps
 
-- [Play a Track](./play-track.mdx) — add tracks and start playback
-- [Listen to Events](./listen-events.mdx) — subscribe to playback and remote events
+- [Play a Track](./play-track/) — add tracks and start playback
+- [Listen to Events](./listen-events/) — subscribe to playback and remote events

--- a/apps/docs-site/src/content/docs/packages/capacitor/how-to/set-up.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/how-to/set-up.mdx
@@ -1,0 +1,71 @@
+---
+title: Set Up Legato Capacitor
+description: How to install and initialize the legato-capacitor plugin.
+---
+
+import { Aside, Steps } from '@astrojs/starlight/components';
+
+This guide covers how to install and initialize the Legato Capacitor plugin for audio playback.
+
+## Prerequisites
+
+- An existing Capacitor project (iOS and/or Android)
+- Node.js 18+ installed
+- `npm` or your preferred package manager
+
+## Installation
+
+<Steps>
+
+1. **Install the packages**
+
+   ```bash
+   npm install @ddgutierrezc/legato-capacitor @ddgutierrezc/legato-contract
+   ```
+
+2. **Sync native platforms**
+
+   ```bash
+   npx cap sync
+   ```
+
+</Steps>
+
+## Initialization
+
+Import and initialize both `audioPlayer` and `mediaSession`:
+
+```ts
+import { audioPlayer, mediaSession } from '@ddgutierrezc/legato-capacitor';
+
+async function initialize() {
+  await audioPlayer.setup();
+  await mediaSession.setup();
+}
+
+initialize();
+```
+
+<Aside type="note">
+Both `audioPlayer.setup()` and `mediaSession.setup()` must be called before their respective APIs are used. Calling `audioPlayer.setup()` does NOT initialize media session, and vice-versa.
+</Aside>
+
+## Expected result
+
+After successful initialization:
+
+- `audioPlayer` is ready to accept playback commands
+- `mediaSession` is ready to receive remote control events
+- Native platform services are running
+
+You can verify the setup by querying the state:
+
+```ts
+const state = await audioPlayer.getState();
+console.log('Player state:', state); // 'idle'
+```
+
+## Next steps
+
+- [Play a Track](./play-track.mdx) — add tracks and start playback
+- [Listen to Events](./listen-events.mdx) — subscribe to playback and remote events

--- a/apps/docs-site/src/content/docs/packages/capacitor/how-to/use-sync.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/how-to/use-sync.mdx
@@ -160,6 +160,6 @@ Capabilities are runtime-dependent and may change based on the current track typ
 
 ## Related pages
 
-- [Reference: Sync](../reference/sync.mdx) — for complete API documentation
-- [Reference: Audio Player](../reference/audio-player.mdx) — for getSnapshot() source
-- [Reference: Snapshots](../reference/snapshots.mdx) — for `PlaybackSnapshot` and `BindingCapabilitiesSnapshot` shapes
+- [Reference: Sync](../reference/sync/) — for complete API documentation
+- [Reference: Audio Player](../reference/audio-player/) — for getSnapshot() source
+- [Reference: Snapshots](../reference/snapshots/) — for `PlaybackSnapshot` and `BindingCapabilitiesSnapshot` shapes

--- a/apps/docs-site/src/content/docs/packages/capacitor/how-to/use-sync.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/how-to/use-sync.mdx
@@ -1,0 +1,165 @@
+---
+title: Use Sync Controllers
+description: How to create and use sync controllers for local snapshot mirroring.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+This guide covers how to create and use sync controllers for maintaining a local PlaybackSnapshot in sync with the native runtime.
+
+## When to use sync
+
+Sync controllers are useful when:
+
+- You need a local snapshot that stays in sync with native playback
+- You want to receive event callbacks without manually registering multiple listeners
+- You're building a UI component that displays playback state
+
+## Basic usage
+
+### Create and start sync
+
+```ts
+import { createLegatoSync } from '@ddgutierrezc/legato-capacitor';
+
+const sync = createLegatoSync({
+  onSnapshot: (snapshot) => {
+    console.log('State:', snapshot.state);
+    console.log('Position:', snapshot.position);
+    console.log('Track:', snapshot.currentTrack?.title);
+  },
+});
+
+await sync.start();
+```
+
+### Inspect current snapshot
+
+```ts
+const current = sync.getCurrent();
+if (current) {
+  console.log('Current state:', current.state);
+  console.log('Current position:', current.position);
+}
+```
+
+### Force resync
+
+```ts
+await sync.resync();
+```
+
+### Stop sync
+
+```ts
+await sync.stop();
+```
+
+<Aside type="tip">
+Always call `stop()` to clean up listeners when the component unmounts or the controller is no longer needed.
+</Aside>
+
+## Full example
+
+```ts
+import { createLegatoSync } from '@ddgutierrezc/legato-capacitor';
+import { audioPlayer } from '@ddgutierrezc/legato-capacitor';
+
+async function initSyncUI() {
+  const sync = createLegatoSync({
+    onSnapshot: (snapshot) => {
+      // Update UI elements
+      updatePlayPauseButton(snapshot.state === 'playing');
+      updateProgressBar(snapshot.position, snapshot.duration);
+      updateTrackInfo(snapshot.currentTrack);
+    },
+    onEvent: (eventName, payload) => {
+      console.log('Event:', eventName);
+    },
+  });
+
+  // Start sync
+  await sync.start();
+
+  // Add some tracks
+  await audioPlayer.add({
+    tracks: [{ id: '1', url: 'https://example.com/audio.mp3', title: 'Demo' }],
+  });
+
+  // Start playback
+  await audioPlayer.play();
+
+  // Return cleanup function
+  return () => sync.stop();
+}
+
+async function updatePlayPauseButton(isPlaying: boolean) {
+  // Update your UI
+}
+
+async function updateProgressBar(position: number, duration: number | null) {
+  // Update your progress bar
+}
+
+async function updateTrackInfo(track: any) {
+  // Update track info display
+}
+
+initSyncUI().then((cleanup) => {
+  // Call cleanup() when done
+});
+```
+
+## Expected result
+
+| Action | Result |
+|--------|--------|
+| `createLegatoSync()` | Creates controller with optional callbacks |
+| `start()` | Subscribes to events, returns initial snapshot |
+| `getCurrent()` | Returns current local snapshot or `null` |
+| `resync()` | Refreshes snapshot from native state |
+| `stop()` | Removes all listeners |
+
+## Using with audioPlayer only
+
+```ts
+import { createAudioPlayerSync } from '@ddgutierrezc/legato-capacitor';
+
+const sync = createAudioPlayerSync({
+  onSnapshot: (snapshot) => {
+    console.log('State:', snapshot.state);
+  },
+});
+
+await sync.start();
+```
+
+<Aside type="note">
+`createAudioPlayerSync` is a type alias for `createLegatoSync` with a constrained client option. Both produce identical behavior.
+</Aside>
+
+## Capabilities and sync behavior
+
+The sync controller mirrors native state using `getSnapshot()` and event listeners. Runtime capability projection (e.g., whether `seek` is supported) is not reflected in the local snapshot fields directly — use `audioPlayer.getCapabilities()` separately to conditionally enable UI features like seek bars or skip buttons.
+
+```ts
+const caps = await audioPlayer.getCapabilities();
+
+// Conditionally show/hide UI based on runtime capabilities
+if (caps.supported.includes('seek')) {
+  showSeekBar();
+}
+if (!caps.supported.includes('skip-next')) {
+  hideNextButton();
+}
+```
+
+<Aside type="note">
+Capabilities are runtime-dependent and may change based on the current track type and playback state. Check `getCapabilities()` when initializing UI and after track changes.
+</Aside>
+
+## Related pages
+
+- [Reference: Sync](../reference/sync.mdx) — for complete API documentation
+- [Reference: Audio Player](../reference/audio-player.mdx) — for getSnapshot() source
+- [Reference: Snapshots](../reference/snapshots.mdx) — for `PlaybackSnapshot` and `BindingCapabilitiesSnapshot` shapes

--- a/apps/docs-site/src/content/docs/packages/capacitor/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/index.mdx
@@ -1,51 +1,74 @@
 ---
 title: Capacitor Package
-description: Capacitor integration guide for Legato runtime APIs, events, and migration posture.
+description: Capacitor integration guide for Legato runtime APIs, events, and synchronization.
 ---
 
-import { Aside, Steps } from '@astrojs/starlight/components';
+import { Aside, Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
-Use `@ddgutierrezc/legato-capacitor` when you need Capacitor runtime integration.
+Use `@ddgutierrezc/legato-capacitor` when you need Capacitor runtime integration for audio playback on iOS and Android.
 
-## Install
+## What is legato-capacitor?
 
-<Steps>
+A Capacitor plugin that exposes Legato playback APIs to web and hybrid JavaScript runtimes. It provides:
 
-1. Install runtime and contract packages.
+- **Audio player commands** — play, pause, seek, queue management, and state queries.
+- **Media session integration** — remote control from lock screen, notification center, and Bluetooth controls.
+- **Event subscriptions** — typed listeners for playback lifecycle and remote commands.
+- **Sync controllers** — local snapshot mirroring for offline or UI-only display contexts.
 
-   ```bash
-   npm install @ddgutierrezc/legato-capacitor @ddgutierrezc/legato-contract
-   ```
+## Exposed namespaces
 
-2. Run the first health check.
+| Export | Purpose |
+|--------|---------|
+| `audioPlayer` | Playback commands, queue operations, read-model queries, and player events. |
+| `mediaSession` | Remote control event listeners. |
+| `Legato` | Unified facade combining `audioPlayer` and `mediaSession` surfaces with a single event listener. See [Legato Facade](reference/legato.mdx). |
 
-   ```bash
-   npx legato native doctor
-   ```
+## Package exports
 
-3. Initialize runtime APIs.
+```ts
+import { audioPlayer, mediaSession, Legato } from '@ddgutierrezc/legato-capacitor';
+import {
+  AUDIO_PLAYER_EVENTS,
+  MEDIA_SESSION_EVENTS,
+  LEGATO_EVENTS,
+  addAudioPlayerListener,
+  addMediaSessionListener,
+  addLegatoListener,
+  onPlaybackStateChanged,
+  onPlaybackActiveTrackChanged,
+  onPlaybackQueueChanged,
+  onPlaybackProgress,
+  onPlaybackEnded,
+  onPlaybackError,
+  onRemotePlay,
+  onRemotePause,
+  onRemoteNext,
+  onRemotePrevious,
+  onRemoteSeek,
+} from '@ddgutierrezc/legato-capacitor';
+import { createLegatoSync, createAudioPlayerSync } from '@ddgutierrezc/legato-capacitor';
+```
 
-   ```ts
-   import { audioPlayer, mediaSession } from '@ddgutierrezc/legato-capacitor';
+## Documentation structure
 
-   await audioPlayer.setup();
-   await mediaSession.setup();
-   ```
+This package is documented in three sections following Diátaxis methodology:
 
-</Steps>
+<CardGrid>
+  <Card title="Overview" icon="open-book">
+    **[`index.mdx`](./)**
+    What the package provides and how to get started.
+  </Card>
+  <Card title="Reference" icon="seti:api">
+    **[`reference/`](./reference/)**
+    Detailed API reference for every exported method, type, and event.
+  </Card>
+  <Card title="How-to" icon="list-check">
+    **[`how-to/`](./how-to/)**
+    Task-oriented guides for common integration patterns.
+  </Card>
+</CardGrid>
 
-## Runtime surface
-
-- `audioPlayer`: playback and queue commands, read-model queries, playback events.
-- `mediaSession`: remote/session listener surface.
-- `Legato`: compatibility facade for existing integrations.
-
-## Migration posture
-
-- Existing apps can keep `Legato` with no immediate migration pressure.
-- New integrations should prefer namespaced surfaces (`audioPlayer`, `mediaSession`).
-- Listener helpers like `addAudioPlayerListener` align new code with explicit boundaries.
-
-<Aside type="caution">
-This public page excludes maintainer-only release/CLI runbook depth. Keep operational internals in root maintainer docs.
+<Aside type="note">
+See the [Contract Package](../contract/) for shared types and event constants that both the Capacitor plugin and other Legato runtimes consume.
 </Aside>

--- a/apps/docs-site/src/content/docs/packages/capacitor/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/index.mdx
@@ -3,7 +3,7 @@ title: Capacitor Package
 description: Capacitor integration guide for Legato runtime APIs, events, and synchronization.
 ---
 
-import { Aside, Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
+import { Aside, Card, CardGrid } from '@astrojs/starlight/components';
 
 Use `@ddgutierrezc/legato-capacitor` when you need Capacitor runtime integration for audio playback on iOS and Android.
 
@@ -22,7 +22,7 @@ A Capacitor plugin that exposes Legato playback APIs to web and hybrid JavaScrip
 |--------|---------|
 | `audioPlayer` | Playback commands, queue operations, read-model queries, and player events. |
 | `mediaSession` | Remote control event listeners. |
-| `Legato` | Unified facade combining `audioPlayer` and `mediaSession` surfaces with a single event listener. See [Legato Facade](reference/legato.mdx). |
+| `Legato` | Unified facade combining `audioPlayer` and `mediaSession` surfaces with a single event listener. See [Legato Facade](reference/legato/). |
 
 ## Package exports
 

--- a/apps/docs-site/src/content/docs/packages/capacitor/reference/audio-player.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/reference/audio-player.mdx
@@ -1,0 +1,401 @@
+---
+title: Audio Player API
+description: Complete API reference for the AudioPlayerApi interface.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+The `audioPlayer` namespace provides playback commands, queue operations, state queries, and player event subscriptions.
+
+## Interface
+
+```ts
+interface AudioPlayerApi {
+  setup(): Promise<void>;
+  add(options: AddOptions): Promise<PlaybackSnapshot>;
+  remove(options: RemoveOptions): Promise<PlaybackSnapshot>;
+  reset(): Promise<PlaybackSnapshot>;
+  play(): Promise<void>;
+  pause(): Promise<void>;
+  stop(): Promise<void>;
+  seekTo(options: SeekToOptions): Promise<void>;
+  skipTo(options: SkipToOptions): Promise<PlaybackSnapshot>;
+  skipToNext(): Promise<void>;
+  skipToPrevious(): Promise<void>;
+  getState(): Promise<PlaybackState>;
+  getPosition(): Promise<number>;
+  getDuration(): Promise<number | null>;
+  getCurrentTrack(): Promise<Track | null>;
+  getQueue(): Promise<QueueSnapshot>;
+  getSnapshot(): Promise<PlaybackSnapshot>;
+  getCapabilities(): Promise<BindingCapabilitiesSnapshot>;
+  addListener<E extends AudioPlayerEventName>(
+    eventName: E,
+    listener: AudioPlayerListener<E>
+  ): Promise<BindingListenerHandle>;
+  removeAllListeners(): Promise<void>;
+}
+```
+
+## Methods
+
+### `setup()`
+
+Initializes the native plugin. MUST be called before any other playback operations.
+
+```ts
+await audioPlayer.setup();
+```
+
+**Returns:** `Promise<void>`
+
+---
+
+### `add(options)`
+
+Appends tracks to the playback queue.
+
+```ts
+const snapshot = await audioPlayer.add({
+  tracks: [
+    { id: 'track-1', url: 'https://example.com/audio-1.mp3', title: 'Track One' },
+    { id: 'track-2', url: 'https://example.com/audio-2.mp3', title: 'Track Two' },
+  ],
+  startIndex: 0, // optional: position to activate after insertion
+});
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `tracks` | `Track[]` | Yes | Tracks to append in insertion order. |
+| `startIndex` | `number` | No | Queue index to activate after insertion. |
+
+**Returns:** `Promise<PlaybackSnapshot>`
+
+---
+
+### `remove(options)`
+
+Removes queue entries by ID or index.
+
+```ts
+// Remove by track ID
+await audioPlayer.remove({ id: 'track-1' });
+
+// Remove by index
+await audioPlayer.remove({ index: 0 });
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | `string` | No | Track identifier to remove. |
+| `index` | `number` | No | Queue index to remove. |
+
+**Returns:** `Promise<PlaybackSnapshot>`
+
+---
+
+### `reset()`
+
+Clears the queue and stops playback.
+
+```ts
+await audioPlayer.reset();
+```
+
+**Returns:** `Promise<PlaybackSnapshot>`
+
+---
+
+### `play()`
+
+Starts or resumes playback.
+
+```ts
+await audioPlayer.play();
+```
+
+**Returns:** `Promise<void>`
+
+<Aside type="note">
+This requires the queue to have at least one track added via `add()` and an active track selected.
+</Aside>
+
+---
+
+### `pause()`
+
+Pauses playback.
+
+```ts
+await audioPlayer.pause();
+```
+
+**Returns:** `Promise<void>`
+
+---
+
+### `stop()`
+
+Stops playback and resets position.
+
+```ts
+await audioPlayer.stop();
+```
+
+**Returns:** `Promise<void>`
+
+---
+
+### `seekTo(options)`
+
+Seeks to a specific position.
+
+```ts
+await audioPlayer.seekTo({ position: 30.5 }); // 30.5 seconds
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `position` | `number` | Yes | Target playback position in seconds. |
+
+**Returns:** `Promise<void>`
+
+<Aside type="note">
+Seek behavior may be limited by track type and runtime capabilities. Check `getCapabilities()` for supported features.
+</Aside>
+
+---
+
+### `skipTo(options)`
+
+Skips to a specific queue index.
+
+```ts
+const snapshot = await audioPlayer.skipTo({ index: 2 });
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `index` | `number` | Yes | Queue index to activate. |
+
+**Returns:** `Promise<PlaybackSnapshot>`
+
+---
+
+### `skipToNext()`
+
+Skips to the next track in the queue.
+
+```ts
+await audioPlayer.skipToNext();
+```
+
+**Returns:** `Promise<void>`
+
+---
+
+### `skipToPrevious()`
+
+Skips to the previous track in the queue.
+
+```ts
+await audioPlayer.skipToPrevious();
+```
+
+**Returns:** `Promise<void>`
+
+---
+
+### `getState()`
+
+Queries the current playback state.
+
+```ts
+const state = await audioPlayer.getState();
+// 'idle' | 'loading' | 'ready' | 'playing' | 'paused' | 'buffering' | 'ended' | 'error'
+```
+
+**Returns:** `Promise<PlaybackState>`
+
+---
+
+### `getPosition()`
+
+Queries the current playback position in seconds.
+
+```ts
+const position = await audioPlayer.getPosition();
+```
+
+**Returns:** `Promise<number>`
+
+---
+
+### `getDuration()`
+
+Queries the current track duration.
+
+```ts
+const duration = await audioPlayer.getDuration();
+// number | null (null for live/unknown duration)
+```
+
+**Returns:** `Promise<number | null>`
+
+---
+
+### `getCurrentTrack()`
+
+Queries the active track.
+
+```ts
+const track = await audioPlayer.getCurrentTrack();
+```
+
+**Returns:** `Promise<Track | null>`
+
+---
+
+### `getQueue()`
+
+Queries the current queue state.
+
+```ts
+const queue = await audioPlayer.getQueue();
+```
+
+**Returns:** `Promise<QueueSnapshot>`
+
+---
+
+### `getSnapshot()`
+
+Queries the complete playback state.
+
+```ts
+const snapshot = await audioPlayer.getSnapshot();
+```
+
+**Returns:** `Promise<PlaybackSnapshot>`
+
+---
+
+### `getCapabilities()`
+
+Queries runtime-supported capabilities.
+
+```ts
+const caps = await audioPlayer.getCapabilities();
+// { supported: ['play', 'pause', 'stop', 'seek', 'skip-next', 'skip-previous'] }
+```
+
+**Returns:** `Promise<BindingCapabilitiesSnapshot>`
+
+<Aside type="note">
+Capability values are defined in the contract package as `'play' | 'pause' | 'stop' | 'seek' | 'skip-next' | 'skip-previous'`.
+Projection is runtime-dependent: for example, `seek` may only be reported when the current track and playback state allow it.
+See the [Snapshots Reference](snapshots.mdx#bindingcapabilitiessnapshot) for the full shape and practical usage.
+</Aside>
+
+---
+
+### `addListener(eventName, listener)`
+
+Registers a listener for player lifecycle events.
+
+```ts
+const handle = await audioPlayer.addListener('playback-state-changed', (payload) => {
+  console.log('State changed:', payload.state);
+});
+
+// Remove listener when done
+await handle.remove();
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `eventName` | `AudioPlayerEventName` | Yes | Event to subscribe to. |
+| `listener` | `AudioPlayerListener<E>` | Yes | Callback with typed payload. |
+
+**Returns:** `Promise<BindingListenerHandle>`
+
+---
+
+### `removeAllListeners()`
+
+Removes all registered player listeners.
+
+```ts
+await audioPlayer.removeAllListeners();
+```
+
+**Returns:** `Promise<void>`
+
+---
+
+## Type definitions
+
+### `AddOptions`
+
+```ts
+interface AddOptions {
+  tracks: Track[];
+  startIndex?: number;
+}
+```
+
+### `RemoveOptions`
+
+```ts
+interface RemoveOptions {
+  id?: string;
+  index?: number;
+}
+```
+
+### `SeekToOptions`
+
+```ts
+interface SeekToOptions {
+  position: number;
+}
+```
+
+### `SkipToOptions`
+
+```ts
+interface SkipToOptions {
+  index: number;
+}
+```
+
+### `BindingCapabilitiesSnapshot`
+
+```ts
+interface BindingCapabilitiesSnapshot {
+  supported: Capability[];
+}
+```
+
+### `BindingListenerHandle`
+
+```ts
+interface BindingListenerHandle {
+  remove(): Promise<void> | void;
+}
+```
+
+<Aside type="tip">
+For event-name constants and shortcut helpers, see the [Events Reference](events.mdx).
+</Aside>

--- a/apps/docs-site/src/content/docs/packages/capacitor/reference/audio-player.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/reference/audio-player.mdx
@@ -303,7 +303,7 @@ const caps = await audioPlayer.getCapabilities();
 <Aside type="note">
 Capability values are defined in the contract package as `'play' | 'pause' | 'stop' | 'seek' | 'skip-next' | 'skip-previous'`.
 Projection is runtime-dependent: for example, `seek` may only be reported when the current track and playback state allow it.
-See the [Snapshots Reference](snapshots.mdx#bindingcapabilitiessnapshot) for the full shape and practical usage.
+See the [Snapshots Reference](snapshots/#bindingcapabilitiessnapshot) for the full shape and practical usage.
 </Aside>
 
 ---
@@ -397,5 +397,5 @@ interface BindingListenerHandle {
 ```
 
 <Aside type="tip">
-For event-name constants and shortcut helpers, see the [Events Reference](events.mdx).
+For event-name constants and shortcut helpers, see the [Events Reference](events/).
 </Aside>

--- a/apps/docs-site/src/content/docs/packages/capacitor/reference/errors.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/reference/errors.mdx
@@ -1,0 +1,100 @@
+---
+title: Errors Reference
+description: Complete reference for LegatoError interface and error codes.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+This page documents the `LegatoError` interface and error codes emitted by the Legato runtime.
+
+## LegatoError interface
+
+Error payload shape used by `playback-error` events and API failures.
+
+```ts
+interface LegatoError {
+  /** Stable machine-readable code. */
+  code: LegatoErrorCode;
+  /** Human-readable error message from adapter/runtime. */
+  message: string;
+  /** Optional transport-specific details. */
+  details?: unknown;
+}
+```
+
+## Error codes
+
+### `LEGATO_ERROR_CODES`
+
+All supported error code literals.
+
+```ts
+import { LEGATO_ERROR_CODES } from '@ddgutierrezc/legato-contract';
+
+// LEGATO_ERROR_CODES = [
+//   'player_not_setup',
+//   'invalid_index',
+//   'empty_queue',
+//   'no_active_track',
+//   'invalid_url',
+//   'load_failed',
+//   'playback_failed',
+//   'seek_failed',
+//   'unsupported_operation',
+//   'platform_error'
+// ];
+```
+
+### Error code reference
+
+| Code | Description |
+|------|-------------|
+| `player_not_setup` | Playback APIs called before `audioPlayer.setup()`. |
+| `invalid_index` | Queue index out of bounds or invalid for current queue length. |
+| `empty_queue` | Playback attempted on empty queue. |
+| `no_active_track` | No active track selected in the queue. |
+| `invalid_url` | Track URL is malformed or unsupported. |
+| `load_failed` | Media failed to load (network error, unsupported format, etc.). |
+| `playback_failed` | Playback interrupted or failed during active playback. |
+| `seek_failed` | Seek operation failed (unsupported by track type or runtime). |
+| `unsupported_operation` | Operation not supported by current platform capabilities. |
+| `platform_error` | Platform-specific error (native layer failure). |
+
+## Handling errors
+
+### Via event listener
+
+```ts
+import { onPlaybackError } from '@ddgutierrezc/legato-capacitor';
+
+onPlaybackError(({ error }) => {
+  console.error('Playback error:', error.code, error.message);
+  if (error.details) {
+    console.error('Details:', error.details);
+  }
+});
+```
+
+### Via async error handling
+
+```ts
+try {
+  await audioPlayer.play();
+} catch (err) {
+  if (err.code) {
+    console.error('Legato error:', err.code);
+  } else {
+    throw err;
+  }
+}
+```
+
+<Aside type="note">
+Not all methods throw `LegatoError`. Check individual method documentation for error behavior.
+</Aside>
+
+## Related types
+
+- `PlaybackState` — can be `'error'` when a playback error occurs
+- `PlaybackSnapshot` — may contain error state information
+- `LEGATO_EVENTS` — includes `playback-error` for event-driven error handling

--- a/apps/docs-site/src/content/docs/packages/capacitor/reference/events.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/reference/events.mdx
@@ -152,22 +152,22 @@ await unsubProgress.remove();
 
 | Event | Payload Type |
 |-------|-------------|
-| `playback-state-changed` | `{ state: PlaybackState }` |
-| `playback-active-track-changed` | `{ track: Track | null; index: number | null }` |
-| `playback-queue-changed` | `{ queue: QueueSnapshot }` |
-| `playback-progress` | `{ position: number; duration: number | null; bufferedPosition: number | null }` |
-| `playback-ended` | `{ snapshot: PlaybackSnapshot }` |
-| `playback-error` | `{ error: LegatoError }` |
+| `playback-state-changed` | ``{ state: PlaybackState }`` |
+| `playback-active-track-changed` | ``{ track: Track | null; index: number | null }`` |
+| `playback-queue-changed` | ``{ queue: QueueSnapshot }`` |
+| `playback-progress` | ``{ position: number; duration: number | null; bufferedPosition: number | null }`` |
+| `playback-ended` | ``{ snapshot: PlaybackSnapshot }`` |
+| `playback-error` | ``{ error: LegatoError }`` |
 
 ### Media session payloads
 
 | Event | Payload Type |
 |-------|-------------|
-| `remote-play` | `{}` |
-| `remote-pause` | `{}` |
-| `remote-next` | `{}` |
-| `remote-previous` | `{}` |
-| `remote-seek` | `{ position: number }` |
+| `remote-play` | ``{}`` |
+| `remote-pause` | ``{}`` |
+| `remote-next` | ``{}`` |
+| `remote-previous` | ``{}`` |
+| `remote-seek` | ``{ position: number }`` |
 
 <Aside type="note">
 The `remote-seek` event is only emitted when the runtime supports seek capability. Check `getCapabilities()` to determine if seek is available on the current platform.

--- a/apps/docs-site/src/content/docs/packages/capacitor/reference/events.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/reference/events.mdx
@@ -1,9 +1,9 @@
 ---
 title: Events Reference
 description: Complete reference for event-name constants, payload types, and event listener helpers.
+---
 
 import { Aside } from '@astrojs/starlight/components';
-
 
 This page documents event-name constants, payload maps, and event listener helpers exported by `@ddgutierrezc/legato-capacitor`.
 

--- a/apps/docs-site/src/content/docs/packages/capacitor/reference/events.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/reference/events.mdx
@@ -1,0 +1,223 @@
+---
+title: Events Reference
+description: Complete reference for event-name constants, payload types, and event listener helpers.
+---
+
+This page documents event-name constants, payload maps, and event listener helpers exported by `@ddgutierrezc/legato-capacitor`.
+
+## Event-name constants
+
+### `AUDIO_PLAYER_EVENTS`
+
+Player lifecycle event names.
+
+```ts
+import { AUDIO_PLAYER_EVENTS } from '@ddgutierrezc/legato-capacitor';
+
+// AUDIO_PLAYER_EVENTS = [
+//   'playback-state-changed',
+//   'playback-active-track-changed',
+//   'playback-queue-changed',
+//   'playback-progress',
+//   'playback-ended',
+//   'playback-error'
+// ];
+```
+
+### `MEDIA_SESSION_EVENTS`
+
+Remote control event names.
+
+```ts
+import { MEDIA_SESSION_EVENTS } from '@ddgutierrezc/legato-capacitor';
+
+// MEDIA_SESSION_EVENTS = [
+//   'remote-play',
+//   'remote-pause',
+//   'remote-next',
+//   'remote-previous',
+//   'remote-seek'
+// ];
+```
+
+### `LEGATO_EVENTS`
+
+All Legato event names (union of player and media session events).
+
+```ts
+import { LEGATO_EVENTS } from '@ddgutierrezc/legato-capacitor';
+
+// LEGATO_EVENTS = [
+//   'playback-state-changed',
+//   'playback-active-track-changed',
+//   'playback-queue-changed',
+//   'playback-progress',
+//   'playback-ended',
+//   'playback-error',
+//   'remote-play',
+//   'remote-pause',
+//   'remote-next',
+//   'remote-previous',
+//   'remote-seek'
+// ];
+```
+
+## Listener helpers
+
+### Direct listeners
+
+#### `addAudioPlayerListener(eventName, listener)`
+
+Registers a listener for player lifecycle events.
+
+```ts
+import { addAudioPlayerListener } from '@ddgutierrezc/legato-capacitor';
+
+const handle = await addAudioPlayerListener('playback-state-changed', (payload) => {
+  console.log('State:', payload.state);
+});
+```
+
+#### `addMediaSessionListener(eventName, listener)`
+
+Registers a listener for media session events.
+
+```ts
+import { addMediaSessionListener } from '@ddgutierrezc/legato-capacitor';
+
+const handle = await addMediaSessionListener('remote-play', () => {
+  console.log('User pressed play');
+});
+```
+
+#### `addLegatoListener(eventName, listener)`
+
+Registers a listener for any Legato event.
+
+```ts
+import { addLegatoListener } from '@ddgutierrezc/legato-capacitor';
+
+const handle = await addLegatoListener('playback-progress', (payload) => {
+  console.log(`Position: ${payload.position}s / ${payload.duration}s`);
+});
+```
+
+### Shortcut helpers
+
+These helpers provide a simpler API for common event subscriptions.
+
+| Helper | Event | Description |
+|--------|-------|-------------|
+| `onPlaybackStateChanged` | `playback-state-changed` | Playback state transitions. |
+| `onPlaybackActiveTrackChanged` | `playback-active-track-changed` | Active track or index changes. |
+| `onPlaybackQueueChanged` | `playback-queue-changed` | Queue structure changes. |
+| `onPlaybackProgress` | `playback-progress` | Position/duration/buffer progress. |
+| `onPlaybackEnded` | `playback-ended` | Terminal playback state. |
+| `onPlaybackError` | `playback-error` | Playback error events. |
+| `onRemotePlay` | `remote-play` | Remote play command. |
+| `onRemotePause` | `remote-pause` | Remote pause command. |
+| `onRemoteNext` | `remote-next` | Remote next command. |
+| `onRemotePrevious` | `remote-previous` | Remote previous command. |
+| `onRemoteSeek` | `remote-seek` | Remote seek command. |
+
+### Example: Using shortcut helpers
+
+```ts
+import {
+  onPlaybackStateChanged,
+  onPlaybackProgress,
+  onPlaybackEnded,
+} from '@ddgutierrezc/legato-capacitor';
+
+// Subscribe to state changes
+const unsubState = onPlaybackStateChanged((payload) => {
+  console.log('State changed:', payload.state);
+});
+
+// Subscribe to progress
+const unsubProgress = onPlaybackProgress((payload) => {
+  console.log(`Position: ${payload.position.toFixed(1)}s`);
+});
+
+// Clean up subscriptions when done
+await unsubState.remove();
+await unsubProgress.remove();
+```
+
+## Payload reference
+
+### Player event payloads
+
+| Event | Payload Type |
+|-------|-------------|
+| `playback-state-changed` | `{ state: PlaybackState }` |
+| `playback-active-track-changed` | `{ track: Track | null; index: number | null }` |
+| `playback-queue-changed` | `{ queue: QueueSnapshot }` |
+| `playback-progress` | `{ position: number; duration: number | null; bufferedPosition: number | null }` |
+| `playback-ended` | `{ snapshot: PlaybackSnapshot }` |
+| `playback-error` | `{ error: LegatoError }` |
+
+### Media session payloads
+
+| Event | Payload Type |
+|-------|-------------|
+| `remote-play` | `{}` |
+| `remote-pause` | `{}` |
+| `remote-next` | `{}` |
+| `remote-previous` | `{}` |
+| `remote-seek` | `{ position: number }` |
+
+<Aside type="note">
+The `remote-seek` event is only emitted when the runtime supports seek capability. Check `getCapabilities()` to determine if seek is available on the current platform.
+</Aside>
+
+## Type definitions
+
+### `LegatoEventName`
+
+Union of all Legato event name strings.
+
+```ts
+type LegatoEventName =
+  | 'playback-state-changed'
+  | 'playback-active-track-changed'
+  | 'playback-queue-changed'
+  | 'playback-progress'
+  | 'playback-ended'
+  | 'playback-error'
+  | 'remote-play'
+  | 'remote-pause'
+  | 'remote-next'
+  | 'remote-previous'
+  | 'remote-seek';
+```
+
+### `LegatoEventPayloadMap`
+
+Map of event names to their payload types.
+
+```ts
+interface LegatoEventPayloadMap {
+  'playback-state-changed': { state: PlaybackState };
+  'playback-active-track-changed': { track: Track | null; index: number | null };
+  'playback-queue-changed': { queue: QueueSnapshot };
+  'playback-progress': { position: number; duration: number | null; bufferedPosition: number | null };
+  'playback-ended': { snapshot: PlaybackSnapshot };
+  'playback-error': { error: LegatoError };
+  'remote-play': {};
+  'remote-pause': {};
+  'remote-next': {};
+  'remote-previous': {};
+  'remote-seek': { position: number };
+}
+```
+
+### `LegatoListener<E>`
+
+Listener signature for any Legato event.
+
+```ts
+type LegatoListener<E extends LegatoEventName> = (
+  payload: LegatoEventPayloadMap[E]
+) => void;
+```

--- a/apps/docs-site/src/content/docs/packages/capacitor/reference/events.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/reference/events.mdx
@@ -1,7 +1,9 @@
 ---
 title: Events Reference
 description: Complete reference for event-name constants, payload types, and event listener helpers.
----
+
+import { Aside } from '@astrojs/starlight/components';
+
 
 This page documents event-name constants, payload maps, and event listener helpers exported by `@ddgutierrezc/legato-capacitor`.
 

--- a/apps/docs-site/src/content/docs/packages/capacitor/reference/events.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/reference/events.mdx
@@ -150,24 +150,20 @@ await unsubProgress.remove();
 
 ### Player event payloads
 
-| Event | Payload Type |
-|-------|-------------|
-| `playback-state-changed` | ``{ state: PlaybackState }`` |
-| `playback-active-track-changed` | ``{ track: Track | null; index: number | null }`` |
-| `playback-queue-changed` | ``{ queue: QueueSnapshot }`` |
-| `playback-progress` | ``{ position: number; duration: number | null; bufferedPosition: number | null }`` |
-| `playback-ended` | ``{ snapshot: PlaybackSnapshot }`` |
-| `playback-error` | ``{ error: LegatoError }`` |
+- `playback-state-changed` — ``{ state: PlaybackState }``
+- `playback-active-track-changed` — ``{ track: Track | null; index: number | null }``
+- `playback-queue-changed` — ``{ queue: QueueSnapshot }``
+- `playback-progress` — ``{ position: number; duration: number | null; bufferedPosition: number | null }``
+- `playback-ended` — ``{ snapshot: PlaybackSnapshot }``
+- `playback-error` — ``{ error: LegatoError }``
 
 ### Media session payloads
 
-| Event | Payload Type |
-|-------|-------------|
-| `remote-play` | ``{}`` |
-| `remote-pause` | ``{}`` |
-| `remote-next` | ``{}`` |
-| `remote-previous` | ``{}`` |
-| `remote-seek` | ``{ position: number }`` |
+- `remote-play` — ``{}``
+- `remote-pause` — ``{}``
+- `remote-next` — ``{}``
+- `remote-previous` — ``{}``
+- `remote-seek` — ``{ position: number }``
 
 <Aside type="note">
 The `remote-seek` event is only emitted when the runtime supports seek capability. Check `getCapabilities()` to determine if seek is available on the current platform.

--- a/apps/docs-site/src/content/docs/packages/capacitor/reference/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/reference/index.mdx
@@ -9,13 +9,13 @@ This section provides complete API documentation for all exported members of `@d
 
 | Page | Description |
 |------|-------------|
-| **[Audio Player](audio-player.mdx)** | `AudioPlayerApi` — playback commands, queue operations, state queries, and player event listeners. |
-| **[Media Session](media-session.mdx)** | `MediaSessionApi` — remote control event listeners and subscription helpers. |
-| **[Legato Facade](legato.mdx)** | `Legato` — unified facade combining `audioPlayer` and `mediaSession` surfaces with a single event listener. |
-| **[Snapshots](snapshots.mdx)** | `PlaybackSnapshot`, `QueueSnapshot`, and `BindingCapabilitiesSnapshot` — shapes, sources, and usage. |
-| **[Events](events.mdx)** | Event-name constants, payload types, and shortcut listener helpers. |
-| **[Errors](errors.mdx)** | `LegatoError` interface and error code constants. |
-| **[Sync](sync.mdx)** | Sync controller factories for local snapshot mirroring. |
+| **[Audio Player](audio-player/)** | `AudioPlayerApi` — playback commands, queue operations, state queries, and player event listeners. |
+| **[Media Session](media-session/)** | `MediaSessionApi` — remote control event listeners and subscription helpers. |
+| **[Legato Facade](legato/)** | `Legato` — unified facade combining `audioPlayer` and `mediaSession` surfaces with a single event listener. |
+| **[Snapshots](snapshots/)** | `PlaybackSnapshot`, `QueueSnapshot`, and `BindingCapabilitiesSnapshot` — shapes, sources, and usage. |
+| **[Events](events/)** | Event-name constants, payload types, and shortcut listener helpers. |
+| **[Errors](errors/)** | `LegatoError` interface and error code constants. |
+| **[Sync](sync/)** | Sync controller factories for local snapshot mirroring. |
 
 ## Quick reference
 
@@ -38,7 +38,7 @@ The following types are re-exported from `@ddgutierrezc/legato-contract`:
 
 - `Track` — queue item shape
 - `PlaybackState` — playback state literals (`idle`, `loading`, `ready`, `playing`, `paused`, `buffering`, `ended`, `error`)
-- `PlaybackSnapshot` — full playback projection (see [Snapshots](snapshots.mdx))
-- `QueueSnapshot` — queue projection (see [Snapshots](snapshots.mdx))
-- `BindingCapabilitiesSnapshot` — runtime capability snapshot (see [Snapshots](snapshots.mdx))
+- `PlaybackSnapshot` — full playback projection (see [Snapshots](snapshots/))
+- `QueueSnapshot` — queue projection (see [Snapshots](snapshots/))
+- `BindingCapabilitiesSnapshot` — runtime capability snapshot (see [Snapshots](snapshots/))
 - `LegatoError` — error payload

--- a/apps/docs-site/src/content/docs/packages/capacitor/reference/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/reference/index.mdx
@@ -1,0 +1,44 @@
+---
+title: API Reference
+description: Detailed API reference for the legato-capacitor package.
+---
+
+This section provides complete API documentation for all exported members of `@ddgutierrezc/legato-capacitor`.
+
+## Reference pages
+
+| Page | Description |
+|------|-------------|
+| **[Audio Player](audio-player.mdx)** | `AudioPlayerApi` — playback commands, queue operations, state queries, and player event listeners. |
+| **[Media Session](media-session.mdx)** | `MediaSessionApi` — remote control event listeners and subscription helpers. |
+| **[Legato Facade](legato.mdx)** | `Legato` — unified facade combining `audioPlayer` and `mediaSession` surfaces with a single event listener. |
+| **[Snapshots](snapshots.mdx)** | `PlaybackSnapshot`, `QueueSnapshot`, and `BindingCapabilitiesSnapshot` — shapes, sources, and usage. |
+| **[Events](events.mdx)** | Event-name constants, payload types, and shortcut listener helpers. |
+| **[Errors](errors.mdx)** | `LegatoError` interface and error code constants. |
+| **[Sync](sync.mdx)** | Sync controller factories for local snapshot mirroring. |
+
+## Quick reference
+
+### Namespaces
+
+```ts
+// Playback commands and queries
+const player = audioPlayer;
+
+// Remote control listeners
+const remote = mediaSession;
+
+// Unified facade
+const legato = Legato;
+```
+
+### Types re-exported from contract
+
+The following types are re-exported from `@ddgutierrezc/legato-contract`:
+
+- `Track` — queue item shape
+- `PlaybackState` — playback state literals (`idle`, `loading`, `ready`, `playing`, `paused`, `buffering`, `ended`, `error`)
+- `PlaybackSnapshot` — full playback projection (see [Snapshots](snapshots.mdx))
+- `QueueSnapshot` — queue projection (see [Snapshots](snapshots.mdx))
+- `BindingCapabilitiesSnapshot` — runtime capability snapshot (see [Snapshots](snapshots.mdx))
+- `LegatoError` — error payload

--- a/apps/docs-site/src/content/docs/packages/capacitor/reference/legato.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/reference/legato.mdx
@@ -1,0 +1,142 @@
+---
+title: Legato Facade
+description: Complete API reference for the unified Legato facade.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+The `Legato` facade is a unified API surface that combines `audioPlayer` and `mediaSession` with a single event listener covering all Legato event names.
+
+## When to use Legato vs audioPlayer vs mediaSession
+
+| Export | Surface | Listener scope | Typical use |
+|--------|---------|----------------|-------------|
+| `audioPlayer` | Playback commands + player events | `AudioPlayerEventName` only | When you only need playback control and player lifecycle events. |
+| `mediaSession` | Media session commands + remote events | `MediaSessionEventName` only | When you only need remote control listeners. |
+| `Legato` | Playback commands + media session + unified events | `LegatoEventName` (all events) | When you want a single import for both playback control and all event types. |
+
+## Interface
+
+```ts
+type LegatoApi = AudioPlayerApi & MediaSessionApi;
+
+interface LegatoEventApi {
+  addListener<E extends LegatoEventName>(
+    eventName: E,
+    listener: LegatoListener<E>
+  ): Promise<BindingListenerHandle>;
+  removeAllListeners(): Promise<void>;
+}
+
+// Legato exposes both surfaces:
+const Legato: LegatoApi & LegatoEventApi;
+```
+
+`Legato` is the union of:
+- All `AudioPlayerApi` methods (play, pause, seek, queue ops, `getSnapshot()`, `getCapabilities()`, etc.)
+- All `MediaSessionApi` methods (`setup()`, `addListener`, `removeAllListeners`)
+- A unified `addListener` that accepts any `LegatoEventName` (player + media session events combined)
+
+## Key difference: addListener scopes
+
+```ts
+import { Legato, audioPlayer, mediaSession } from '@ddgutierrezc/legato-capacitor';
+
+// audioPlayer.addListener only accepts AudioPlayerEventName
+await audioPlayer.addListener('playback-state-changed', (payload) => { ... });
+// ❌ This would fail: 'remote-play' is not in AudioPlayerEventName
+// await audioPlayer.addListener('remote-play', ...);
+
+// mediaSession.addListener only accepts MediaSessionEventName
+await mediaSession.addListener('remote-play', () => { ... });
+// ❌ This would fail: 'playback-state-changed' is not in MediaSessionEventName
+// await mediaSession.addListener('playback-state-changed', ...);
+
+// Legato.addListener accepts ALL event names
+await Legato.addListener('playback-state-changed', (payload) => { ... });
+await Legato.addListener('remote-play', () => { ... });
+```
+
+## Playback methods
+
+`Legato` inherits all playback methods from `AudioPlayerApi`:
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `setup()` | `Promise<void>` | Initializes the native plugin. |
+| `add(options)` | `Promise<PlaybackSnapshot>` | Appends tracks to the queue. |
+| `remove(options)` | `Promise<PlaybackSnapshot>` | Removes queue entries by ID or index. |
+| `reset()` | `Promise<PlaybackSnapshot>` | Clears the queue and stops playback. |
+| `play()` | `Promise<void>` | Starts or resumes playback. |
+| `pause()` | `Promise<void>` | Pauses playback. |
+| `stop()` | `Promise<void>` | Stops playback and resets position. |
+| `seekTo(options)` | `Promise<void>` | Seeks to a specific position. |
+| `skipTo(options)` | `Promise<PlaybackSnapshot>` | Skips to a specific queue index. |
+| `skipToNext()` | `Promise<void>` | Skips to the next track. |
+| `skipToPrevious()` | `Promise<void>` | Skips to the previous track. |
+| `getState()` | `Promise<PlaybackState>` | Queries the current playback state. |
+| `getPosition()` | `Promise<number>` | Queries the current playback position. |
+| `getDuration()` | `Promise<number \| null>` | Queries the current track duration. |
+| `getCurrentTrack()` | `Promise<Track \| null>` | Queries the active track. |
+| `getQueue()` | `Promise<QueueSnapshot>` | Queries the current queue state. |
+| `getSnapshot()` | `Promise<PlaybackSnapshot>` | Queries the complete playback state. |
+| `getCapabilities()` | `Promise<BindingCapabilitiesSnapshot>` | Queries runtime-supported capabilities. |
+
+## Event methods
+
+```ts
+// Unified listener: accepts any LegatoEventName
+const handle = await Legato.addListener('playback-state-changed', (payload) => {
+  console.log('State:', payload.state);
+});
+
+// Also accepts media session events
+const remoteHandle = await Legato.addListener('remote-play', () => {
+  console.log('Remote play triggered');
+});
+
+// Remove a specific listener
+await handle.remove();
+
+// Remove all listeners
+await Legato.removeAllListeners();
+```
+
+## Usage example
+
+```ts
+import { Legato } from '@ddgutierrezc/legato-capacitor';
+
+// Initialize (setup is idempotent via the shared native plugin)
+await Legato.setup();
+
+// Add tracks and start playback
+await Legato.add({
+  tracks: [{ id: 't1', url: 'https://example.com/audio.mp3', title: 'My Track' }],
+  startIndex: 0,
+});
+await Legato.play();
+
+// Listen to ALL events with a single import
+const stateHandle = await Legato.addListener('playback-state-changed', (payload) => {
+  console.log('State:', payload.state);
+});
+
+const remoteHandle = await Legato.addListener('remote-pause', () => {
+  console.log('Paused from lock screen');
+});
+
+// Clean up
+await stateHandle.remove();
+await remoteHandle.remove();
+```
+
+<Aside type="tip">
+If you only need player events OR remote events, prefer `audioPlayer` or `mediaSession` respectively for tighter type scoping. Use `Legato` when you want a single import for everything.
+</Aside>
+
+## Related pages
+
+- [Audio Player API](audio-player.mdx) — for the full `AudioPlayerApi` interface
+- [Media Session API](media-session.mdx) — for the full `MediaSessionApi` interface
+- [Events Reference](events.mdx) — for event-name constants and payload types

--- a/apps/docs-site/src/content/docs/packages/capacitor/reference/legato.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/reference/legato.mdx
@@ -137,6 +137,6 @@ If you only need player events OR remote events, prefer `audioPlayer` or `mediaS
 
 ## Related pages
 
-- [Audio Player API](audio-player.mdx) — for the full `AudioPlayerApi` interface
-- [Media Session API](media-session.mdx) — for the full `MediaSessionApi` interface
-- [Events Reference](events.mdx) — for event-name constants and payload types
+- [Audio Player API](audio-player/) — for the full `AudioPlayerApi` interface
+- [Media Session API](media-session/) — for the full `MediaSessionApi` interface
+- [Events Reference](events/) — for event-name constants and payload types

--- a/apps/docs-site/src/content/docs/packages/capacitor/reference/media-session.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/reference/media-session.mdx
@@ -1,0 +1,111 @@
+---
+title: Media Session API
+description: Complete API reference for the MediaSessionApi interface.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+The `mediaSession` namespace provides listeners for remote control events from system media controls, Bluetooth devices, and the lock screen.
+
+## Interface
+
+```ts
+interface MediaSessionApi {
+  setup(): Promise<void>;
+  addListener<E extends MediaSessionEventName>(
+    eventName: E,
+    listener: MediaSessionListener<E>
+  ): Promise<BindingListenerHandle>;
+  removeAllListeners(): Promise<void>;
+}
+```
+
+## Methods
+
+### `setup()`
+
+Initializes the native plugin. MUST be called before registering listeners.
+
+```ts
+await mediaSession.setup();
+```
+
+**Returns:** `Promise<void>`
+
+<Aside type="note">
+Unlike `audioPlayer.setup()`, `mediaSession.setup()` does NOT initialize the playback system. It only prepares the media session service. Call both `audioPlayer.setup()` and `mediaSession.setup()` for full integration.
+</Aside>
+
+---
+
+### `addListener(eventName, listener)`
+
+Registers a listener for remote control events.
+
+```ts
+const handle = await mediaSession.addListener('remote-play', () => {
+  console.log('User pressed play on remote control');
+});
+
+// Remove listener when done
+await handle.remove();
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `eventName` | `MediaSessionEventName` | Yes | Remote event to subscribe to. |
+| `listener` | `MediaSessionListener<E>` | Yes | Callback with typed payload. |
+
+**Returns:** `Promise<BindingListenerHandle>`
+
+### Supported event names
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `remote-play` | `{}` | User triggered play from remote control. |
+| `remote-pause` | `{}` | User triggered pause from remote control. |
+| `remote-next` | `{}` | User triggered next track. |
+| `remote-previous` | `{}` | User triggered previous track. |
+| `remote-seek` | `{ position: number }` | User triggered seek. **Only emitted if runtime supports seek.** |
+
+---
+
+### `removeAllListeners()`
+
+Removes all registered media session listeners.
+
+```ts
+await mediaSession.removeAllListeners();
+```
+
+**Returns:** `Promise<void>`
+
+---
+
+## Payload types
+
+### `MediaSessionEventPayloadMap`
+
+```ts
+interface MediaSessionEventPayloadMap {
+  'remote-play': {};
+  'remote-pause': {};
+  'remote-next': {};
+  'remote-previous': {};
+  'remote-seek': { position: number };
+}
+```
+
+## Listener type
+
+```ts
+type MediaSessionListener<E extends MediaSessionEventName> = (
+  payload: MediaSessionEventPayloadMap[E]
+) => void;
+```
+
+<Aside type="tip">
+For shortcut helpers like `onRemotePlay` and `onRemotePause`, see the [Events Reference](events.mdx).
+</Aside>

--- a/apps/docs-site/src/content/docs/packages/capacitor/reference/media-session.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/reference/media-session.mdx
@@ -107,5 +107,5 @@ type MediaSessionListener<E extends MediaSessionEventName> = (
 ```
 
 <Aside type="tip">
-For shortcut helpers like `onRemotePlay` and `onRemotePause`, see the [Events Reference](events.mdx).
+For shortcut helpers like `onRemotePlay` and `onRemotePause`, see the [Events Reference](events/).
 </Aside>

--- a/apps/docs-site/src/content/docs/packages/capacitor/reference/snapshots.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/reference/snapshots.mdx
@@ -1,0 +1,169 @@
+---
+title: Snapshots
+description: Complete reference for PlaybackSnapshot, QueueSnapshot, and BindingCapabilitiesSnapshot types.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Snapshots are immutable read-model projections returned by query methods and events. They represent a point-in-time view of the playback runtime state.
+
+## PlaybackSnapshot
+
+Returned by `getSnapshot()`, and by mutating methods that change playback state (`add()`, `remove()`, `reset()`, `skipTo()`). Also appears in the `playback-ended` event payload.
+
+```ts
+interface PlaybackSnapshot {
+  /** Current playback state. */
+  state: PlaybackState;
+  /** Current active track, or null when none is active. */
+  currentTrack: Track | null;
+  /** Current active queue index, or null when none is active. */
+  currentIndex: number | null;
+  /** Playback position in seconds. */
+  position: number;
+  /**
+   * Nullable duration semantics:
+   * - null => unknown/live-like timeline semantics.
+   * - finite number => evidence of finite media length, but not a seekability guarantee by itself.
+   *
+   * Consumers should combine duration with projected canSeek capability.
+   */
+  duration: number | null;
+  /** Buffered position in seconds when provided by runtime. */
+  bufferedPosition?: number | null;
+  /** Queue projection associated with the snapshot. */
+  queue: QueueSnapshot;
+}
+```
+
+### Methods that return PlaybackSnapshot
+
+| Method | When |
+|--------|------|
+| `getSnapshot()` | Explicit query of current playback state. |
+| `add(options)` | After appending tracks to the queue. |
+| `remove(options)` | After removing queue entries. |
+| `reset()` | After clearing the queue. |
+| `skipTo(options)` | After skipping to a specific index. |
+
+### Events that carry PlaybackSnapshot
+
+| Event | Payload field |
+|-------|---------------|
+| `playback-ended` | `payload.snapshot` — terminal snapshot at end of playback. |
+
+---
+
+## QueueSnapshot
+
+Returned by `getQueue()`. Also embedded inside every `PlaybackSnapshot.queue` field.
+
+```ts
+interface QueueSnapshot {
+  /** Ordered queue items. */
+  items: Track[];
+  /** Active queue index, or null when no active item exists. */
+  currentIndex: number | null;
+}
+```
+
+### Methods that return QueueSnapshot
+
+| Method | When |
+|--------|------|
+| `getQueue()` | Explicit query of current queue state. |
+
+### Events that carry QueueSnapshot
+
+| Event | Payload field |
+|-------|---------------|
+| `playback-queue-changed` | `payload.queue` — full queue projection after structural changes. |
+
+---
+
+## BindingCapabilitiesSnapshot
+
+Returned by `getCapabilities()`. Describes which playback operations are currently supported by the runtime.
+
+```ts
+interface BindingCapabilitiesSnapshot {
+  /** Capabilities currently supported by the plugin runtime. */
+  supported: Capability[];
+}
+```
+
+### Capability values
+
+The `Capability` type is a union of runtime-supported feature literals:
+
+| Value | Description |
+|-------|-------------|
+| `'play'` | Runtime can start or resume playback. |
+| `'pause'` | Runtime can pause playback. |
+| `'stop'` | Runtime can stop playback and reset position. |
+| `'seek'` | Runtime supports seeking to arbitrary positions. |
+| `'skip-next'` | Runtime supports skipping to the next track. |
+| `'skip-previous'` | Runtime supports skipping to the previous track. |
+
+These values are defined in the contract package as:
+
+```ts
+const CAPABILITIES = [
+  'play',
+  'pause',
+  'stop',
+  'seek',
+  'skip-next',
+  'skip-previous',
+] as const;
+
+type Capability = (typeof CAPABILITIES)[number];
+```
+
+<Aside type="note">
+Capability projection is runtime-dependent. For example, `seek` may only be reported when the current track type and playback state allow it. Always check `getCapabilities()` at runtime rather than hardcoding assumptions.
+</Aside>
+
+### Practical usage
+
+```ts
+import { audioPlayer } from '@ddgutierrezc/legato-capacitor';
+
+const caps = await audioPlayer.getCapabilities();
+
+if (caps.supported.includes('seek')) {
+  // Enable seek UI
+  showSeekBar();
+} else {
+  // Hide seek UI or show disabled state
+  hideSeekBar();
+}
+
+if (caps.supported.includes('skip-next')) {
+  showNextButton();
+}
+```
+
+---
+
+## Type hierarchy
+
+```
+PlaybackSnapshot
+├── state: PlaybackState
+├── currentTrack: Track | null
+├── currentIndex: number | null
+├── position: number
+├── duration: number | null
+├── bufferedPosition?: number | null
+└── queue: QueueSnapshot
+    ├── items: Track[]
+    └── currentIndex: number | null
+```
+
+## Related pages
+
+- [Audio Player API](audio-player.mdx) — methods that return snapshots
+- [Events Reference](events.mdx) — events that carry snapshot payloads
+- [Legato Facade](legato.mdx) — unified API surface that includes snapshot methods
+- [Sync Controllers](sync.mdx) — local snapshot mirroring using these types

--- a/apps/docs-site/src/content/docs/packages/capacitor/reference/snapshots.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/reference/snapshots.mdx
@@ -163,7 +163,7 @@ PlaybackSnapshot
 
 ## Related pages
 
-- [Audio Player API](audio-player.mdx) — methods that return snapshots
-- [Events Reference](events.mdx) — events that carry snapshot payloads
-- [Legato Facade](legato.mdx) — unified API surface that includes snapshot methods
-- [Sync Controllers](sync.mdx) — local snapshot mirroring using these types
+- [Audio Player API](audio-player/) — methods that return snapshots
+- [Events Reference](events/) — events that carry snapshot payloads
+- [Legato Facade](legato/) — unified API surface that includes snapshot methods
+- [Sync Controllers](sync/) — local snapshot mirroring using these types

--- a/apps/docs-site/src/content/docs/packages/capacitor/reference/sync.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/reference/sync.mdx
@@ -155,4 +155,4 @@ The sync controller processes these events to update the local snapshot:
 
 - [Audio Player API](audio-player/) — for `getSnapshot()` source
 - [Events Reference](events/) — for event payload types
-- [How-to: Use Sync](./../how-to/use-sync/) — task-oriented guide
+- [How-to: Use Sync](../how-to/use-sync/) — task-oriented guide

--- a/apps/docs-site/src/content/docs/packages/capacitor/reference/sync.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/reference/sync.mdx
@@ -1,0 +1,158 @@
+---
+title: Sync Controllers
+description: Complete reference for sync controller factories and interfaces.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Sync controllers provide local snapshot mirroring for UI-only contexts or offline playback state management.
+
+## Overview
+
+The sync module exports two factory functions that create controllers for maintaining a local PlaybackSnapshot that stays in sync with the native runtime:
+
+- `createLegatoSync` — uses the full `Legato` facade
+- `createAudioPlayerSync` — uses only the `audioPlayer` surface
+
+Both return a `LegatoSyncController` with identical behavior.
+
+## Interfaces
+
+### `LegatoSyncOptions`
+
+Configuration options for sync controller creation.
+
+```ts
+interface LegatoSyncOptions {
+  /** Optional playback client override; defaults to the exported `Legato` facade. */
+  client?: AudioPlayerApi;
+  /** Optional callback invoked when local snapshot state changes. */
+  onSnapshot?: (snapshot: PlaybackSnapshot) => void;
+  /** Optional callback invoked for each received event payload. */
+  onEvent?: <E extends LegatoEventName>(eventName: E, payload: LegatoEventPayloadMap[E]) => void;
+}
+```
+
+### `AudioPlayerSyncOptions`
+
+Audio-player-specific options (extends `LegatoSyncOptions`).
+
+```ts
+interface AudioPlayerSyncOptions extends LegatoSyncOptions {
+  /** Optional playback client override constrained to the audio-player surface. */
+  client?: AudioPlayerApi;
+}
+```
+
+### `LegatoSyncController`
+
+Controller API for maintaining a local playback snapshot mirror.
+
+```ts
+interface LegatoSyncController {
+  /** Starts sync and returns initial snapshot. */
+  start(): Promise<PlaybackSnapshot>;
+  /** Resyncs from native state and returns updated snapshot. */
+  resync(): Promise<PlaybackSnapshot>;
+  /** Returns the current local snapshot, or null if sync not started. */
+  getCurrent(): PlaybackSnapshot | null;
+  /** Stops sync and removes all listeners. */
+  stop(): Promise<void>;
+}
+```
+
+## Factory functions
+
+### `createLegatoSync(options?)`
+
+Creates a sync controller using the full Legato facade.
+
+```ts
+import { createLegatoSync } from '@ddgutierrezc/legato-capacitor';
+
+const sync = createLegatoSync({
+  onSnapshot: (snapshot) => {
+    console.log('Update UI:', snapshot.state, snapshot.position);
+  },
+  onEvent: (eventName, payload) => {
+    console.log('Event:', eventName);
+  },
+});
+
+await sync.start();
+```
+
+### `createAudioPlayerSync(options?)`
+
+Creates a sync controller using only the audio-player surface.
+
+```ts
+import { createAudioPlayerSync } from '@ddgutierrezc/legato-capacitor';
+
+const sync = createAudioPlayerSync({
+  onSnapshot: (snapshot) => {
+    updateProgressBar(snapshot.position, snapshot.duration);
+  },
+});
+
+await sync.start();
+```
+
+## Usage patterns
+
+### Basic usage
+
+```ts
+const sync = createLegatoSync();
+
+const snapshot = await sync.start();
+// sync.getCurrent() now returns snapshot
+
+setInterval(() => {
+  const current = sync.getCurrent();
+  if (current) {
+    console.log(`Now playing: ${current.currentTrack?.title} at ${current.position}s`);
+  }
+}, 1000);
+
+// Stop sync when done
+await sync.stop();
+```
+
+### With manual resync
+
+```ts
+const sync = createLegatoSync();
+
+await sync.start();
+
+// Force resync (e.g., after app returns to foreground)
+document.addEventListener('visibilitychange', async () => {
+  if (document.visibilityState === 'visible') {
+    await sync.resync();
+  }
+});
+```
+
+<Aside type="note">
+The sync controller attaches listeners for all `AUDIO_PLAYER_EVENTS` when `start()` is called. Call `stop()` to clean up listeners when the controller is no longer needed, especially in component unmount handlers.
+</Aside>
+
+### Event handling via sync
+
+The sync controller processes these events to update the local snapshot:
+
+| Event | Snapshot update |
+|-------|------------------|
+| `playback-state-changed` | Updates `state` field |
+| `playback-active-track-changed` | Updates `currentTrack`, `currentIndex`, `duration`, and queue `currentIndex` |
+| `playback-queue-changed` | Replaces entire `queue` |
+| `playback-progress` | Updates `position`, `duration`, `bufferedPosition` |
+| `playback-ended` | Replaces snapshot with terminal snapshot |
+| `playback-error`, remote events | No snapshot update (event delivered via `onEvent` callback only) |
+
+## Related pages
+
+- [Audio Player API](audio-player.mdx) — for `getSnapshot()` source
+- [Events Reference](events.mdx) — for event payload types
+- [How-to: Use Sync](./../how-to/use-sync.mdx) — task-oriented guide

--- a/apps/docs-site/src/content/docs/packages/capacitor/reference/sync.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/reference/sync.mdx
@@ -153,6 +153,6 @@ The sync controller processes these events to update the local snapshot:
 
 ## Related pages
 
-- [Audio Player API](audio-player.mdx) — for `getSnapshot()` source
-- [Events Reference](events.mdx) — for event payload types
-- [How-to: Use Sync](./../how-to/use-sync.mdx) — task-oriented guide
+- [Audio Player API](audio-player/) — for `getSnapshot()` source
+- [Events Reference](events/) — for event payload types
+- [How-to: Use Sync](./../how-to/use-sync/) — task-oriented guide


### PR DESCRIPTION
## Summary

- Expand `legato-capacitor` docs from a shallow overview into a full API reference and practical integration guides.
- Document the real exported playback, media-session, event, sync, snapshot, capability, and `Legato` facade surfaces so integrators can use the package without guessing.
- Keep the docs aligned with the code contract and Diátaxis navigation in `apps/docs-site`.

## Linked issue

Resolves #125

## Validation

- [x] Relevant tests/checks were run
- [x] No unrelated workflows were changed

## Policy checks

- [x] Exactly one `type:*` label added
- [x] Approved issue linked when required (`status:approved`)
