### PR TITLE
docs(site): add operational confidence guides

### DIFF
--- a/apps/docs-site/src/content/docs/how-to/migration-and-versioning.mdx
+++ b/apps/docs-site/src/content/docs/how-to/migration-and-versioning.mdx
@@ -1,0 +1,79 @@
+---
+title: Migration and Versioning
+description: How to evaluate and execute Legato upgrades with explicit risk checks.
+---
+
+Use this guide when you are upgrading dependencies and need to reduce production risk.
+
+## Choose your consumer profile first
+
+### Contract-only consumer
+
+You depend on `@ddgutierrezc/legato-contract` types, events, error codes, and capabilities, but you do not consume the Capacitor runtime package directly.
+
+Primary risk surface:
+
+- Semantic assumptions in your adapters and state machines
+- Event payload handling and type narrowing
+- Branches keyed by capability/error literals
+
+### Capacitor runtime consumer
+
+You depend on `@ddgutierrezc/legato-capacitor` (and transitively align with contract semantics).
+
+Primary risk surface:
+
+- Runtime behavior under real device conditions
+- Setup/order lifecycle integration
+- Capability-gated controls and remote event handling
+
+## Upgrade flow
+
+1. Read the target release entry in [Releases](/releases/) and the root changelog.
+2. Confirm version alignment expectations from [Compatibility](/reference/compatibility/).
+3. Update dependencies in a branch.
+4. Run consumer-specific validation (contract-only or runtime).
+5. Roll forward only after passing your app-level checks.
+
+## Contract-only upgrade checklist
+
+- Verify `LEGATO_ERROR_CODES` handling still branches on `error.code`, never on `message` text.
+- Verify capability checks still use literal names from the contract (`play`, `pause`, `stop`, `seek`, `skip-next`, `skip-previous`).
+- Verify event-name assumptions match documented public names.
+- Re-run TypeScript checks in your integration package(s).
+
+## Capacitor runtime upgrade checklist
+
+- Verify initialization order is explicit and awaited (`audioPlayer.setup()`, `mediaSession.setup()` where used).
+- Verify queue lifecycle: `add(...)`, `startIndex`, `play()`, `skipTo...()`, `reset()`.
+- Verify capability-gated UI logic (`getCapabilities()` before showing seek/skip affordances).
+- Verify event listeners are attached/removed correctly across component lifecycles.
+- Verify error handling uses `error.code` and logs `details` for diagnostics.
+
+## Breaking-change review checklist
+
+For each release, answer these questions before production rollout:
+
+1. Were any public literals (event names, error codes, capability names) added/removed/renamed?
+2. Did setup, queue, or snapshot semantics change in a way your UI assumes implicitly?
+3. Did release notes mention native/runtime parity or behavior fixes that could alter edge-case flows?
+4. Do you rely on behavior not guaranteed by the documented public surface?
+5. Is your rollback path defined (previous package versions + deployment procedure)?
+
+If any answer is uncertain, run additional device-level validation before promoting.
+
+## Minimal rollout strategy
+
+1. Update dependencies on a feature branch.
+2. Run smoke tests on representative Android and iOS targets.
+3. Validate one real queue/playback scenario and one error-path scenario.
+4. Roll out gradually and monitor playback error-code distribution.
+
+This guide does not assume automated migration tooling. Treat each upgrade as an explicit engineering change with observable checks.
+
+## Related pages
+
+- [Releases](/releases/)
+- [Compatibility](/reference/compatibility/)
+- [Troubleshooting](/how-to/troubleshooting/)
+- [Set Up Legato Capacitor](/packages/capacitor/how-to/set-up/)

