### PR TITLE
docs(capacitor): expand advanced integration docs

### DIFF
--- a/apps/docs-site/src/content/docs/packages/capacitor/explanation/capability-projection.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/explanation/capability-projection.mdx
@@ -1,0 +1,45 @@
+---
+title: Capability Projection
+description: Why capability availability is dynamic and projected at runtime in legato-capacitor.
+---
+
+Capabilities in Legato are not static feature flags. They are runtime projections of what operations are currently supported.
+
+## Contract literal vs runtime availability
+
+`Capability` is a shared contract union (`'play'`, `'pause'`, `'stop'`, `'seek'`, `'skip-next'`, `'skip-previous'`). It defines the allowed vocabulary.
+
+`getCapabilities()` returns the current runtime projection:
+
+- `Capability` answers: "Which capability names exist in the model?"
+- `getCapabilities().supported` answers: "Which of those are supported now?"
+
+This distinction matters because support can vary with runtime state and media context.
+
+## Why `seek` must be treated as projected
+
+The contract explicitly documents `seek` as projector-owned runtime semantics, not queue-only inference.
+
+Also, `PlaybackSnapshot.duration` explicitly says that a finite duration is evidence of media length, not a seekability guarantee by itself.
+
+That means:
+
+- finite `duration` does not imply `seek`,
+- and `seek` should be enabled only when `supported.includes('seek')` is true.
+
+## Relationship with track type and state
+
+The Capacitor and contract docs do not expose a deterministic mapping from track fields or playback states to capability outcomes.
+
+What is explicitly guaranteed:
+
+- capabilities are read from `getCapabilities()` at runtime,
+- `remote-seek` is emitted only when projected seek capability is enabled.
+
+So integrations should consume the projection directly instead of deriving capability support from inferred media traits.
+
+## Related pages
+
+- [Build Capability-Driven Controls](../how-to/capability-driven-controls/)
+- [Snapshots](../reference/snapshots/)
+- [Events Reference](../reference/events/)

--- a/apps/docs-site/src/content/docs/packages/capacitor/explanation/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/explanation/index.mdx
@@ -1,0 +1,19 @@
+---
+title: Explanation
+description: Conceptual guidance for reasoning about legato-capacitor runtime behavior.
+---
+
+Use this section to understand how to think about the Capacitor integration model before implementing controls or event wiring.
+
+## Conceptual pages
+
+| Page | Focus |
+|------|-------|
+| **[Capability Projection](./capability-projection/)** | Why capability availability is runtime-projected and must be read dynamically. |
+| **[Snapshot Semantics](./snapshot-semantics/)** | How to interpret `PlaybackSnapshot` and `QueueSnapshot` values without over-assuming runtime behavior. |
+
+## Related pages
+
+- [Capacitor package overview](../)
+- [How-To Guides](../how-to/)
+- [API Reference](../reference/)

--- a/apps/docs-site/src/content/docs/packages/capacitor/explanation/snapshot-semantics.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/explanation/snapshot-semantics.mdx
@@ -1,0 +1,42 @@
+---
+title: Snapshot Semantics
+description: How to interpret PlaybackSnapshot and QueueSnapshot values in Capacitor integrations.
+---
+
+Snapshots are a read model, not a promise about what operations are currently allowed.
+
+## Read snapshots as observable state
+
+`PlaybackSnapshot` and `QueueSnapshot` encode what the runtime is reporting at a point in time. They are intentionally typed to include uncertainty.
+
+Key signals in the model:
+
+- `currentTrack: null` and `currentIndex: null` are valid "no active item" states,
+- `duration: null` is valid for unknown or live-like timelines,
+- `bufferedPosition` is optional and can be `null` when runtime data is unavailable.
+
+These values are part of normal semantics, not exceptional conditions.
+
+## `duration` is timeline evidence, not seek permission
+
+A finite `duration` means the runtime reported a finite media length. It does not grant seek behavior by itself.
+
+Seek should still be decided from projected capabilities (`getCapabilities().supported`), not from timeline values alone.
+
+## Snapshot and event relationship
+
+Events and snapshots are complementary read channels:
+
+- snapshot-returning APIs (`getSnapshot()`, `add()`, `remove()`, `reset()`, `skipTo()`) give explicit point-in-time projections,
+- `playback-ended` carries a terminal `PlaybackSnapshot`,
+- `playback-queue-changed` carries a `QueueSnapshot`,
+- `playback-progress` carries timeline fields (`position`, `duration`, `bufferedPosition`) without the full snapshot object.
+
+Use each payload according to its shape instead of assuming every event has full snapshot context.
+
+## Related pages
+
+- [Snapshots](../reference/snapshots/)
+- [Events Reference](../reference/events/)
+- [Listen to Events](../how-to/listen-events/)
+- [Build Capability-Driven Controls](../how-to/capability-driven-controls/)

