### PR TITLE
docs(site): deepen entrypoints and mental models

### DIFF
--- a/apps/docs-site/src/content/docs/getting-started/index.mdx
+++ b/apps/docs-site/src/content/docs/getting-started/index.mdx
@@ -7,12 +7,58 @@ import { Card, CardGrid, Steps } from '@astrojs/starlight/components';
 
 Legato provides two public packages for continuous audio playback integrations.
 
+## Start with the problem, not the package
+
+Pick a package based on where your integration risk lives:
+
+- If your main risk is **shared semantics across app layers** (events, snapshots, track model, invariants), start with `@ddgutierrezc/legato-contract`.
+- If your main risk is **runtime integration with native playback surfaces** (commands, media session, listeners), use `@ddgutierrezc/legato-capacitor` and keep `@ddgutierrezc/legato-contract` as the shared model.
+
+Legato is intentionally layered: `legato-contract` gives the vocabulary, `legato-capacitor` gives a concrete runtime integration.
+
 ## Package decision matrix
 
-| If you need... | Install | Canonical guide |
+| If you need... | Install | Why this is the fit |
 |---|---|---|
-| Shared playback events and contract types (no Capacitor runtime) | `@ddgutierrezc/legato-contract` | `packages/contract` (coming in this docs site) |
-| Capacitor runtime plugin APIs (`audioPlayer`, `mediaSession`) | `@ddgutierrezc/legato-capacitor` + `@ddgutierrezc/legato-contract` | `packages/capacitor` (coming in this docs site) |
+| Shared playback events, snapshots, and invariants across multiple runtimes or app layers | `@ddgutierrezc/legato-contract` | You can stabilize app logic first without coupling it to Capacitor runtime APIs. |
+| Hybrid app playback with Capacitor runtime integration (`audioPlayer`, `mediaSession`) | `@ddgutierrezc/legato-capacitor` + `@ddgutierrezc/legato-contract` | You need runtime commands/listeners, while still reusing the same shared contract semantics. |
+
+## Decision aid
+
+Use this quick checklist:
+
+- Are you designing a playback domain model shared by frontend, services, or tests? Start with `@ddgutierrezc/legato-contract`.
+- Do you need native runtime control surfaces today (playback commands, media-session events)? Add `@ddgutierrezc/legato-capacitor`.
+- Do you expect to evolve from app-logic validation into native integration? Start contract-first, then add Capacitor when runtime concerns become real.
+
+## Typical scenarios and tradeoffs
+
+### Scenario A: Shared types first, runtime later
+
+You are aligning state, events, and queue semantics across teams before deciding runtime details.
+
+- **Good fit**: `@ddgutierrezc/legato-contract`
+- **Tradeoff**: you gain portability and testability, but runtime commands are out of scope until you add an adapter/plugin surface.
+
+### Scenario B: Hybrid app with immediate runtime needs
+
+You already need native playback control, media-session events, and runtime capability checks.
+
+- **Good fit**: `@ddgutierrezc/legato-capacitor` + `@ddgutierrezc/legato-contract`
+- **Tradeoff**: faster runtime integration, but you must treat capability support as runtime-projected (not static assumptions).
+
+### Scenario C: Contract-first growth path
+
+You can start by making your app logic consume contract snapshots/events, then plug in Capacitor without rewriting that logic.
+
+- **Benefit**: app policy remains written against stable contract shapes.
+- **Tradeoff**: you need a clear boundary where runtime specifics stay in adapter/plugin-facing code.
+
+## Anti-patterns when choosing
+
+- Picking `@ddgutierrezc/legato-capacitor` only because "we might need native later" while no runtime integration exists yet.
+- Treating `@ddgutierrezc/legato-contract` as a full runtime solution; it does not provide playback execution APIs.
+- Delaying contract modeling until after runtime wiring, then retrofitting app logic to shared types under time pressure.
 
 ## Install
 
@@ -39,6 +85,12 @@ Legato provides two public packages for continuous audio playback integrations.
 ## Next steps
 
 <CardGrid>
-  <Card title="Read core concepts" icon="puzzle">Understand public vs maintainer boundaries before diving deeper.</Card>
+  <Card title="Contract-first rationale" icon="puzzle">Read why Legato separates shared semantics from runtime implementation details.</Card>
+  <Card title="Snapshot mental model" icon="open-book">Understand how to interpret nullable and projected playback state before building UI.</Card>
+  <Card title="Capability projection" icon="lightbulb">Learn why runtime-supported controls must come from capability projections.</Card>
   <Card title="Join community channels" icon="star">Get contribution and support links in the Community section.</Card>
 </CardGrid>
+
+- [Why Contract-First](../packages/contract/explanation/why-contract-first/)
+- [Snapshot Model](../packages/contract/explanation/snapshot-model/)
+- [Capability Projection](../packages/capacitor/explanation/capability-projection/)