--- a/apps/docs-site/src/content/docs/how-to/production-quickstart-capacitor.mdx
+++ b/apps/docs-site/src/content/docs/how-to/production-quickstart-capacitor.mdx
@@ -1,0 +1,150 @@
+---
+title: Production Quickstart (Capacitor)
+description: Minimal production-oriented Legato Capacitor integration with setup, queue, listeners, and validation.
+---
+
+Use this guide to bootstrap a realistic first production integration for `@ddgutierrezc/legato-capacitor`.
+
+## Prerequisites
+
+- Capacitor app with native targets configured (`ios` and/or `android`)
+- `@ddgutierrezc/legato-capacitor` and `@ddgutierrezc/legato-contract` installed
+- Successful native sync (`npx cap sync`)
+
+## Step 1: Install and align versions
+
+```bash
+npm install @ddgutierrezc/legato-capacitor @ddgutierrezc/legato-contract
+npx cap sync
+```
+
+Then confirm dependency alignment with [Compatibility](/reference/compatibility/).
+
+## Step 2: Initialize playback and media session early
+
+```ts
+import { audioPlayer, mediaSession } from '@ddgutierrezc/legato-capacitor';
+
+export async function initializeLegato() {
+  await audioPlayer.setup();
+  await mediaSession.setup();
+}
+```
+
+Call initialization from your app bootstrap before exposing playback UI interactions.
+
+## Step 3: Register essential listeners
+
+```ts
+import {
+  audioPlayer,
+  onPlaybackStateChanged,
+  onPlaybackProgress,
+  onPlaybackError,
+  onRemotePlay,
+  onRemotePause,
+} from '@ddgutierrezc/legato-capacitor';
+
+export async function registerLegatoListeners() {
+  const handles = await Promise.all([
+    onPlaybackStateChanged(({ state }) => {
+      console.log('[playback-state]', state);
+    }),
+    onPlaybackProgress(({ position, duration }) => {
+      console.log('[playback-progress]', { position, duration });
+    }),
+    onPlaybackError(({ error }) => {
+      console.error('[playback-error]', error.code, error.message, error.details);
+    }),
+    onRemotePlay(async () => {
+      await audioPlayer.play();
+    }),
+    onRemotePause(async () => {
+      await audioPlayer.pause();
+    }),
+  ]);
+
+  return async () => {
+    await Promise.all(handles.map((h) => h.remove()));
+  };
+}
+```
+
+## Step 4: Add a realistic queue and start playback
+
+```ts
+import { audioPlayer } from '@ddgutierrezc/legato-capacitor';
+
+export async function startDemoPlayback() {
+  const snapshotAfterAdd = await audioPlayer.add({
+    tracks: [
+      {
+        id: 'episode-001',
+        url: 'https://cdn.example.com/audio/episode-001.mp3',
+        title: 'Episode 1',
+        artist: 'Legato Demo',
+      },
+      {
+        id: 'episode-002',
+        url: 'https://cdn.example.com/audio/episode-002.mp3',
+        title: 'Episode 2',
+        artist: 'Legato Demo',
+      },
+    ],
+    startIndex: 0,
+  });
+
+  console.log('Queue after add:', snapshotAfterAdd.queue);
+  await audioPlayer.play();
+}
+```
+
+## Step 5: Capability checks before optional controls
+
+```ts
+const caps = await audioPlayer.getCapabilities();
+
+const canSeek = caps.supported.includes('seek');
+const canSkipNext = caps.supported.includes('skip-next');
+const canSkipPrevious = caps.supported.includes('skip-previous');
+```
+
+Render or enable seek/skip controls based on these flags instead of static assumptions.
+
+## Step 6: Final validation checklist
+
+1. `setup()` for both namespaces resolves without errors.
+2. `add(...)` returns a snapshot with expected queue items.
+3. `play()` transitions state through expected playback lifecycle events.
+4. `playback-progress` events are observed while playing.
+5. At least one remote event path (`remote-play`/`remote-pause`) is validated on target device.
+6. Error logs include `error.code` and `error.details` when failures occur.
+
+## Common mistakes
+
+- Calling `play()` before `setup()` or before adding tracks.
+- Assuming `audioPlayer.setup()` initializes media-session listeners.
+- Branching logic on `error.message` instead of stable `error.code`.
+- Showing seek controls unconditionally without checking runtime capabilities.
+- Registering listeners without removing them on teardown (duplicate handlers).
+
+## Optional native check
+
+If behavior is inconsistent at the native integration layer:
+
+```bash
+legato native doctor
+```
+
+For safe patch planning before file mutation:
+
+```bash
+legato native configure --dry-run
+```
+
+## Related pages
+
+- [Set Up Legato Capacitor](/packages/capacitor/how-to/set-up/)
+- [Listen to Events](/packages/capacitor/how-to/listen-events/)
+- [Use Sync](/packages/capacitor/how-to/use-sync/)
+- [Troubleshooting](/how-to/troubleshooting/)