--- a/apps/docs-site/src/content/docs/packages/capacitor/how-to/capability-driven-controls.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/how-to/capability-driven-controls.mdx
@@ -1,0 +1,76 @@
+---
+title: Build Capability-Driven Controls
+description: Adapt playback controls at runtime using getCapabilities() instead of static assumptions.
+---
+
+Use this guide to render or disable playback controls based on runtime capabilities.
+
+## 1) Read capabilities after setup
+
+```ts
+import { audioPlayer } from '@ddgutierrezc/legato-capacitor';
+
+await audioPlayer.setup();
+
+const caps = await audioPlayer.getCapabilities();
+const supported = new Set(caps.supported);
+```
+
+## 2) Drive control state from `supported`
+
+```ts
+const controls = {
+  canPlay: supported.has('play'),
+  canPause: supported.has('pause'),
+  canStop: supported.has('stop'),
+  canSeek: supported.has('seek'),
+  canNext: supported.has('skip-next'),
+  canPrevious: supported.has('skip-previous'),
+};
+
+renderControls(controls);
+```
+
+## 3) Refresh capabilities when runtime context changes
+
+Capabilities are runtime projections, so recalculate after queue/track transitions.
+
+```ts
+const handle = await audioPlayer.addListener('playback-active-track-changed', async () => {
+  const next = await audioPlayer.getCapabilities();
+  renderControls({
+    canPlay: next.supported.includes('play'),
+    canPause: next.supported.includes('pause'),
+    canStop: next.supported.includes('stop'),
+    canSeek: next.supported.includes('seek'),
+    canNext: next.supported.includes('skip-next'),
+    canPrevious: next.supported.includes('skip-previous'),
+  });
+});
+
+// later
+await handle.remove();
+```
+
+## 4) Do not infer `seek` from `duration`
+
+A finite `duration` does not guarantee `seek` support. The contract models seekability as a runtime capability projection, not a direct consequence of duration presence.
+
+Use this rule in UI logic:
+
+```ts
+const duration = await audioPlayer.getDuration();
+const capsNow = await audioPlayer.getCapabilities();
+
+const showSeekBar = duration !== null && capsNow.supported.includes('seek');
+```
+
+## Expected result
+
+Your UI enables only controls listed in `getCapabilities().supported`, updates those controls after active-track changes, and treats `duration` as informational rather than automatic seek permission.
+
+## Related pages
+
+- [Reference: Audio Player](../reference/audio-player/)
+- [Reference: Snapshots](../reference/snapshots/)
+- [Contract capabilities reference](../../contract/reference/capabilities/)

--- a/apps/docs-site/src/content/docs/packages/capacitor/how-to/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/how-to/index.mdx
@@ -24,4 +24,12 @@ This section provides step-by-step guides for the most common integration tasks.
     **[Use Sync Controllers](./use-sync/)**
     Create and use sync controllers for local snapshot mirroring.
   </Card>
+  <Card title="Capability-Driven Controls" icon="adjustments-horizontal">
+    **[Build Capability-Driven Controls](./capability-driven-controls/)**
+    Adapt seek/skip/playback controls using `getCapabilities()` at runtime.
+  </Card>
+  <Card title="Secure Track Headers" icon="lock">
+    **[Send Secure Track Headers](./secure-track-headers/)**
+    Configure static per-track HTTP headers for protected media URLs.
+  </Card>
 </CardGrid>

