### PR TITLE
docs(site): refresh readmes and public branding

### DIFF
--- a/apps/docs-site/astro.config.mjs
+++ b/apps/docs-site/astro.config.mjs
@@ -10,7 +10,11 @@ export default defineConfig({
 			title: 'Legato Docs',
 			description:
 				'Canonical public documentation for Legato contract and Capacitor integration packages.',
-			social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/ddgutierrezc/legato' }],
+			social: [
+				{ icon: 'github', label: 'GitHub', href: 'https://github.com/ddgutierrezc/legato' },
+				{ icon: 'discord', label: 'Discord', href: 'https://discord.com/invite/Hhnumyk2N' },
+				{ icon: 'linkedin', label: 'LinkedIn', href: 'https://www.linkedin.com/in/ddgutierrezc' },
+			],
 			editLink: {
 				baseUrl: 'https://github.com/ddgutierrezc/legato/edit/main/apps/docs-site/src/content/docs/',
 			},

--- a/apps/docs-site/src/content/docs/community/index.mdx
+++ b/apps/docs-site/src/content/docs/community/index.mdx
@@ -1,16 +1,35 @@
 ---
 title: Community
-description: Community, contribution, and support entrypoints for Legato users.
+description: Official community and support hub for Legato users and contributors.
 ---
 
-Use these entrypoints to contribute or get support.
+import { Card, CardGrid } from '@astrojs/starlight/components';
+
+Use this page as the official hub to get help, follow updates, and contribute to Legato.
+
+## Connect
+
+<CardGrid>
+  <Card title="Documentation" icon="open-book" href="https://legato-docs.netlify.app/">
+    Canonical package docs, references, and onboarding guides.
+  </Card>
+  <Card title="Discord" icon="discord" href="https://discord.com/invite/Hhnumyk2N">
+    Community support, integration questions, and technical discussion.
+  </Card>
+  <Card title="LinkedIn" icon="linkedin" href="https://www.linkedin.com/in/ddgutierrezc">
+    Follow public updates and project direction from the maintainer.
+  </Card>
+  <Card title="GitHub" icon="github" href="https://github.com/ddgutierrezc/legato">
+    Source code, issues, releases, and contribution workflow.
+  </Card>
+</CardGrid>
+
+## Contribution and governance
 
 - [Contributing guide](https://github.com/ddgutierrezc/legato/blob/main/CONTRIBUTING.md)
 - [Code of Conduct](https://github.com/ddgutierrezc/legato/blob/main/CODE_OF_CONDUCT.md)
 - [Security policy](https://github.com/ddgutierrezc/legato/blob/main/SECURITY.md)
-- [Discord community](https://discord.gg/Hhnumyk2N)
 
 ## Scope note
 
-This page links to public community resources only.
-Maintainer runbooks and release operations remain in root `docs/` for internal workflows.
+This hub links public community resources only. Maintainer runbooks and release operations remain in root `docs/` for internal workflows.

--- a/apps/docs-site/src/content/docs/getting-started/index.mdx
+++ b/apps/docs-site/src/content/docs/getting-started/index.mdx
@@ -94,3 +94,9 @@ You can start by making your app logic consume contract snapshots/events, then p
 - [Why Contract-First](../packages/contract/explanation/why-contract-first/)
 - [Snapshot Model](../packages/contract/explanation/snapshot-model/)
 - [Capability Projection](../packages/capacitor/explanation/capability-projection/)
+
+## Support and community
+
+- Community hub: [Community](../community/)
+- Discord: [https://discord.com/invite/Hhnumyk2N](https://discord.com/invite/Hhnumyk2N)
+- LinkedIn: [https://www.linkedin.com/in/ddgutierrezc](https://www.linkedin.com/in/ddgutierrezc)

--- a/apps/docs-site/src/content/docs/index.mdx
+++ b/apps/docs-site/src/content/docs/index.mdx
@@ -53,3 +53,9 @@ If guidance in a README conflicts with content here, this docs site is authorita
     Get contribution and support links without maintainer-only runbook details.
   </Card>
 </CardGrid>
+
+## Need help or want to connect?
+
+- Community hub: [Community](./community/)
+- Discord: [https://discord.com/invite/Hhnumyk2N](https://discord.com/invite/Hhnumyk2N)
+- LinkedIn: [https://www.linkedin.com/in/ddgutierrezc](https://www.linkedin.com/in/ddgutierrezc)

--- a/apps/docs-site/src/content/docs/packages/capacitor/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/index.mdx
@@ -79,3 +79,9 @@ See the [Contract Package](../contract/) for shared types and event constants th
 </Aside>
 
 Start with [Capability Projection](explanation/capability-projection/) and [Snapshot Semantics](explanation/snapshot-semantics/) for the mental model, then apply it in [Build Capability-Driven Controls](how-to/capability-driven-controls/) and [Send Secure Track Headers](how-to/secure-track-headers/). Use [Native CLI](reference/cli-native/) when working on repository-native setup checks.
+
+## Support and community
+
+- Community hub: [Community](/community/)
+- Discord: [https://discord.com/invite/Hhnumyk2N](https://discord.com/invite/Hhnumyk2N)
+- LinkedIn: [https://www.linkedin.com/in/ddgutierrezc](https://www.linkedin.com/in/ddgutierrezc)

--- a/apps/docs-site/src/content/docs/packages/contract/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/contract/index.mdx
@@ -49,3 +49,9 @@ Use `@ddgutierrezc/legato-contract` when you need shared contract primitives wit
 <Aside type="note">
 This page summarizes consumer-safe guidance only. Maintainer verification maps and release runbooks stay outside the public docs-site boundary.
 </Aside>
+
+## Support and community
+
+- Community hub: [Community](/community/)
+- Discord: [https://discord.com/invite/Hhnumyk2N](https://discord.com/invite/Hhnumyk2N)
+- LinkedIn: [https://www.linkedin.com/in/ddgutierrezc](https://www.linkedin.com/in/ddgutierrezc)

--- a/packages/capacitor/README.md
+++ b/packages/capacitor/README.md
@@ -1,35 +1,96 @@
 # @ddgutierrezc/legato-capacitor
 
-Modern Capacitor binding MVP for Legato.
+<p align="center">
+  <img src="https://legato-docs.netlify.app/brand.png" alt="Legato brand" width="720" />
+</p>
 
-This package provides Capacitor-native integration and is not a replacement for contract-only consumers.
+Capacitor runtime adapter for Legato playback APIs, media-session events, and typed sync helpers.
 
-## npm quickstart
+## Why this package
+
+`@ddgutierrezc/legato-capacitor` gives you a concrete runtime surface for hybrid iOS/Android apps using Capacitor. It pairs runtime commands (`audioPlayer`), remote-control events (`mediaSession`), and a unified facade (`Legato`) with the shared contract from `@ddgutierrezc/legato-contract`.
+
+## When to use / when not to use
+
+Use this package when you need:
+
+- Capacitor-native playback commands in production app flows.
+- Media-session event handling (play/pause/next/previous/seek).
+- Runtime capability-driven UI behavior sourced from `getCapabilities()` and snapshots.
+
+Do not use this package when you only need shared playback semantics (types, events, invariants) without runtime integration. In that case, start with `@ddgutierrezc/legato-contract`.
+
+## Install
 
 ```bash
 npm install @ddgutierrezc/legato-capacitor @ddgutierrezc/legato-contract
 ```
 
-## Canonical docs
+## Quickstart
 
-For installation flow, API surface, and migration guidance, use the canonical docs-site guide:
+```ts
+import {
+  Legato,
+  audioPlayer,
+  mediaSession,
+  onPlaybackStateChanged,
+  onRemotePlay,
+} from '@ddgutierrezc/legato-capacitor';
 
-- [`apps/docs-site/src/content/docs/packages/capacitor/index.mdx`](../../apps/docs-site/src/content/docs/packages/capacitor/index.mdx)
+await audioPlayer.setup();
+await mediaSession.setup();
 
-This README is an orientation entrypoint only.
+await audioPlayer.add({
+  tracks: [
+    {
+      id: 'intro-001',
+      url: 'https://cdn.example.com/audio/intro.mp3',
+      title: 'Welcome',
+      artist: 'Legato Demo',
+      type: 'progressive',
+    },
+  ],
+  startIndex: 0,
+});
 
-## Contractual scope notes
+await audioPlayer.play();
 
-- Streaming semantics claims follow a **conservative policy**: capability signals are inferred only from source-backed native/runtime evidence and must not be expanded into unsupported guarantees.
-- Inference and scope constraints for streaming behavior remain bounded to the documented v1 guardrails; out-of-scope claims (for example DRM/process-death coverage in this milestone) are intentionally excluded.
-- `@ddgutierrezc/legato-capacitor` is the **first concrete adapter** and currently the **only implemented binding** for the contract's transport-neutral surface.
-- Release decision traceability for v1 is anchored in [`../../docs/releases/v1-release-go-no-go-record-v1.md`](../../docs/releases/v1-release-go-no-go-record-v1.md).
+onPlaybackStateChanged(({ state }) => {
+  console.log('Playback state:', state);
+});
 
-## CLI scope note
+onRemotePlay(() => {
+  void Legato.play();
+});
 
-This package is the only public package that ships the `legato` command.
-The `legato native` CLI remains a repo-owned maintainer helper for native setup and diagnostics, not a contract-only consumer surface.
+const snapshot = await Legato.getSnapshot();
+console.log('Current snapshot:', snapshot);
+```
 
-## Maintainer operations
+## Public entrypoints
 
-Maintainer-heavy CLI/release/SPM operational details are documented in [`../../docs/maintainers/legato-capacitor-operator-guide.md`](../../docs/maintainers/legato-capacitor-operator-guide.md).
+- `audioPlayer`: playback commands, queue operations, snapshot/state queries, capability projection.
+- `mediaSession`: remote-command listener surface.
+- `Legato`: unified facade over `audioPlayer` + `mediaSession`.
+- Event helpers/constants: `AUDIO_PLAYER_EVENTS`, `MEDIA_SESSION_EVENTS`, `LEGATO_EVENTS`, `onPlayback*`, `onRemote*`.
+- Sync helpers: `createLegatoSync`, `createAudioPlayerSync`.
+- Types: exported from package root via `export type * from './definitions'`.
+
+## Docs map
+
+- Overview: https://legato-docs.netlify.app/packages/capacitor/
+- Capability model: https://legato-docs.netlify.app/packages/capacitor/explanation/capability-projection/
+- Snapshot semantics: https://legato-docs.netlify.app/packages/capacitor/explanation/snapshot-semantics/
+- API reference: https://legato-docs.netlify.app/packages/capacitor/reference/
+- Getting started: https://legato-docs.netlify.app/getting-started/
+
+## Community and support
+
+- Docs: https://legato-docs.netlify.app/
+- Discord: https://discord.com/invite/Hhnumyk2N
+- LinkedIn: https://www.linkedin.com/in/ddgutierrezc
+- GitHub: https://github.com/ddgutierrezc/legato
+
+## License
+
+MIT

--- a/packages/contract/README.md
+++ b/packages/contract/README.md
@@ -1,6 +1,21 @@
 # @ddgutierrezc/legato-contract
 
-Library-only contract package for Legato shared types, events, and invariants.
+<p align="center">
+  <img src="https://legato-docs.netlify.app/brand.png" alt="Legato brand" width="720" />
+</p>
+
+Contract-first playback primitives for Legato shared semantics, events, snapshots, and invariants.
+
+## Why this package
+
+`@ddgutierrezc/legato-contract` lets teams model playback behavior with stable, transport-neutral types before coupling to a specific runtime. It defines the shared language for track, queue, state, snapshot, capabilities, and event payload maps.
+
+## Package role vs Capacitor
+
+- `@ddgutierrezc/legato-contract`: semantics and type contracts only (no playback runtime).
+- `@ddgutierrezc/legato-capacitor`: concrete Capacitor adapter that executes playback and emits runtime events using these same contracts.
+
+Start with contract-first modeling when you need portability across app layers, tests, or future adapters.
 
 ## Install
 
@@ -8,14 +23,73 @@ Library-only contract package for Legato shared types, events, and invariants.
 npm install @ddgutierrezc/legato-contract
 ```
 
-## Canonical docs
+## Quickstart
 
-For package roles, public exports, and usage patterns, use the canonical docs-site guide:
+```ts
+import type { LegatoEventPayloadMap, PlaybackSnapshot, Track } from '@ddgutierrezc/legato-contract';
+import { LEGATO_EVENT_NAMES, PLAYER_EVENT_NAMES, PLAYBACK_STATES } from '@ddgutierrezc/legato-contract';
 
-- [`apps/docs-site/src/content/docs/packages/contract/index.mdx`](../../apps/docs-site/src/content/docs/packages/contract/index.mdx)
+const seedTrack: Track = {
+  id: 'episode-42',
+  url: 'https://cdn.example.com/podcast/42.mp3',
+  title: 'Episode 42',
+  type: 'progressive',
+};
 
-This README is an orientation entrypoint only.
+const initialSnapshot: PlaybackSnapshot = {
+  state: 'idle',
+  currentTrack: seedTrack,
+  currentIndex: 0,
+  position: 0,
+  duration: null,
+  queue: { items: [seedTrack], currentIndex: 0 },
+};
 
-Streaming semantics interpretation is documented in the canonical package guide and architecture guardrails, not expanded in this thin README.
+function onPlaybackEvent<E extends (typeof LEGATO_EVENT_NAMES)[number]>(
+  eventName: E,
+  payload: LegatoEventPayloadMap[E],
+) {
+  console.log(eventName, payload);
+}
 
-Maintainer verification map: [`../../docs/maintainers/package-documentation-foundation-v1-source-map.md`](../../docs/maintainers/package-documentation-foundation-v1-source-map.md)
+console.log('Known player events:', PLAYER_EVENT_NAMES);
+console.log('Known states:', PLAYBACK_STATES);
+console.log('Initial snapshot:', initialSnapshot);
+```
+
+## Public exports (high level)
+
+- Domain primitives: `Track`, `QueueSnapshot`, `PlaybackState`, `PlaybackSnapshot`, `LegatoError`.
+- Event semantics: `PLAYER_EVENT_NAMES`, `MEDIA_SESSION_EVENT_NAMES`, `LEGATO_EVENT_NAMES` and payload maps.
+- Runtime capability semantics: `CAPABILITIES`, `Capability`.
+- Boundary contracts: transport-neutral adapter interfaces from `binding-adapter`.
+- Invariants/helpers: exported from package root for contract-safe app logic.
+
+## Best practices
+
+- Model app behavior against contract snapshots/events first, then plug a runtime adapter.
+- Treat nullable `duration` as semantic signal (`null` can mean unknown/live-like timeline).
+- Keep imports at package root only.
+
+Anti-pattern:
+
+- Deep imports such as `@ddgutierrezc/legato-contract/dist/*` (unsupported public surface).
+
+## Docs map
+
+- Contract overview: https://legato-docs.netlify.app/packages/contract/
+- Contract explanation: https://legato-docs.netlify.app/packages/contract/explanation/
+- Contract how-to guides: https://legato-docs.netlify.app/packages/contract/how-to/
+- Contract reference: https://legato-docs.netlify.app/packages/contract/reference/
+- First integration tutorial: https://legato-docs.netlify.app/tutorials/first-contract-integration/
+
+## Community and support
+
+- Docs: https://legato-docs.netlify.app/
+- Discord: https://discord.com/invite/Hhnumyk2N
+- LinkedIn: https://www.linkedin.com/in/ddgutierrezc
+- GitHub: https://github.com/ddgutierrezc/legato
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

- rewrite the `@ddgutierrezc/legato-capacitor` and `@ddgutierrezc/legato-contract` README files for a more polished npm-first presentation
- add consistent public branding, docs, Discord, LinkedIn, and GitHub links across the docs-site entrypoints
- turn the Community page into a clearer official hub for support and connection

## Linked issue

Resolves #139

## Validation

- [x] Relevant tests/checks were run
- [x] No unrelated workflows were changed

## Policy checks

- [x] Exactly one `type:*` label added
- [x] Approved issue linked when required (`status:approved`)