--- a/apps/docs-site/src/content/docs/packages/capacitor/explanation/capability-projection.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/explanation/capability-projection.mdx
@@ -16,6 +16,16 @@ Capabilities in Legato are not static feature flags. They are runtime projection
 
 This distinction matters because support can vary with runtime state and media context.
 
+`Capability` is the vocabulary. `getCapabilities()` is the current projection.
+
+## Capability as projection, not entitlement
+
+A capability name being valid in the contract does not mean it is always available in runtime.
+
+Product implication: UI should represent controls as conditional affordances that follow runtime projection, not as permanently enabled features.
+
+Operational implication: integrations should re-read capability projection when playback context changes, instead of assuming setup-time support remains valid.
+
 ## Why `seek` must be treated as projected
 
 The contract explicitly documents `seek` as projector-owned runtime semantics, not queue-only inference.
@@ -26,6 +36,8 @@ That means:
 
 - finite `duration` does not imply `seek`,
 - and `seek` should be enabled only when `supported.includes('seek')` is true.
+
+In short: timeline metadata and action permissions are related but distinct signals.
 
 ## Relationship with track type and state
 
@@ -38,8 +50,26 @@ What is explicitly guaranteed:
 
 So integrations should consume the projection directly instead of deriving capability support from inferred media traits.
 
+## Conceptual runtime-change scenarios
+
+Without assuming a public deterministic matrix, these are valid projection patterns:
+
+- A control is available for one active context and not available after a track/context transition.
+- A capability appears after runtime setup settles, then changes again when queue selection changes.
+- Two sessions with similar media metadata can still expose different projected support.
+
+Your integration logic should stay correct under all three by treating projection as authoritative each time it is read.
+
+## Anti-patterns
+
+- Enabling controls from `duration`, `state`, or queue shape alone.
+- Caching capabilities once at app boot and never refreshing.
+- Interpreting absence of `remote-seek` emissions as proof that seek is globally unsupported.
+- Using indirect heuristics (track fields, guessed platform rules) instead of `getCapabilities().supported`.
+
 ## Related pages
 
 - [Build Capability-Driven Controls](../how-to/capability-driven-controls/)
 - [Snapshots](../reference/snapshots/)
 - [Events Reference](../reference/events/)
+- [Contract snapshot model](../../contract/explanation/snapshot-model/)

--- a/apps/docs-site/src/content/docs/packages/contract/explanation/snapshot-model.mdx
+++ b/apps/docs-site/src/content/docs/packages/contract/explanation/snapshot-model.mdx
@@ -14,12 +14,26 @@ In Legato, the read model is split into:
 - `PlaybackSnapshot` for current playback projection,
 - `QueueSnapshot` for queue projection and active index.
 
+This is not accidental duplication. It is a boundary choice: playback timeline and queue topology evolve together, but they are not the same concern.
+
 ## `PlaybackSnapshot` and `QueueSnapshot` roles
 
 - `PlaybackSnapshot` carries state, active item pointers, timeline values, and the queue projection.
 - `QueueSnapshot` carries ordered `items` and nullable `currentIndex`.
 
 This pairing keeps timeline and queue concerns explicit while still allowing a single playback payload to include queue context.
+
+## Snapshot evolution as a sequence
+
+Think in projections over time, not in imperative commands:
+
+1. **No active item**: `currentTrack: null`, `currentIndex: null`, queue may be empty or preloaded.
+2. **Activation**: `currentTrack` becomes non-null, `currentIndex` points to the active queue item.
+3. **Progress updates**: `position` changes over time; `duration` can stay `null` if timeline is unknown/live-like.
+4. **Queue transition**: `currentIndex` changes, `currentTrack` changes, and queue projection remains the source of ordering truth.
+5. **Reset/clear phase**: runtime can project back to `currentTrack: null` and `currentIndex: null`.
+
+The point is that each snapshot is valid on its own; consumers should react to what is projected now, not to assumptions about what "must" have happened before.
 
 ## Nullability as signal, not error
 
@@ -31,12 +45,27 @@ The contract uses nullability and optionality to represent runtime uncertainty e
 
 These states are intentional parts of the model. Consumers should treat them as valid contract values, not exceptional conditions.
 
+## Anti-patterns to avoid
+
+- Treating `duration !== null` as automatic seek permission. Duration is evidence of media length, not seekability permission.
+- Treating nullable fields as runtime failure signals. `currentTrack: null` and `currentIndex: null` can represent legitimate idle or transition states.
+- Reconstructing queue truth from timeline events alone. Queue ordering and active selection belong to `QueueSnapshot`.
+- Assuming snapshot updates are command acknowledgements. They are read-model projections and can include uncertainty.
+
 ## Practical consequence for consumers
 