--- a/apps/docs-site/src/content/docs/packages/capacitor/how-to/secure-track-headers.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/how-to/secure-track-headers.mdx
@@ -1,0 +1,76 @@
+---
+title: Send Secure Track Headers
+description: Use Track.headers for static per-track HTTP headers in protected media integrations.
+---
+
+Use this guide when your media URLs require static request headers (for example, bearer tokens or client identifiers).
+
+## 1) Model each protected track with `headers`
+
+`Track` is re-exported by `@ddgutierrezc/legato-capacitor` from the contract package, including the `headers` field.
+
+```ts
+import type { Track } from '@ddgutierrezc/legato-capacitor';
+
+const tracks: Track[] = [
+  {
+    id: 'episode-42',
+    url: 'https://media.example.com/audio/episode-42.mp3',
+    type: 'progressive',
+    headers: {
+      Authorization: 'Bearer <static-token>',
+      'X-Client-Version': '1.0.0',
+    },
+  },
+];
+```
+
+## 2) Add tracks normally
+
+```ts
+import { audioPlayer } from '@ddgutierrezc/legato-capacitor';
+
+await audioPlayer.add({ tracks, startIndex: 0 });
+await audioPlayer.play();
+```
+
+## 3) Apply headers per track, not globally
+
+In v1 contract scope, headers are isolated per track and are not shared across queue transitions. If different items need different auth context, set `headers` on each item.
+
+```ts
+const queue: Track[] = [
+  {
+    id: 'a',
+    url: 'https://media.example.com/a.mp3',
+    headers: { Authorization: 'Bearer token-a' },
+  },
+  {
+    id: 'b',
+    url: 'https://media.example.com/b.mp3',
+    headers: { Authorization: 'Bearer token-b' },
+  },
+];
+```
+
+## v1 scope and non-goals
+
+Backed by contract comments, v1 guarantees and non-goals are:
+
+- Scope: headers are applied by Android/iOS runtime media requests for that track.
+- Scope: headers are isolated per track.
+- Non-goal: DRM/license request authentication flows.
+- Non-goal: token refresh/rotation or dynamic auth callbacks.
+- Non-goal: cookie/session renewal orchestration.
+
+If your integration requires dynamic auth lifecycle management, implement that outside the current `Track.headers` contract and queue model.
+
+## Expected result
+
+Protected tracks can be queued and played with static per-track HTTP headers, while your integration keeps token refresh, DRM/license flows, and session renewal logic outside the v1 Legato track contract.
+
+## Related pages
+
+- [Contract track reference](../../contract/reference/track/)
+- [Contract how-to: Model a Track](../../contract/how-to/model-a-track/)
+- [How-to: Play a Track](./play-track/)

--- a/apps/docs-site/src/content/docs/packages/capacitor/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/index.mdx
@@ -60,6 +60,10 @@ This package is documented in three sections following Diátaxis methodology:
     **[`index.mdx`](./)**
     What the package provides and how to get started.
   </Card>
+  <Card title="Explanation" icon="lightbulb">
+    **[`explanation/`](./explanation/)**
+    Conceptual guidance for capabilities, snapshots, and runtime interpretation.
+  </Card>
   <Card title="Reference" icon="seti:api">
     **[`reference/`](./reference/)**
     Detailed API reference for every exported method, type, and event.
@@ -74,4 +78,4 @@ This package is documented in three sections following Diátaxis methodology:
 See the [Contract Package](../contract/) for shared types and event constants that both the Capacitor plugin and other Legato runtimes consume.
 </Aside>
 
-For practical integration steps, start with [Build Capability-Driven Controls](how-to/capability-driven-controls/) and [Send Secure Track Headers](how-to/secure-track-headers/), then use [Native CLI](reference/cli-native/) when working on repository-native setup checks.
+Start with [Capability Projection](explanation/capability-projection/) and [Snapshot Semantics](explanation/snapshot-semantics/) for the mental model, then apply it in [Build Capability-Driven Controls](how-to/capability-driven-controls/) and [Send Secure Track Headers](how-to/secure-track-headers/). Use [Native CLI](reference/cli-native/) when working on repository-native setup checks.

