### PR TITLE
docs(site): deepen contract semantics and onboarding

### DIFF
--- a/apps/docs-site/src/content/docs/packages/capacitor/how-to/set-up.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/how-to/set-up.mdx
@@ -9,9 +9,10 @@ This guide covers how to install and initialize the Legato Capacitor plugin for 
 
 ## Prerequisites
 
-- An existing Capacitor project (iOS and/or Android)
+- An existing Capacitor project with at least one native target (`ios` and/or `android`)
 - Node.js 18+ installed
 - `npm` or your preferred package manager
+- Your app already installs Capacitor dependencies and can run `npx cap sync` successfully
 
 ## Installation
 
@@ -25,9 +26,13 @@ This guide covers how to install and initialize the Legato Capacitor plugin for 
 
 2. **Sync native platforms**
 
-   ```bash
-   npx cap sync
-   ```
+    ```bash
+    npx cap sync
+    ```
+
+3. **Verify package installation and sync output**
+
+   Confirm both packages are present in `package.json` dependencies and that `npx cap sync` finished without errors.
 
 </Steps>
 
@@ -46,9 +51,41 @@ async function initialize() {
 initialize();
 ```
 
+Verify after setup:
+
+```ts
+const state = await audioPlayer.getState();
+console.log('Player state after setup:', state);
+// Expected on first setup: 'idle'
+```
+
 <Aside type="note">
 Both `audioPlayer.setup()` and `mediaSession.setup()` must be called before their respective APIs are used. Calling `audioPlayer.setup()` does NOT initialize media session, and vice-versa.
 </Aside>
+
+## Step-by-step verification checklist
+
+1. **After install**: `@ddgutierrezc/legato-capacitor` and `@ddgutierrezc/legato-contract` appear in dependencies.
+2. **After sync**: `npx cap sync` completes without errors.
+3. **After setup calls**: both `await audioPlayer.setup()` and `await mediaSession.setup()` resolve.
+4. **After state probe**: `audioPlayer.getState()` resolves (commonly `'idle'` before queue insertion).
+
+## Troubleshooting
+
+### Setup fails before playback commands
+
+- Verify `audioPlayer.setup()` is called and awaited before using `add()`, `play()`, `getSnapshot()`, or other player APIs.
+- If an operation reports `player_not_setup`, check that setup is not skipped by an app lifecycle branch and that initialization completes before user actions.
+
+### Remote events are not received
+
+- Verify `mediaSession.setup()` was called; `audioPlayer.setup()` alone does not prepare remote-control listeners.
+- Verify listeners are registered through `mediaSession` or remote helper APIs (for example `onRemotePlay`) after setup.
+
+### Native command checks fail
+
+- Run `legato native doctor` and review findings before debugging runtime behavior.
+- If you need a safe patch plan first, run `legato native configure --dry-run`.
 
 ## Expected result
 
@@ -67,5 +104,7 @@ console.log('Player state:', state); // 'idle'
 
 ## Next steps
 
-- [Play a Track](./play-track/) — add tracks and start playback
-- [Listen to Events](./listen-events/) — subscribe to playback and remote events
+- If you want to validate queue and playback commands first, continue with [Play a Track](./play-track/).
+- If you need UI/event-driven behavior next, continue with [Listen to Events](./listen-events/).
+- If you need a local state mirror in app code, continue with [Use Sync](./use-sync/).
+- If setup problems look platform-specific, check [Native CLI](../reference/cli-native/) and run doctor/configure flows.

--- a/apps/docs-site/src/content/docs/packages/contract/reference/binding-adapter.mdx
+++ b/apps/docs-site/src/content/docs/packages/contract/reference/binding-adapter.mdx
@@ -5,6 +5,8 @@ description: Reference for BindingAdapter and related adapter boundary types in 
 
 `BindingAdapter` defines the runtime-facing contract implemented by host bindings.
 
+It is the boundary where a concrete runtime projects transport operations, snapshots, queue state, capabilities, and event streams into a shared contract surface.
+
 ## Core adapter surface
 
 ```ts
@@ -35,6 +37,41 @@ interface BindingAdapter {
 }
 ```
 
+## Boundary role
+
+`BindingAdapter` is a boundary contract, not an application service API. Its purpose is to normalize runtime behavior into stable types that higher layers can consume without depending on platform-specific SDKs.
+
+In practice, adapter implementations sit between:
+
+- runtime/player integrations that perform real playback work,
+- and consumer code that expects contract-first shapes (`PlaybackSnapshot`, event payload maps, capability literals).
+
+## Operation groups and semantics
+
+### Setup
+
+- `setup()` initializes adapter runtime integration.
+
+### Queue-mutating operations
+
+- `add(options)`, `remove(options)`, `reset()`, and `skipTo(options)` return `PlaybackSnapshot`.
+- These methods are queue/topology-affecting commands where returning a snapshot allows callers to consume an updated projection immediately.
+
+### Playback transport operations
+
+- `play()`, `pause()`, `stop()`, `seekTo(options)`, `skipToNext()`, and `skipToPrevious()` return `Promise<void>`.
+- Void return means the contract does not require these methods to return an updated snapshot directly.
+
+### State query operations
+
+- `getState()`, `getPosition()`, `getDuration()`, `getCurrentTrack()`, `getQueue()`, `getSnapshot()`, and `getCapabilities()` expose current projections as typed reads.
+
+### Listener registration operations
+
+- `addListener(eventName, listener)` registers a typed listener and returns `BindingListenerHandle`.
+- `BindingListenerHandle.remove()` is the per-listener detach path.
+- `removeAllListeners()` clears listener registrations at adapter scope.
+
 ## Related exported types
 
 - `BindingListenerHandle`: listener registration handle with `remove(): Promise<void> | void`.
@@ -45,6 +82,30 @@ interface BindingAdapter {
 - `SeekToOptions`: `{ position: number }`.
 - `SkipToOptions`: `{ index: number }`.
 
+## Contract expectations vs non-guarantees
+
+What is defined by this contract:
+
+- method names, parameter shapes, and return types,
+- event-name and payload coupling through `LegatoEventName` + `LegatoEventPayloadMap`,
+- capability snapshot shape (`{ supported: Capability[] }`).
+
+What is not defined here:
+
+- retry strategy,
+- command/event ordering guarantees,
+- timeout, cancellation, or backpressure policy,
+- listener delivery scheduling details.
+
+Those concerns belong to concrete adapter/runtime implementations and higher-level orchestration policy.
+
+## Common adapter anti-patterns
+
+- Treating `Promise<void>` operations as if they must return immediate snapshot truth.
+- Inferring capability support from queue state alone instead of `getCapabilities()`.
+- Encoding platform-specific behavior into shared contract types.
+- Assuming listener registration implies any particular event sequencing semantics.
+
 ## Contract role
 
 `BindingAdapter` is the transport boundary between runtime implementations and contract consumers. Adapters project state, queue, events, capabilities, and operation results through this interface.
@@ -54,3 +115,4 @@ interface BindingAdapter {
 - [Capabilities](../capabilities/)
 - [Events](../events/)
 - [Snapshots](../snapshots/)
+- [Snapshot Model](../../explanation/snapshot-model/)

--- a/apps/docs-site/src/content/docs/packages/contract/reference/capabilities.mdx
+++ b/apps/docs-site/src/content/docs/packages/contract/reference/capabilities.mdx
@@ -5,6 +5,8 @@ description: Reference for CAPABILITIES and Capability in @ddgutierrezc/legato-c
 
 This page documents runtime capability literals projected through the adapter boundary.
 
+Capabilities are runtime projections, not static feature flags baked into the package.
+
 ## `CAPABILITIES`
 
 `Capability` is derived from `CAPABILITIES`:
@@ -33,7 +35,28 @@ type Capability = (typeof CAPABILITIES)[number];
 
 `CAPABILITIES` are runtime projections at the moment they are reported. They are not permanent guarantees across the full session and can change with queue, track, transport, or platform conditions.
 
+## Design implications for consumers
+
+- Build UI controls from the latest `supported` capability projection, not from assumptions about a platform.
+- Keep capability decisions separate from snapshot rendering concerns: capabilities express allowed operations, snapshots express current playback/queue state.
+- Re-evaluate support over time; projection can change as runtime context changes.
+
+## Contract limits
+
+- The literal list defines valid capability identifiers, not an SLA that every runtime always supports every literal.
+- The contract does not define permanence windows (for example, "once supported, always supported").
+- Capability literals do not by themselves define command success, retries, or timing behavior.
+
+## Common anti-patterns
+
+- Treating `CAPABILITIES` as a startup-only static config.
+- Inferring `seek` support only from timeline fields like `duration` instead of runtime capability projection.
+- Hiding controls forever after one unsupported read, without re-reading current capabilities.
+- Coupling UI state directly to transport assumptions that are not represented in `supported`.
+
 ## Related pages
 
 - [Binding Adapter](../binding-adapter/)
 - [Snapshots](../snapshots/)
+- [Snapshot Model](../../explanation/snapshot-model/)
+- [Capability Projection (capacitor)](../../../capacitor/explanation/capability-projection/)

--- a/apps/docs-site/src/content/docs/packages/contract/reference/events.mdx
+++ b/apps/docs-site/src/content/docs/packages/contract/reference/events.mdx
@@ -5,6 +5,8 @@ description: Reference for event names and payload maps exported by @ddgutierrez
 
 This page documents event-name tuples and payload maps exported by the contract package.
 
+Events in this package are type-level contract surfaces: they define valid names and payload shapes, but they do not define delivery policy (ordering, retries, buffering, or latency).
+
 ## Player events
 
 ### `PLAYER_EVENT_NAMES`
@@ -29,6 +31,22 @@ const PLAYER_EVENT_NAMES = [
 - `playback-ended` -> `{ snapshot: PlaybackSnapshot }`
 - `playback-error` -> `{ error: LegatoError }`
 
+#### Payload semantics by event
+
+- `playback-state-changed`: state transition signal only (`PlaybackState`), not a full playback projection.
+- `playback-active-track-changed`: active pointer delta (`track` + `index`), useful when only selection changed.
+- `playback-queue-changed`: queue projection update (`QueueSnapshot`), focused on queue topology.
+- `playback-progress`: timeline-focused payload (`position`, `duration`, `bufferedPosition`), intentionally narrower than `PlaybackSnapshot`.
+- `playback-ended`: terminal payload that carries a full `PlaybackSnapshot`.
+- `playback-error`: error-focused payload (`LegatoError`) for failure reporting.
+
+### Partial vs complete payloads
+
+- **Specialized/partial payloads**: `playback-state-changed`, `playback-active-track-changed`, `playback-queue-changed`, `playback-progress`, and `playback-error` each project one concern.
+- **Complete snapshot payload**: `playback-ended` provides `{ snapshot: PlaybackSnapshot }`.
+
+Use event payloads when your reaction depends only on the projected concern. Use a snapshot read (`getSnapshot()` via adapter boundary) when your logic needs a full, coherent playback + queue view.
+
 ## Remote events
 
 ### `MEDIA_SESSION_EVENT_NAMES`
@@ -51,6 +69,10 @@ const MEDIA_SESSION_EVENT_NAMES = [
 - `remote-previous` -> `Record<string, never>`
 - `remote-seek` -> `{ position: number }`
 
+Remote command events represent intent from media-session controls. Empty payload commands (`remote-play`, `remote-pause`, `remote-next`, `remote-previous`) carry no additional data. `remote-seek` adds a target `position`.
+
+`remote-seek` is documented in source as emitted only when runtime-projected capabilities include `seek`.
+
 ## Legacy and canonical unified tuples
 
 The contract also exports:
@@ -63,6 +85,15 @@ Related type aliases:
 - `PlayerEventName`, `MediaSessionEventName`, `LegacyPlayerEventName`, `LegatoEventName`
 - `PlayerEventPayload<E>`, `MediaSessionEventPayload<E>`, `LegacyPlayerEventPayload<E>`, `LegatoEventPayload<E>`
 - `LegacyPlayerEventPayloadMap`, `LegatoEventPayloadMap`
+
+`LEGATO_EVENT_NAMES` is currently an alias of the legacy composite tuple, so canonical and legacy names are identical at this time.
+
+## Interpretation anti-patterns
+
+- Assuming every event payload is a full snapshot. Only `playback-ended` includes `PlaybackSnapshot`.
+- Reconstructing global playback state from a single specialized event payload.
+- Treating tuple membership as a delivery guarantee. Names are allowed values, not transport guarantees.
+- Assuming remote commands are always available or always emitted; capability projection remains runtime-dependent.
 
 ## Minimal usage
 
@@ -86,3 +117,5 @@ LEGATO_EVENT_NAMES;
 
 - [Snapshots](../snapshots/)
 - [Errors](../errors/)
+- [Consume Events and Payloads](../../how-to/consume-events-and-payloads/)
+- [Snapshot Model](../../explanation/snapshot-model/)

--- a/apps/docs-site/src/content/docs/packages/contract/reference/invariants.mdx
+++ b/apps/docs-site/src/content/docs/packages/contract/reference/invariants.mdx
@@ -5,6 +5,8 @@ description: Reference for POSITION_MIN and LEGATO_INVARIANTS in @ddgutierrezc/l
 
 This page documents invariant-related exports used as shared contract expectations.
 
+These exports are source-of-truth constants for defensive validation logic. They describe expected data constraints but do not execute validation by themselves.
+
 ## `POSITION_MIN`
 
 ```ts
@@ -12,6 +14,8 @@ const POSITION_MIN = 0;
 ```
 
 `POSITION_MIN` defines the minimum allowed playback position value.
+
+Use `POSITION_MIN` as the canonical floor when checking position-like numeric fields (`position`, and optional numeric timeline fields when present).
 
 ## `LEGATO_INVARIANTS`
 
@@ -34,9 +38,31 @@ const LEGATO_INVARIANTS = {
 - `snapshot.position` must be greater than or equal to `0`.
 - `snapshot.duration` and `snapshot.bufferedPosition`, when present, must be greater than or equal to `0`.
 
-These exports document shared expectations. They do not introduce additional runtime validation APIs by themselves.
+## Enforcement thinking
+
+Treat these constants as a shared vocabulary between producers and consumers:
+
+- adapter/binding implementations can validate outgoing projections against the invariant set,
+- consuming apps can validate incoming snapshots before state updates,
+- diagnostics can emit invariant message literals directly for consistent observability.
+
+This keeps validation intent aligned across layers without relying on hidden helper logic.
+
+## What this package does not provide
+
+- No exported runtime validator function.
+- No built-in policy for reject vs warn vs recover when a violation appears.
+- No extra inferred invariants beyond the string constants listed in `LEGATO_INVARIANTS`.
+
+## Anti-patterns
+
+- Hardcoding ad-hoc error strings instead of using `LEGATO_INVARIANTS` literals.
+- Replacing `POSITION_MIN` with a local constant that can drift from contract truth.
+- Validating assumptions not stated by the contract (for example, requiring non-null `duration` or requiring `currentTrack` whenever queue has items).
+- Treating invariant strings as implementation detail; they are explicit contract exports.
 
 ## Related pages
 
 - [Track](../track/)
 - [Snapshots](../snapshots/)
+- [Validate Runtime Invariants](../../how-to/validate-runtime-invariants/)

--- a/apps/docs-site/src/content/docs/packages/contract/reference/track.mdx
+++ b/apps/docs-site/src/content/docs/packages/contract/reference/track.mdx
@@ -5,6 +5,8 @@ description: Reference for Track and TrackType in @ddgutierrezc/legato-contract.
 
 `Track` is the queue item shape shared across adapter and consumer boundaries.
 
+Use this page as the canonical source for track payload semantics used by queue operations, snapshot projections, and event payloads.
+
 ## TrackType
 
 `TrackType` is derived from `TRACK_TYPES`:
@@ -28,6 +30,12 @@ type TrackType = (typeof TRACK_TYPES)[number];
 | `type` | `TrackType` | No | Declared media semantics used by native capability projectors. |
 | `headers` | `Record<string, string>` | No | Static per-track HTTP headers used by native playback transport. |
 
+## What `type` means (and does NOT mean)
+
+- `type` expresses media-kind intent (`file`, `progressive`, `hls`, `dash`) used by runtime capability projection.
+- `type` does NOT guarantee that a specific operation (for example seek) is always available.
+- Runtime decisions should combine track declaration with runtime projections and snapshot signals (for example nullable duration semantics).
+
 ## `headers` scope and guarantees
 
 Based on the contract comments, v1 support scope is intentionally narrow:
@@ -41,7 +49,49 @@ v1 non-goals explicitly documented in the contract:
 - Token refresh or dynamic auth callbacks.
 - Cookie/session renewal orchestration.
 
-## Minimal example
+What this means in practice:
+
+- `headers` is useful for static per-track request headers.
+- `headers` is not an auth lifecycle engine and should not be treated as one.
+
+## Progressive examples
+
+### 1) Minimal track
+
+```ts
+import type { Track } from '@ddgutierrezc/legato-contract';
+
+const track: Track = {
+  id: 'song-42',
+  url: 'https://cdn.example.com/song-42.mp3',
+};
+```
+
+### 2) Metadata-rich track
+
+```ts
+const track: Track = {
+  id: 'podcast-ep-12',
+  url: 'https://cdn.example.com/podcast/ep-12.mp3',
+  title: 'Episode 12',
+  artist: 'Legato Studio',
+  album: 'Season 2',
+  artwork: 'https://cdn.example.com/podcast/ep-12.jpg',
+  duration: 1620,
+};
+```
+
+### 3) Typed track
+
+```ts
+const track: Track = {
+  id: 'live-hour',
+  url: 'https://stream.example.com/live.m3u8',
+  type: 'hls',
+};
+```
+
+### 4) Protected track with headers
 
 ```ts
 import type { Track } from '@ddgutierrezc/legato-contract';
@@ -52,9 +102,17 @@ const track: Track = {
   type: 'progressive',
   headers: {
     Authorization: 'Bearer demo-token',
+    'X-Client': 'mobile-app',
   },
 };
 ```
+
+## Anti-patterns
+
+- Setting `type: 'hls'` or `type: 'dash'` and assuming seek is always available. Seek remains runtime-capability-dependent.
+- Omitting stable `id` values (for example randomizing per render). Queue operations (`remove`, `skip`) depend on stable identifiers and indexes.
+- Treating `headers` as shared global auth state across all queue items. Header scope is per track.
+- Expecting `headers` to solve token refresh, cookie renewal, or DRM license workflows. Those are out of contract v1 scope.
 
 ## Related pages
 

--- a/apps/docs-site/src/content/docs/tutorials/first-contract-integration.mdx
+++ b/apps/docs-site/src/content/docs/tutorials/first-contract-integration.mdx
@@ -39,7 +39,20 @@ This tutorial walks through a first integration of `@ddgutierrezc/legato-contrac
 
 ## 1) Model a Track
 
-Create a strongly typed track object from the contract:
+Start with a minimal track, then enrich it as your integration grows.
+
+### Minimal track
+
+```ts
+import type { Track } from '@ddgutierrezc/legato-contract';
+
+const introTrack: Track = {
+  id: 'ep-001',
+  url: 'https://cdn.example.com/audio/episode-001.mp3',
+};
+```
+
+### Metadata-rich and transport-aware track
 
 ```ts
 import type { Track } from '@ddgutierrezc/legato-contract';
@@ -49,6 +62,9 @@ const introTrack: Track = {
   url: 'https://cdn.example.com/audio/episode-001.mp3',
   title: 'Episode 001',
   artist: 'Legato Team',
+  album: 'Season 1',
+  artwork: 'https://cdn.example.com/artwork/ep-001.jpg',
+  duration: 180,
   type: 'progressive',
   headers: {
     Authorization: 'Bearer static-token-for-demo',
@@ -64,12 +80,29 @@ What this gives you immediately:
 
 ## 2) Model a QueueSnapshot
 
+Start with one item, then move to a realistic multi-item queue.
+
 ```ts
 import type { QueueSnapshot } from '@ddgutierrezc/legato-contract';
 
 const queue: QueueSnapshot = {
   items: [introTrack],
   currentIndex: 0,
+};
+```
+
+```ts
+const queue: QueueSnapshot = {
+  items: [
+    introTrack,
+    {
+      id: 'ep-002',
+      url: 'https://cdn.example.com/audio/episode-002.m3u8',
+      title: 'Episode 002',
+      type: 'hls',
+    },
+  ],
+  currentIndex: 1,
 };
 ```
 
@@ -88,6 +121,22 @@ const playback: PlaybackSnapshot = {
   duration: 180,
   bufferedPosition: 30,
   queue,
+};
+```
+
+Model the no-active-item state too:
+
+```ts
+const idlePlayback: PlaybackSnapshot = {
+  state: 'idle',
+  currentTrack: null,
+  currentIndex: null,
+  position: 0,
+  duration: null,
+  queue: {
+    items: [],
+    currentIndex: null,
+  },
 };
 ```
 
@@ -128,6 +177,13 @@ const allNames = LEGATO_EVENT_NAMES;
 
 This pattern keeps your domain and UI code runtime-neutral while still fully typed.
 
+## Common mistakes to avoid
+
+- Treating `type` as a playback guarantee. It declares media semantics; runtime capability still decides what operations are available.
+- Treating `headers` as dynamic auth orchestration. The contract defines static per-track headers, not token refresh or DRM/license flows.
+- Forgetting nullable branches. `duration`, `currentTrack`, and `currentIndex` are intentionally nullable and must be handled.
+- Mixing runtime behavior into shared contract-only modules. Keep this layer transport-neutral.
+
 ## Verify the result
 
 Your integration is correct when:
@@ -136,8 +192,18 @@ Your integration is correct when:
 - Invalid `type` values (for example `'stream'`) fail at compile time.
 - Event payload access narrows by event name (for example, `remote-seek` exposes `position`).
 
+## When this tutorial is no longer enough
+
+Move to runtime integration when you need:
+
+- Real playback commands (`setup`, `add`, `play`, `seekTo`) against native adapters.
+- Runtime event lifecycle management (listener registration + cleanup).
+- Capability-gated UI decisions (`getCapabilities()` for seek/skip availability).
+- Native setup diagnostics and configuration checks.
+
 ## Next steps
 
 - Read the [Contract reference index](/packages/contract/reference/) for the canonical API surface.
 - Deep dive into [Track fields](/packages/contract/reference/track/).
 - Review [Snapshots](/packages/contract/reference/snapshots/), [Events](/packages/contract/reference/events/), and [Errors](/packages/contract/reference/errors/).
+- Continue with [Set Up Legato Capacitor](/packages/capacitor/how-to/set-up/) for runtime integration.


### PR DESCRIPTION
## Summary

- deepen contract reference pages for events, binding adapter, invariants, and capabilities
- deepen the Capacitor setup guide and the first contract integration tutorial with better verification, troubleshooting, and transition guidance
- deepen the contract track reference with stronger semantics, progressive examples, and anti-patterns

## Linked issue

Refs #136

## Validation

- [x] Relevant tests/checks were run
- [x] No unrelated workflows were changed

## Policy checks

- [x] Exactly one `type:*` label added
- [x] Approved issue linked when required (`status:approved`)
