### PR TITLE
docs(contract): add how-to guides and explanations

### DIFF
--- a/apps/docs-site/src/content/docs/packages/contract/explanation/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/contract/explanation/index.mdx
@@ -1,0 +1,19 @@
+---
+title: Explanation
+description: Conceptual model and architecture rationale for the Legato contract package.
+---
+
+Use this section to understand why the contract exists and how its read model is designed.
+
+## Conceptual pages
+
+| Page | Focus |
+|------|-------|
+| **[Why Contract-First](why-contract-first/)** | Why Legato separates shared contract semantics from runtime implementations. |
+| **[Snapshot Model](snapshot-model/)** | Why snapshots are the shared read model and how nullability communicates runtime uncertainty. |
+
+## Related pages
+
+- [Contract package overview](../)
+- [How-To Guides](../how-to/)
+- [API Reference](../reference/)

--- a/apps/docs-site/src/content/docs/packages/contract/explanation/snapshot-model.mdx
+++ b/apps/docs-site/src/content/docs/packages/contract/explanation/snapshot-model.mdx
@@ -1,0 +1,42 @@
+---
+title: Snapshot Model
+description: Why PlaybackSnapshot and QueueSnapshot form Legato's shared read model.
+---
+
+Snapshots are the shared read model because consumers need a consistent view of playback at any moment, independent of runtime implementation details.
+
+## Why snapshots are central
+
+A snapshot captures observable playback state as data, not behavior. This makes it portable across adapters, event streams, and UI layers.
+
+In Legato, the read model is split into:
+
+- `PlaybackSnapshot` for current playback projection,
+- `QueueSnapshot` for queue projection and active index.
+
+## `PlaybackSnapshot` and `QueueSnapshot` roles
+
+- `PlaybackSnapshot` carries state, active item pointers, timeline values, and the queue projection.
+- `QueueSnapshot` carries ordered `items` and nullable `currentIndex`.
+
+This pairing keeps timeline and queue concerns explicit while still allowing a single playback payload to include queue context.
+
+## Nullability as signal, not error
+
+The contract uses nullability and optionality to represent runtime uncertainty explicitly:
+
+- `duration: null` means unknown or live-like timeline semantics.
+- `currentTrack` and `currentIndex` are nullable when no active item exists.
+- `bufferedPosition` is optional and can be `null` when runtime data is unavailable.
+
+These states are intentional parts of the model. Consumers should treat them as valid contract values, not exceptional conditions.
+
+## Practical consequence for consumers
+
+Because snapshots encode uncertainty in the type shape, consumers can apply policy without guessing runtime internals. For example, UI can render unknown duration states directly, and queue views can handle `currentIndex: null` as "no active selection".
+
+## Related pages
+
+- [Snapshots reference](../../reference/snapshots/)
+- [Invariants reference](../../reference/invariants/)
+- [Model a Track](../../how-to/model-a-track/)

--- a/apps/docs-site/src/content/docs/packages/contract/explanation/why-contract-first.mdx
+++ b/apps/docs-site/src/content/docs/packages/contract/explanation/why-contract-first.mdx
@@ -1,0 +1,37 @@
+---
+title: Why Contract-First
+description: Why Legato keeps shared playback semantics separate from runtime implementations.
+---
+
+Legato uses a contract-first model so every integration speaks the same playback language before choosing a runtime.
+
+## Why separate contract from runtime
+
+`@ddgutierrezc/legato-contract` defines stable shared semantics (tracks, snapshots, events, errors, capabilities, invariants) without embedding transport behavior.
+
+This separation allows:
+
+- runtime implementations to evolve independently,
+- consumers to compile against typed guarantees without importing Capacitor-facing code,
+- and adapters/bindings to enforce a boundary where runtime specifics stay local.
+
+## How the boundary works
+
+- **Contract package**: portable types and constants (`Track`, `PlaybackSnapshot`, `LEGATO_EVENT_NAMES`, `LEGATO_INVARIANTS`, and related exports).
+- **Adapters/bindings**: runtime-facing implementations that satisfy contract expectations.
+- **Consumers**: app logic that reads snapshots, handles typed events, and applies policy decisions.
+
+The result is a shared vocabulary across all integration points, with runtime behavior plugged in behind that vocabulary.
+
+## What this improves
+
+- Stronger interoperability: multiple adapters can project data in the same shape.
+- Safer refactors: consumer code depends on a stable public contract, not runtime internals.
+- Cleaner testing boundaries: you can test contract-level consumers with plain TypeScript objects.
+
+## Related pages
+
+- [How-To Guides](../../how-to/)
+- [API Reference](../../reference/)
+- [Binding Adapter reference](../../reference/binding-adapter/)
+- [Consume Events and Payloads](../../how-to/consume-events-and-payloads/)

