### PR TITLE
docs(contract): complete core reference coverage

### DIFF
--- a/apps/docs-site/src/content/docs/packages/contract/reference/binding-adapter.mdx
+++ b/apps/docs-site/src/content/docs/packages/contract/reference/binding-adapter.mdx
@@ -1,0 +1,56 @@
+---
+title: Binding Adapter
+description: Reference for BindingAdapter and related adapter boundary types in @ddgutierrezc/legato-contract.
+---
+
+`BindingAdapter` defines the runtime-facing contract implemented by host bindings.
+
+## Core adapter surface
+
+```ts
+interface BindingAdapter {
+  setup(): Promise<void>;
+  add(options: AddOptions): Promise<PlaybackSnapshot>;
+  remove(options: RemoveOptions): Promise<PlaybackSnapshot>;
+  reset(): Promise<PlaybackSnapshot>;
+  play(): Promise<void>;
+  pause(): Promise<void>;
+  stop(): Promise<void>;
+  seekTo(options: SeekToOptions): Promise<void>;
+  skipTo(options: SkipToOptions): Promise<PlaybackSnapshot>;
+  skipToNext(): Promise<void>;
+  skipToPrevious(): Promise<void>;
+  getState(): Promise<PlaybackState>;
+  getPosition(): Promise<number>;
+  getDuration(): Promise<number | null>;
+  getCurrentTrack(): Promise<Track | null>;
+  getQueue(): Promise<QueueSnapshot>;
+  getSnapshot(): Promise<PlaybackSnapshot>;
+  getCapabilities(): Promise<BindingCapabilitiesSnapshot>;
+  addListener<E extends LegatoEventName>(
+    eventName: E,
+    listener: (payload: LegatoEventPayloadMap[E]) => void,
+  ): Promise<BindingListenerHandle>;
+  removeAllListeners(): Promise<void>;
+}
+```
+
+## Related exported types
+
+- `BindingListenerHandle`: listener registration handle with `remove(): Promise<void> | void`.
+- `BindingCapabilitiesSnapshot`: `{ supported: Capability[] }` runtime capability snapshot.
+- `BindingAdapterError`: `LegatoError` plus optional `source?: string` metadata.
+- `AddOptions`: `{ tracks: Track[]; startIndex?: number }`.
+- `RemoveOptions`: `{ id?: string; index?: number }`.
+- `SeekToOptions`: `{ position: number }`.
+- `SkipToOptions`: `{ index: number }`.
+
+## Contract role
+
+`BindingAdapter` is the transport boundary between runtime implementations and contract consumers. Adapters project state, queue, events, capabilities, and operation results through this interface.
+
+## Related pages
+
+- [Capabilities](../capabilities/)
+- [Events](../events/)
+- [Snapshots](../snapshots/)

--- a/apps/docs-site/src/content/docs/packages/contract/reference/capabilities.mdx
+++ b/apps/docs-site/src/content/docs/packages/contract/reference/capabilities.mdx
@@ -1,0 +1,39 @@
+---
+title: Capabilities
+description: Reference for CAPABILITIES and Capability in @ddgutierrezc/legato-contract.
+---
+
+This page documents runtime capability literals projected through the adapter boundary.
+
+## `CAPABILITIES`
+
+`Capability` is derived from `CAPABILITIES`:
+
+```ts
+const CAPABILITIES = [
+  'play',
+  'pause',
+  'stop',
+  'seek',
+  'skip-next',
+  'skip-previous',
+] as const;
+
+type Capability = (typeof CAPABILITIES)[number];
+```
+
+## Capability meanings
+
+- `play`: start or resume playback.
+- `pause`: pause active playback.
+- `stop`: stop playback.
+- `seek`: move playback to a target position.
+- `skip-next`: move to the next queue item.
+- `skip-previous`: move to the previous queue item.
+
+`CAPABILITIES` are runtime projections at the moment they are reported. They are not permanent guarantees across the full session and can change with queue, track, transport, or platform conditions.
+
+## Related pages
+
+- [Binding Adapter](../binding-adapter/)
+- [Snapshots](../snapshots/)

--- a/apps/docs-site/src/content/docs/packages/contract/reference/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/contract/reference/index.mdx
@@ -12,9 +12,13 @@ Use this section as the source of truth for transport-neutral types, event names
 | Page | Description |
 |------|-------------|
 | **[Track](track/)** | `Track` and `TrackType`, including per-track `headers` scope. |
+| **[Playback State](playback-state/)** | `PLAYBACK_STATES` and `PlaybackState` canonical runtime states. |
 | **[Snapshots](snapshots/)** | `PlaybackSnapshot` and `QueueSnapshot` projections. |