--- a/apps/docs-site/src/content/docs/how-to/troubleshooting.mdx
+++ b/apps/docs-site/src/content/docs/how-to/troubleshooting.mdx
@@ -1,0 +1,98 @@
+---
+title: Troubleshooting
+description: Symptom-first troubleshooting for Legato contract and Capacitor consumers.
+---
+
+Use this guide when playback behavior is failing in a real app and you need the next correct check, not a full API explanation.
+
+## Triage order
+
+1. Capture the exact `error.code` from `playback-error` when available.
+2. Verify initialization order (`audioPlayer.setup()` and `mediaSession.setup()` as needed).
+3. Verify queue and active-track preconditions (`add(...)`, `startIndex`, `getSnapshot()`).
+4. Verify runtime capabilities before sending optional commands (`getCapabilities()`).
+5. If symptoms look native-environment-specific, run `legato native doctor`.
+
+## Error-code lookup
+
+Use `error.code` as the machine-stable branch key.
+
+| `error.code` | Most likely category | Next action |
+|---|---|---|
+| `player_not_setup` | Initialization order | Ensure `await audioPlayer.setup()` ran before playback commands. See [Set Up Legato Capacitor](/packages/capacitor/how-to/set-up/). |
+| `empty_queue` | Queue preconditions | Verify `add({ tracks: [...] })` succeeds before `play()`. Then inspect `getSnapshot().queue`. |
+| `invalid_index` | Queue addressing | Validate `skipTo({ index })`, `remove({ index })`, or `startIndex` against current queue length. |
+| `no_active_track` | Active-track selection | Re-check `startIndex` and `currentIndex` in snapshot after queue insertion. |
+| `unsupported_operation` | Capability projection | Gate UI/action on `getCapabilities().supported`. See [Capabilities](/packages/contract/reference/capabilities/). |
+| `seek_failed` | Seek runtime path | Confirm seek capability is currently supported before calling `seekTo`. |
+| `invalid_url` | Track input validity | Re-check `Track.url` value and transport-level accessibility in your environment. |
+| `load_failed` | Media loading | Re-check media URL reachability and track metadata assumptions; inspect `error.details` for adapter context. |
+| `playback_failed` | Runtime playback | Observe state transitions and error payload together (`playback-state-changed` + `playback-error`). |
+| `platform_error` | Native/platform layer | Collect `error.details`, then run `legato native doctor` for supported native checks. |
+
+## Symptom: `play()` does nothing or fails immediately
+
+1. Run `await audioPlayer.getSnapshot()` and confirm queue is not empty.
+2. Confirm setup already completed in this app lifecycle (`await audioPlayer.setup()`).
+3. Confirm an active track exists (`currentIndex !== null`, `currentTrack !== null`).
+4. Register `onPlaybackError` and branch by `error.code`.
+
+## Symptom: seek controls are visible but seek fails
+
+1. Read capabilities right before rendering/handling seek:
+
+```ts
+const caps = await audioPlayer.getCapabilities();
+const canSeek = caps.supported.includes('seek');
+```
+
+2. Hide or disable seek controls when `canSeek` is false.
+3. If `canSeek` is true but `seek_failed` occurs, log `error.details` and runtime state snapshot for diagnosis.
+
+## Symptom: remote controls do not trigger app actions
+
+1. Confirm `await mediaSession.setup()` is called (separate from `audioPlayer.setup()`).
+2. Confirm listeners are registered and retained (not garbage-collected by component teardown).
+3. Confirm you are testing on a device/context that emits media-session controls.
+4. For seek-specific remote controls, confirm `seek` capability is currently projected.
+
+## Symptom: local UI state drifts from actual playback state
+
+1. Prefer a sync controller (`createLegatoSync` or `createAudioPlayerSync`) for local projection.
+2. Ensure `sync.start()` is called once and `sync.stop()` runs on teardown.
+3. On foreground resume, run `await sync.resync()` before trusting stale UI state.
+
+## Symptom: native integration behaves differently than expected
+
+1. Run `legato native doctor` from repository context supported by the CLI.
+2. If you need a preview of safe changes, run `legato native configure --dry-run`.
+3. Apply changes intentionally with `legato native configure --apply` and re-run doctor.
+
+## Diagnostic snippet (minimal)
+
+```ts
+import {
+  audioPlayer,
+  mediaSession,
+  onPlaybackError,
+  onPlaybackStateChanged,
+} from '@ddgutierrezc/legato-capacitor';
+
+await audioPlayer.setup();
+await mediaSession.setup();
+
+onPlaybackStateChanged(({ state }) => console.log('[state]', state));
+onPlaybackError(({ error }) => {
+  console.error('[legato:error]', error.code, error.message, error.details);
+});
+
+console.log('[snapshot]', await audioPlayer.getSnapshot());
+console.log('[capabilities]', await audioPlayer.getCapabilities());
+```
+
+## Related pages
+
+- [Errors Reference](/packages/capacitor/reference/errors/)
+- [Native CLI](/packages/capacitor/reference/cli-native/)
+- [Use Sync](/packages/capacitor/how-to/use-sync/)
+- [Migration and Versioning](/how-to/migration-and-versioning/)

--- a/apps/docs-site/src/content/docs/index.mdx
+++ b/apps/docs-site/src/content/docs/index.mdx
@@ -35,21 +35,21 @@ If guidance in a README conflicts with content here, this docs site is authorita
 </Aside>
 
 <CardGrid stagger>