--- a/apps/docs-site/src/content/docs/packages/contract/how-to/consume-events-and-payloads.mdx
+++ b/apps/docs-site/src/content/docs/packages/contract/how-to/consume-events-and-payloads.mdx
@@ -1,0 +1,80 @@
+---
+title: Consume Events and Payloads
+description: Use Legato event constants and payload typing for transport-neutral event handling.
+---
+
+This guide shows a transport-neutral pattern for consuming contract events with type-safe payload narrowing.
+
+## 1) Import canonical event exports
+
+```ts
+import {
+  LEGATO_EVENT_NAMES,
+  type LegatoEventName,
+  type LegatoEventPayload,
+} from '@ddgutierrezc/legato-contract';
+```
+
+`LEGATO_EVENT_NAMES` is the canonical tuple of supported names. `LegatoEventName` and `LegatoEventPayload<E>` provide typed event and payload coupling.
+
+## 2) Build a typed event handler
+
+Use a generic handler so payload type follows the event name.
+
+```ts
+function onLegatoEvent<E extends LegatoEventName>(
+  name: E,
+  payload: LegatoEventPayload<E>,
+) {
+  switch (name) {
+    case 'playback-state-changed': {
+      payload.state;
+      break;
+    }
+    case 'playback-active-track-changed': {
+      payload.track;
+      payload.index;
+      break;
+    }
+    case 'playback-progress': {
+      payload.position;
+      payload.duration;
+      payload.bufferedPosition;
+      break;
+    }
+    case 'playback-error': {
+      payload.error.code;
+      payload.error.message;
+      break;
+    }
+    case 'remote-seek': {
+      payload.position;
+      break;
+    }
+    default: {
+      break;
+    }
+  }
+}
+```
+
+## 3) Validate names before dispatching
+
+If you receive dynamic event names, validate against the exported tuple before invoking typed logic.
+
+```ts
+function isLegatoEventName(value: string): value is LegatoEventName {
+  return (LEGATO_EVENT_NAMES as readonly string[]).includes(value);
+}
+```
+
+This pattern does not depend on Capacitor APIs; it uses only contract exports.
+
+## Expected result
+
+You can consume all Legato event names with payload types that narrow automatically by event name, while keeping your event pipeline transport-neutral.
+
+## Related pages
+
+- [Events reference](../../reference/events/)
+- [Snapshots reference](../../reference/snapshots/)

--- a/apps/docs-site/src/content/docs/packages/contract/how-to/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/contract/how-to/index.mdx
@@ -1,0 +1,20 @@
+---
+title: How-To Guides
+description: Task-oriented guides for users who already know the contract basics.
+---
+
+Use these guides when you already understand the core `@ddgutierrezc/legato-contract` reference surface and need practical implementation patterns.
+
+## Guides
+
+| Guide | When to use it |
+|------|-----------------|
+| **[Model a Track](model-a-track/)** | You need to construct valid `Track` objects, including optional metadata and transport headers. |
+| **[Consume Events and Payloads](consume-events-and-payloads/)** | You want strongly typed event handling with `LEGATO_EVENT_NAMES`, `LegatoEventName`, and `LegatoEventPayload`. |
+| **[Validate Runtime Invariants](validate-runtime-invariants/)** | You need defensive consumer-side validation based on exported contract constants. |
+
+## Related pages
+
+- [Contract package overview](../)
+- [API Reference](../reference/)
+- [Explanation](../explanation/)

--- a/apps/docs-site/src/content/docs/packages/contract/how-to/model-a-track.mdx
+++ b/apps/docs-site/src/content/docs/packages/contract/how-to/model-a-track.mdx
@@ -1,0 +1,72 @@
+---
+title: Model a Track
+description: Build a valid Track payload with required fields, optional metadata, type, and headers.
+---
+
+This guide shows how to model a `Track` object that matches the shared contract.
+
+## 1) Start with required fields
+
+`Track` requires only `id` and `url`.
+
+```ts
+import type { Track } from '@ddgutierrezc/legato-contract';
+
+const minimalTrack: Track = {
+  id: 'episode-001',
+  url: 'https://cdn.example.com/audio/episode-001.mp3',
+};
+```
+
+## 2) Add optional display metadata
+
+Add metadata only when your product surface needs it.
+
+```ts
+const withMetadata: Track = {
+  id: 'episode-001',
+  url: 'https://cdn.example.com/audio/episode-001.mp3',
+  title: 'Episode 1',
+  artist: 'Legato Team',
+  album: 'Release Notes',
+  artwork: 'https://cdn.example.com/artwork/episode-001.jpg',
+  duration: 1840,
+};
+```
+
+## 3) Declare media semantics with `type`
+
+When known, set `type` to one of the supported literals exported by the contract (`file`, `progressive`, `hls`, `dash`).
+
+```ts
+const typedTrack: Track = {
+  id: 'episode-001',
+  url: 'https://cdn.example.com/audio/episode-001.mp3',
+  type: 'progressive',
+};
+```
+
+## 4) Add per-track transport headers when needed
+
+Use `headers` for static per-track HTTP request headers.
+
+```ts
+const protectedTrack: Track = {
+  id: 'episode-001',
+  url: 'https://cdn.example.com/audio/episode-001.mp3',
+  type: 'progressive',
+  headers: {
+    Authorization: 'Bearer demo-token',
+    'X-Client-Version': '1.0.0',
+  },
+};
+```
+
+## Expected result
+
+You can now construct `Track` values that satisfy the contract using required fields first, then optional metadata, `type`, and `headers` as consumer needs evolve.
+
+## Related pages
+
+- [Track reference](../../reference/track/)
+- [Validate Runtime Invariants](../validate-runtime-invariants/)