+| **[Capabilities](capabilities/)** | `CAPABILITIES` and `Capability` runtime capability projections. |
 | **[Events](events/)** | Canonical event-name tuples and payload maps for player and remote events. |
 | **[Errors](errors/)** | `LegatoError`, `LegatoErrorCode`, and `LEGATO_ERROR_CODES`. |
+| **[Invariants](invariants/)** | `POSITION_MIN` and `LEGATO_INVARIANTS` shared expectations. |
+| **[Binding Adapter](binding-adapter/)** | `BindingAdapter` runtime boundary and related option/snapshot types. |
 
 ## Related pages
 

--- a/apps/docs-site/src/content/docs/packages/contract/reference/invariants.mdx
+++ b/apps/docs-site/src/content/docs/packages/contract/reference/invariants.mdx
@@ -1,0 +1,42 @@
+---
+title: Invariants
+description: Reference for POSITION_MIN and LEGATO_INVARIANTS in @ddgutierrezc/legato-contract.
+---
+
+This page documents invariant-related exports used as shared contract expectations.
+
+## `POSITION_MIN`
+
+```ts
+const POSITION_MIN = 0;
+```
+
+`POSITION_MIN` defines the minimum allowed playback position value.
+
+## `LEGATO_INVARIANTS`
+
+```ts
+const LEGATO_INVARIANTS = {
+  TRACK_ID_MUST_BE_NON_EMPTY: 'track.id must be a non-empty string',
+  TRACK_URL_MUST_BE_NON_EMPTY: 'track.url must be a non-empty string',
+  QUEUE_CURRENT_INDEX_IN_BOUNDS:
+    'queue.currentIndex must be null or within [0, queue.items.length - 1]',
+  POSITION_NON_NEGATIVE: 'snapshot.position must be >= 0',
+  OPTIONAL_NUMERIC_FIELDS_NON_NEGATIVE:
+    'snapshot.duration and snapshot.bufferedPosition, when present, must be >= 0',
+} as const;
+```
+
+## Contract rules for consumers and adapters
+
+- Track items must provide non-empty `id` and `url` strings.
+- `queue.currentIndex` must be `null` or point to a valid index within `queue.items`.
+- `snapshot.position` must be greater than or equal to `0`.
+- `snapshot.duration` and `snapshot.bufferedPosition`, when present, must be greater than or equal to `0`.
+
+These exports document shared expectations. They do not introduce additional runtime validation APIs by themselves.
+
+## Related pages
+
+- [Track](../track/)
+- [Snapshots](../snapshots/)

--- a/apps/docs-site/src/content/docs/packages/contract/reference/playback-state.mdx
+++ b/apps/docs-site/src/content/docs/packages/contract/reference/playback-state.mdx
@@ -1,0 +1,43 @@
+---
+title: Playback State
+description: Reference for PLAYBACK_STATES and PlaybackState in @ddgutierrezc/legato-contract.
+---
+
+This page documents the canonical playback-state literals exported by the contract package.
+
+## `PLAYBACK_STATES`
+
+`PlaybackState` is derived from `PLAYBACK_STATES`:
+
+```ts
+const PLAYBACK_STATES = [
+  'idle',
+  'loading',
+  'ready',
+  'playing',
+  'paused',
+  'buffering',
+  'ended',
+  'error',
+] as const;
+
+type PlaybackState = (typeof PLAYBACK_STATES)[number];
+```
+
+## Observable state semantics
+
+- `idle`: no active playback work is currently in progress.
+- `loading`: the runtime is preparing media before stable playback.
+- `ready`: media is prepared and the runtime can transition to playback.
+- `playing`: playback is currently advancing.
+- `paused`: playback is intentionally halted and can resume.
+- `buffering`: playback flow is temporarily waiting for media data.
+- `ended`: the active item reached its playback end.
+- `error`: the runtime entered an error state for the current playback flow.
+
+These values define the observable contract vocabulary between adapters and consumers. The contract does not prescribe internal player implementation details for how a runtime reaches each state.
+
+## Related pages
+
+- [Snapshots](../snapshots/)
+- [Events](../events/)


### PR DESCRIPTION
## Summary

- Add the remaining core reference pages for `@ddgutierrezc/legato-contract`: playback state, capabilities, invariants, and binding adapter.
- Update the contract reference index so the full core reference surface is discoverable.
- Keep the content aligned with the shared contract source and public docs-site navigation.

## Linked issue

Resolves #129

## Validation

- [x] Relevant tests/checks were run
- [x] No unrelated workflows were changed

## Policy checks

- [x] Exactly one `type:*` label added
- [x] Approved issue linked when required (`status:approved`)