-  <Card title="Getting Started" icon="rocket">
+  <Card title="Getting Started" icon="rocket" href="/getting-started/">
     Choose the right package, install quickly, and complete your first
     integration flow.
   </Card>
-  <Card title="Concepts" icon="puzzle">
+  <Card title="Concepts" icon="puzzle" href="/concepts/">
     Learn the public boundary, canonical authority rules, and where maintainer
     docs live.
   </Card>
-  <Card title="Package Guides" icon="open-book">
+  <Card title="Package Guides" icon="open-book" href="/packages/">
     Find dedicated guides for the contract and Capacitor packages.
   </Card>
-  <Card title="Reference" icon="setting">
+  <Card title="Reference" icon="setting" href="/reference/">
     Use public API/reference entrypoints for integration details.
   </Card>
-  <Card title="Community" icon="star">
+  <Card title="Community" icon="star" href="/community/">
     Get contribution and support links without maintainer-only runbook details.
   </Card>
 </CardGrid>

--- a/apps/docs-site/src/content/docs/reference/compatibility.mdx
+++ b/apps/docs-site/src/content/docs/reference/compatibility.mdx
@@ -1,0 +1,96 @@
+---
+title: Compatibility
+description: Public compatibility expectations and support boundaries for Legato consumers.
+---
+
+This reference states what can be verified from public package metadata and documented API surfaces.
+
+## Scope of this matrix
+
+This page covers:
+
+- Published npm package lines for `@ddgutierrezc/legato-contract` and `@ddgutierrezc/legato-capacitor`
+- Declared dependency compatibility between those packages
+- Public scope of the `legato native` CLI shipped by `@ddgutierrezc/legato-capacitor`
+
+This page does not cover:
+
+- Guarantees about every host-app architecture or every Capacitor plugin combination
+- Runtime behavior promises beyond the documented contract/error/capability surfaces
+- Native artifact version matrices not explicitly published in public release notes
+
+## Current package line (source-backed)
+
+| Package | Source | Public version observed |
+|---|---|---|
+| `@ddgutierrezc/legato-contract` | `packages/contract/package.json` | `1.0.0` |
+| `@ddgutierrezc/legato-capacitor` | `packages/capacitor/package.json` | `1.0.0` |
+
+These values reflect repository metadata at the time this documentation snapshot was written.
+
+## Declared dependency compatibility
+
+`@ddgutierrezc/legato-capacitor` declares:
+
+- `peerDependencies["@ddgutierrezc/legato-contract"]: ^1.0.0`
+- `peerDependencies["@capacitor/core"]: ^8.0.0`
+
+Interpretation:
+
+- Capacitor consumers SHOULD align with `@ddgutierrezc/legato-contract` in the `1.x` line.
+- Capacitor host apps are expected to satisfy the `@capacitor/core` `^8.0.0` peer range.
+- Exact host-platform/version permutations are not fully enumerated here; validate in your app CI.
+
+## Contract package expectations
+
+`@ddgutierrezc/legato-contract` is library-only and defines:
+
+- Type-level contract surface (tracks, snapshots, playback state, queue model)
+- Stable event-name and payload maps
+- Stable error-code literals and capability literals
+
+Compatibility expectation for contract-only consumers:
+
+- Branch behavior on stable literals (`error.code`, capability names, event names).
+- Treat human-readable text (`error.message`) as diagnostic, not compatibility key.
+
+## Capacitor package expectations
+
+`@ddgutierrezc/legato-capacitor` re-exports contract types and provides runtime bridge APIs:
+
+- `audioPlayer` playback operations and queries
+- `mediaSession` remote-control listener surface
+- Unified `Legato` facade and listener helpers
+- Sync controller factories (`createLegatoSync`, `createAudioPlayerSync`)
+
+Compatibility expectation for runtime consumers:
+
+- Capability-dependent operations (for example seek) MUST be gated by `getCapabilities()`.
+- Event payload handling SHOULD use the documented payload maps and stable event names.
+
+## `legato native` CLI scope compatibility
+
+`legato native` is bundled from the package `bin` entry and publicly documents only the `native` command group:
+
+- `legato native doctor [--json]`
+- `legato native configure --dry-run [--json]`
+- `legato native configure --apply [--json]`
+
+Compatibility boundary:
+
+- CLI checks/mutations are intentionally narrow and repository-layout-aware.
+- It is a maintainer/integration aid for supported paths, not a generic Capacitor project migrator.
+
+## Practical alignment checklist
+
+1. Pin or resolve to a coherent package line (`contract` and `capacitor` in compatible major versions).
+2. Satisfy `@capacitor/core` peer range required by `@ddgutierrezc/legato-capacitor`.
+3. Validate event/capability assumptions in-device using your own CI smoke tests.
+4. Read release notes before upgrades: [Releases](/releases/).
+
+## Related pages
+
+- [Releases](/releases/)
+- [Migration and Versioning](/how-to/migration-and-versioning/)
+- [Contract Reference](/packages/contract/reference/)
+- [Capacitor Reference](/packages/capacitor/reference/)