--- a/apps/docs-site/src/content/docs/packages/contract/how-to/validate-runtime-invariants.mdx
+++ b/apps/docs-site/src/content/docs/packages/contract/how-to/validate-runtime-invariants.mdx
@@ -1,0 +1,76 @@
+---
+title: Validate Runtime Invariants
+description: Apply defensive consumer-side checks from POSITION_MIN and LEGATO_INVARIANTS.
+---
+
+This guide shows how to build manual defensive checks using only invariant constants exported by the contract.
+
+## 1) Import invariant constants
+
+```ts
+import {
+  LEGATO_INVARIANTS,
+  POSITION_MIN,
+  type PlaybackSnapshot,
+} from '@ddgutierrezc/legato-contract';
+```
+
+`@ddgutierrezc/legato-contract` does not export a runtime validator helper. The checks below are consumer-side usage built from exported constants.
+
+## 2) Validate a snapshot manually
+
+```ts
+function validateSnapshot(snapshot: PlaybackSnapshot): string[] {
+  const violations: string[] = [];
+
+  if (snapshot.position < POSITION_MIN) {
+    violations.push(LEGATO_INVARIANTS.POSITION_NON_NEGATIVE);
+  }
+
+  if (snapshot.duration !== null && snapshot.duration < POSITION_MIN) {
+    violations.push(LEGATO_INVARIANTS.OPTIONAL_NUMERIC_FIELDS_NON_NEGATIVE);
+  }
+
+  if (
+    snapshot.bufferedPosition !== undefined &&
+    snapshot.bufferedPosition !== null &&
+    snapshot.bufferedPosition < POSITION_MIN
+  ) {
+    violations.push(LEGATO_INVARIANTS.OPTIONAL_NUMERIC_FIELDS_NON_NEGATIVE);
+  }
+
+  const { items, currentIndex } = snapshot.queue;
+  const inBounds = currentIndex === null || (currentIndex >= 0 && currentIndex < items.length);
+  if (!inBounds) {
+    violations.push(LEGATO_INVARIANTS.QUEUE_CURRENT_INDEX_IN_BOUNDS);
+  }
+
+  if (snapshot.currentTrack) {
+    if (snapshot.currentTrack.id.trim().length === 0) {
+      violations.push(LEGATO_INVARIANTS.TRACK_ID_MUST_BE_NON_EMPTY);
+    }
+    if (snapshot.currentTrack.url.trim().length === 0) {
+      violations.push(LEGATO_INVARIANTS.TRACK_URL_MUST_BE_NON_EMPTY);
+    }
+  }
+
+  return violations;
+}
+```
+
+## 3) Decide how to react
+
+Use the returned invariant messages to decide your strategy:
+
+- reject incoming data,
+- log and continue with fallback state,
+- or route diagnostics to your observability pipeline.
+
+## Expected result
+
+You have a transport-neutral defensive validation layer that reuses contract constants as canonical invariant messages without depending on unexported runtime helpers.
+
+## Related pages
+
+- [Invariants reference](../../reference/invariants/)
+- [Snapshots reference](../../reference/snapshots/)

--- a/apps/docs-site/src/content/docs/packages/contract/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/contract/index.mdx
@@ -37,6 +37,8 @@ Use `@ddgutierrezc/legato-contract` when you need shared contract primitives wit
 ## Learn by path
 
 - Start with [First contract integration](/tutorials/first-contract-integration/) for onboarding without Capacitor runtime dependencies.
+- Use [How-To Guides](how-to/) for task-oriented implementation patterns.
+- Read [Explanation](explanation/) for contract architecture and snapshot model rationale.
 - Continue with the [Contract reference](reference/) for core type and event semantics.
 
 ## Public export contract


### PR DESCRIPTION
## Summary

- Add task-oriented how-to guides for `@ddgutierrezc/legato-contract`.
- Add explanation pages for the contract-first architecture and snapshot model.
- Update the contract package overview to surface the new guidance sections.

## Linked issue

Resolves #131

## Validation

- [x] Relevant tests/checks were run
- [x] No unrelated workflows were changed

## Policy checks

- [x] Exactly one `type:*` label added
- [x] Approved issue linked when required (`status:approved`)