--- a/apps/docs-site/src/content/docs/packages/capacitor/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/index.mdx
@@ -15,6 +15,7 @@ A Capacitor plugin that exposes Legato playback APIs to web and hybrid JavaScrip
 - **Media session integration** — remote control from lock screen, notification center, and Bluetooth controls.
 - **Event subscriptions** — typed listeners for playback lifecycle and remote commands.
 - **Sync controllers** — local snapshot mirroring for offline or UI-only display contexts.
+- **Native maintainer CLI** — `legato native` doctor/configure commands for repo-owned Capacitor groundwork checks.
 
 ## Exposed namespaces
 
@@ -72,3 +73,5 @@ This package is documented in three sections following Diátaxis methodology:
 <Aside type="note">
 See the [Contract Package](../contract/) for shared types and event constants that both the Capacitor plugin and other Legato runtimes consume.
 </Aside>
+
+For practical integration steps, start with [Build Capability-Driven Controls](how-to/capability-driven-controls/) and [Send Secure Track Headers](how-to/secure-track-headers/), then use [Native CLI](reference/cli-native/) when working on repository-native setup checks.

--- a/apps/docs-site/src/content/docs/packages/capacitor/reference/cli-native.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/reference/cli-native.mdx
@@ -1,0 +1,96 @@
+---
+title: Native CLI
+description: Reference for the public `legato native` commands shipped by @ddgutierrezc/legato-capacitor.
+---
+
+This page documents the public `legato native` command group exposed by `@ddgutierrezc/legato-capacitor` through its package `bin` entry.
+
+## Command surface
+
+```bash
+legato native doctor [--json]
+legato native configure --dry-run [--json]
+legato native configure --apply [--json]
+```
+
+`native` is the only command group implemented by this CLI surface.
+
+## Repository scope
+
+This CLI resolves the repository root by walking up from the current working directory until both of these paths exist:
+
+- `packages/capacitor`
+- `apps/capacitor-demo`
+
+If that layout is not found, commands fail with exit code `1`.
+
+## `legato native doctor`
+
+Runs repository checks and reports findings for:
+
+- `apps/capacitor-demo/ios/App/App/Info.plist` (`UIBackgroundModes` includes `audio`)
+- `packages/capacitor/android/src/main/AndroidManifest.xml` (required foreground-service permissions and Legato playback service declaration)
+
+### Exit behavior
+
+- `0`: all findings are `ok`
+- `1`: at least one finding is `missing` or `misconfigured`
+
+### Output
+
+- Default output: human-readable report
+- `--json`: prints a JSON object with `command`, `repoRoot`, `findings`, and `exitCode`
+
+## `legato native configure --dry-run`
+
+Builds a change plan from the same checks used by `doctor`, but does not write files.
+
+### Exit behavior
+
+- `0`: always returns success when mode is valid
+- `1`: only for CLI misuse (for example, invalid mode selection)
+
+### Output
+
+- Default output: planned changes marked as `SAFE` or `SKIP`
+- `--json`: prints `command`, `repoRoot`, `findings`, `plannedChanges`, `exitCode`
+
+## `legato native configure --apply`
+
+Applies safe planned changes only.
+
+### What it can mutate
+
+Safe writes are restricted to this patch set:
+
+- `apps/capacitor-demo/ios/App/App/Info.plist`
+- `packages/capacitor/android/src/main/AndroidManifest.xml`
+
+### What it does not mutate
+
+- Paths outside the supported patch set
+- Paths marked as Capacitor-generated artifacts (for example, `ios/App/CapApp-SPM/**`)
+- Unsafe changes that require manual intervention
+
+### Exit behavior
+
+- `0`: no unsafe pending changes remain (including idempotent no-op skips)
+- `1`: one or more planned changes were skipped for safety/manual reasons
+
+### Output
+
+- Default output: plan plus applied/skipped counters
+- `--json`: prints `command`, `repoRoot`, `findings`, `applied`, `skipped`, `exitCode`
+
+## Flags and argument rules
+
+- `--json`: supported by `doctor`, `configure --dry-run`, and `configure --apply`
+- `configure` requires exactly one mode: `--dry-run` or `--apply`
+- Passing both mode flags, or neither, returns exit code `1`
+
+`legato` with no args, `--help`, unknown command groups, or unknown `native` subcommands prints usage and exits with `1`.
+
+## Related pages
+
+- [How-to: Set Up Legato Capacitor](../how-to/set-up/)
+- [Reference: Audio Player](./audio-player/)