--- a/apps/docs-site/src/content/docs/reference/index.mdx
+++ b/apps/docs-site/src/content/docs/reference/index.mdx
@@ -10,6 +10,10 @@ Use this section when you already know what you need and want package-level API 
 - [Contract package reference](/packages/contract/)
 - [Capacitor package reference](/packages/capacitor/)
 
+## Operational reference
+
+- [Compatibility](/reference/compatibility/)
+
 ## Scope boundary
 
 This reference surface is public and consumer-safe.

--- a/apps/docs-site/src/content/docs/releases/index.mdx
+++ b/apps/docs-site/src/content/docs/releases/index.mdx
@@ -1,9 +1,32 @@
 ---
 title: Releases
-description: Consumer-safe release notes surface sourced from the project changelog.
+description: Consumer-safe release notes surface sourced from the project changelog, with upgrade-focused guidance.
 ---
 
 This page summarizes public release highlights from [`CHANGELOG.md`](https://github.com/ddgutierrezc/legato/blob/main/CHANGELOG.md).
+
+Use it to decide whether a release affects your runtime behavior, dependency alignment, or migration work.
+
+## How to read a Legato release
+
+When you evaluate a release entry, check in this order:
+
+1. **Version matrix**: package versions and native artifact references, when provided.
+2. **User impact**: explicit behavior differences that could affect your app.
+3. **Upgrade notes**: concrete required actions or version pairings.
+4. **Breaking changes**: whether there is declared migration risk.
+5. **Durable evidence**: links to npm/Maven/iOS release records.
+
+If a release includes only partial evidence for your stack, treat it as informative and validate behavior in your own CI before production rollout.
+
+## Who should care about which changes
+
+| Change type in notes | Most affected consumers | Typical action |
+|---|---|---|
+| Contract semantics/types/events | `@ddgutierrezc/legato-contract` users (with or without Capacitor) | Re-check compile-time assumptions and event/error handling branches. |
+| Capacitor runtime behavior | `@ddgutierrezc/legato-capacitor` app integrators | Run device-level smoke tests for playback lifecycle, queue, and remote events. |
+| Native distribution alignment | Teams tracking Android/iOS native artifacts explicitly | Validate published artifact versions and repository evidence links. |
+| Governance/docs process updates | Maintainers and release operators | Confirm communication and evidence requirements are met. |
 
 ## Latest stable highlight
 
@@ -15,6 +38,21 @@ This page summarizes public release highlights from [`CHANGELOG.md`](https://git
   - `@ddgutierrezc/legato-capacitor@1.0.0`
 - Runtime parity and authenticated media request scope called out as supported baseline.
 
+Consumer action baseline for this line:
+
+- Keep `@ddgutierrezc/legato-contract` and `@ddgutierrezc/legato-capacitor` aligned in the `1.x` line.
+- For Capacitor apps, validate queue/playback/capabilities/remote controls on real target devices.
+- For contract-only users, validate event/error/capability assumptions against your adapters.
+
 ## Previous release notes
 
 For older entries (including `0.1.x` lines), read the root `CHANGELOG.md` history.
+
+## Upgrade workflow before adopting any release
+
+1. Compare your current package versions against the release version matrix.
+2. Read `Changed`, `Fixed`, and `Security` sections for behavior-impacting changes.
+3. Apply update in a branch and run your app-level playback regression checklist.
+4. If capabilities/semantics changed, re-check UI gating logic built on `getCapabilities()` and `error.code`.
+
+For a step-by-step upgrade checklist, continue with [Migration and Versioning](/how-to/migration-and-versioning/).


### PR DESCRIPTION
## Summary

- add troubleshooting, compatibility, migration/versioning, and production quickstart guidance for consumers
- deepen the releases entrypoint with more actionable upgrade framing
- make landing-page section cards clickable so the docs home acts as clearer navigation

## Linked issue

Resolves #141

## Validation

- [x] Relevant tests/checks were run
- [x] No unrelated workflows were changed

## Policy checks

- [x] Exactly one `type:*` label added
- [x] Approved issue linked when required (`status:approved`)