-Because snapshots encode uncertainty in the type shape, consumers can apply policy without guessing runtime internals. For example, UI can render unknown duration states directly, and queue views can handle `currentIndex: null` as "no active selection".
+Because snapshots encode uncertainty in the type shape, consumers can apply policy without guessing runtime internals.
+
+Practical UI/state decisions that follow from this model:
+
+- Render timeline UI with an explicit unknown-duration state when `duration === null`.
+- Keep transport-control availability separate from timeline rendering (capabilities decide controls, snapshots decide display state).
+- Model queue selection as nullable in state stores and selectors, not as a forced default index.
+- Write reducers/selectors as pure projection consumers: derive view state from each incoming snapshot rather than incremental guesswork.
 
 ## Related pages
 
 - [Snapshots reference](../../reference/snapshots/)
 - [Invariants reference](../../reference/invariants/)
 - [Model a Track](../../how-to/model-a-track/)
+- [Capability Projection (capacitor)](../../../capacitor/explanation/capability-projection/)

--- a/apps/docs-site/src/content/docs/packages/contract/explanation/why-contract-first.mdx
+++ b/apps/docs-site/src/content/docs/packages/contract/explanation/why-contract-first.mdx
@@ -3,25 +3,46 @@ title: Why Contract-First
 description: Why Legato keeps shared playback semantics separate from runtime implementations.
 ---
 
-Legato uses a contract-first model so every integration speaks the same playback language before choosing a runtime.
+Legato uses a contract-first model because playback systems fail first at semantic boundaries, not at command wiring.
 
-## Why separate contract from runtime
+## The core tension
+
+Runtime integrations move fast: APIs change, platform behaviors differ, and adapter implementations evolve.
+
+Application policy moves slower: product behavior depends on stable meaning for snapshots, events, queue state, and errors.
+
+Contract-first resolves this tension by fixing the shared meaning first, then letting runtime implementations project into that meaning.
+
+## Problems this avoids
 
 `@ddgutierrezc/legato-contract` defines stable shared semantics (tracks, snapshots, events, errors, capabilities, invariants) without embedding transport behavior.
 
-This separation allows:
+That separation avoids common failure modes:
 
-- runtime implementations to evolve independently,
-- consumers to compile against typed guarantees without importing Capacitor-facing code,
-- and adapters/bindings to enforce a boundary where runtime specifics stay local.
+- **Semantic drift across layers**: different parts of the app interpreting "current track" or "active queue index" differently.
+- **Runtime leakage into app logic**: domain code coupled to plugin surfaces instead of contract snapshots and event payloads.
+- **Brittle refactors**: runtime changes forcing unrelated UI/business-policy rewrites.
+- **Hard-to-test policy code**: needing plugin/runtime setup just to test event and state decisions.
 
-## How the boundary works
+## How the boundary stays clear
 
 - **Contract package**: portable types and constants (`Track`, `PlaybackSnapshot`, `LEGATO_EVENT_NAMES`, `LEGATO_INVARIANTS`, and related exports).
 - **Adapters/bindings**: runtime-facing implementations that satisfy contract expectations.
 - **Consumers**: app logic that reads snapshots, handles typed events, and applies policy decisions.
 
-The result is a shared vocabulary across all integration points, with runtime behavior plugged in behind that vocabulary.
+The result is a shared vocabulary across integration points, with runtime behavior plugged in behind that vocabulary.
+
+## Runtime-first contrast (and why Legato does not default to it)
+
+A runtime-first approach usually starts from plugin methods/events and only later extracts shared semantics.
+
+That can ship quickly for one integration, but it tends to accumulate translation debt:
+
+- event payload meaning differs between call sites,
+- UI rules are inferred from runtime quirks,
+- and portability to another runtime becomes a rewrite instead of a projection.
+
+Legato's contract-first posture pays that semantic cost up front so runtime-specific complexity stays local.
 
 ## What this improves
 
@@ -29,9 +50,18 @@ The result is a shared vocabulary across all integration points, with runtime be
 - Safer refactors: consumer code depends on a stable public contract, not runtime internals.
 - Cleaner testing boundaries: you can test contract-level consumers with plain TypeScript objects.
 
+## What contract-first does not solve
+
+- It does not provide runtime playback execution by itself; runtime adapters/plugins still own that responsibility.
+- It does not remove platform constraints (for example, capability support remains runtime-projected).
+- It does not guarantee product UX quality automatically; teams still need explicit policy decisions on top of snapshots and events.
+
+Contract-first gives you a stable language. It does not replace runtime engineering or product decision-making.
+
 ## Related pages
 
 - [How-To Guides](../../how-to/)
 - [API Reference](../../reference/)
 - [Binding Adapter reference](../../reference/binding-adapter/)
 - [Consume Events and Payloads](../../how-to/consume-events-and-payloads/)
+- [Snapshot Model](../snapshot-model/)


### PR DESCRIPTION
## Summary

- deepen the main getting-started page with stronger package decision guidance, tradeoffs, and anti-patterns
- expand contract explanation pages with clearer rationale, consequences, and snapshot model semantics
- deepen Capacitor capability projection guidance with stronger UX and runtime interpretation framing

## Linked issue

Refs #136

## Validation

- [x] Relevant tests/checks were run
- [x] No unrelated workflows were changed

## Policy checks

- [x] Exactly one `type:*` label added
- [x] Approved issue linked when required (`status:approved`)