--- a/apps/docs-site/src/content/docs/packages/capacitor/reference/errors.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/reference/errors.mdx
@@ -5,7 +5,7 @@ description: Complete reference for LegatoError interface and error codes.
 
 import { Aside } from '@astrojs/starlight/components';
 
-This page documents the `LegatoError` interface and error codes emitted by the Legato runtime.
+This page documents the `LegatoError` interface and the stable error-code literals used by the Legato boundary.
 
 ## LegatoError interface
 
@@ -45,20 +45,39 @@ import { LEGATO_ERROR_CODES } from '@ddgutierrezc/legato-contract';
 // ];
 ```
 
-### Error code reference
+### Error code matrix
 
-| Code | Description |
-|------|-------------|
-| `player_not_setup` | Playback APIs called before `audioPlayer.setup()`. |
-| `invalid_index` | Queue index out of bounds or invalid for current queue length. |
-| `empty_queue` | Playback attempted on empty queue. |
-| `no_active_track` | No active track selected in the queue. |
-| `invalid_url` | Track URL is malformed or unsupported. |
-| `load_failed` | Media failed to load (network error, unsupported format, etc.). |
-| `playback_failed` | Playback interrupted or failed during active playback. |
-| `seek_failed` | Seek operation failed (unsupported by track type or runtime). |
-| `unsupported_operation` | Operation not supported by current platform capabilities. |
-| `platform_error` | Platform-specific error (native layer failure). |
+| Code | Observable meaning | Notes / source |
+|------|---------------------|----------------|
+| `player_not_setup` | A player operation was rejected because setup preconditions were not met. | Stable literal in `LEGATO_ERROR_CODES` (`packages/contract/src/errors.ts`). |
+| `invalid_index` | An index-based operation was rejected. | Stable literal in `LEGATO_ERROR_CODES` (`packages/contract/src/errors.ts`). |
+| `empty_queue` | An operation required queue items, but queue preconditions were not met. | Stable literal in `LEGATO_ERROR_CODES` (`packages/contract/src/errors.ts`). |
+| `no_active_track` | An operation required an active track, but none was active. | Stable literal in `LEGATO_ERROR_CODES` (`packages/contract/src/errors.ts`). |
+| `invalid_url` | A media URL input was rejected. | Stable literal in `LEGATO_ERROR_CODES` (`packages/contract/src/errors.ts`). |
+| `load_failed` | A media load phase failed. | Stable literal in `LEGATO_ERROR_CODES` (`packages/contract/src/errors.ts`). |
+| `playback_failed` | Playback execution failed after or during start. | Stable literal in `LEGATO_ERROR_CODES` (`packages/contract/src/errors.ts`). |
+| `seek_failed` | A seek request failed. | Stable literal in `LEGATO_ERROR_CODES` (`packages/contract/src/errors.ts`). |
+| `unsupported_operation` | The requested operation is not supported by the runtime in current conditions. | Stable literal in `LEGATO_ERROR_CODES` (`packages/contract/src/errors.ts`). |
+| `platform_error` | A platform/native-layer error was surfaced through the boundary. | Stable literal in `LEGATO_ERROR_CODES` (`packages/contract/src/errors.ts`). |
+
+## Stability model
+
+- Treat `error.code` as the machine-stable discriminator.
+- Treat `error.message` as human-readable runtime text that may vary by adapter, platform, or native source.
+- Treat `error.details` as optional transport-specific payload (`unknown` by contract).
+
+```ts
+function classify(error: LegatoError) {
+  switch (error.code) {
+    case 'unsupported_operation':
+      return 'capability-gated';
+    case 'invalid_index':
+      return 'input-shape';
+    default:
+      return 'other';
+  }
+}
+```
 
 ## Handling errors
 
@@ -90,11 +109,11 @@ try {
 ```
 
 <Aside type="note">
-Not all methods throw `LegatoError`. Check individual method documentation for error behavior.
+Do not couple control flow to exact `message` strings. Prefer `code` for branching and use `message` for logs/diagnostics.
 </Aside>
 
 ## Related types
 
-- `PlaybackState` — can be `'error'` when a playback error occurs
-- `PlaybackSnapshot` — may contain error state information
-- `LEGATO_EVENTS` — includes `playback-error` for event-driven error handling
+- [Events Reference](../events/) — `playback-error` payload shape and listener helpers
+- [Audio Player API](../audio-player/) — operations that can surface boundary errors
+- [Contract error codes](../../contract/reference/errors/) — shared source for `LEGATO_ERROR_CODES`

--- a/apps/docs-site/src/content/docs/packages/capacitor/reference/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/reference/index.mdx
@@ -16,6 +16,7 @@ This section provides complete API documentation for all exported members of `@d
 | **[Events](events/)** | Event-name constants, payload types, and shortcut listener helpers. |
 | **[Errors](errors/)** | `LegatoError` interface and error code constants. |
 | **[Sync](sync/)** | Sync controller factories for local snapshot mirroring. |
+| **[Native CLI](cli-native/)** | Public `legato native` commands for doctor and safe native configure flows. |
 
 ## Quick reference
 

--- a/apps/docs-site/src/content/docs/packages/capacitor/reference/snapshots.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/reference/snapshots.mdx
@@ -7,6 +7,13 @@ import { Aside } from '@astrojs/starlight/components';
 
 Snapshots are immutable read-model projections returned by query methods and events. They represent a point-in-time view of the playback runtime state.
 
+## Interpretation notes
+
+- `duration` communicates timeline information, not operation permissions.
+- `bufferedPosition` may be absent (`undefined`) or present as `null`; both are valid runtime outcomes.
+- `currentTrack: null` and `currentIndex: null` are valid states when no active item exists.
+- Capability decisions (for example seek UI enablement) should come from `getCapabilities().supported`.
+
 ## PlaybackSnapshot
 
 Returned by `getSnapshot()`, and by mutating methods that change playback state (`add()`, `remove()`, `reset()`, `skipTo()`). Also appears in the `playback-ended` event payload.
@@ -124,6 +131,15 @@ type Capability = (typeof CAPABILITIES)[number];
 Capability projection is runtime-dependent. For example, `seek` may only be reported when the current track type and playback state allow it. Always check `getCapabilities()` at runtime rather than hardcoding assumptions.
 </Aside>
 
+## Common anti-patterns
+
+| Anti-pattern | Why it is wrong | Contract-aligned interpretation |
+|-------------|------------------|---------------------------------|
+| "Finite `duration` means seek is always available" | `duration` only encodes timeline length evidence. | Gate seek controls by `supported.includes('seek')`. |
+| "Missing `bufferedPosition` means broken runtime" | `bufferedPosition` is optional and may be `null`. | Treat missing/`null` as "not currently reported". |
+| "`currentIndex` is always a number" | `currentIndex` is nullable in both `PlaybackSnapshot` and `QueueSnapshot`. | Handle `null` as "no active queue item". |
+| "Every playback event contains a full snapshot" | Event payloads are intentionally specialized by event name. | Use each event payload as defined (`playback-progress` is timeline-only, `playback-ended` includes `snapshot`). |
+
 ### Practical usage
 
 ```ts
@@ -167,3 +183,5 @@ PlaybackSnapshot
 - [Events Reference](events/) — events that carry snapshot payloads
 - [Legato Facade](legato/) — unified API surface that includes snapshot methods
 - [Sync Controllers](sync/) — local snapshot mirroring using these types
+- [Capability Projection](../explanation/capability-projection/) — conceptual model for runtime capability availability
+- [Snapshot Semantics](../explanation/snapshot-semantics/) — conceptual guidance for reading nullable snapshot fields


### PR DESCRIPTION
## Summary

- Add a public CLI reference for `legato native` commands shipped with `@ddgutierrezc/legato-capacitor`.
- Add task-oriented guides for capability-driven controls and secure per-track headers.
- Add explanation pages for capability projection and snapshot semantics, and deepen the Capacitor errors and snapshots references.

## Linked issue

Resolves #133
Resolves #135

## Validation

- [x] Relevant tests/checks were run
- [x] No unrelated workflows were changed

## Policy checks

- [x] Exactly one `type:*` label added
- [x] Approved issue linked when required (`status:approved`)
