### PR TITLE
docs(site): add guided onboarding paths

### DIFF
--- a/apps/docs-site/src/content/docs/getting-started/golden-paths.mdx
+++ b/apps/docs-site/src/content/docs/getting-started/golden-paths.mdx
@@ -1,0 +1,124 @@
+---
+title: Golden Paths
+description: Closed onboarding paths by profile for contract-first, Capacitor runtime-first, and production hardening flows.
+---
+
+import { Card, CardGrid, Steps } from '@astrojs/starlight/components';
+
+Use this guide when you want a practical path instead of browsing docs section by section.
+
+## How to use this page
+
+1. Pick one path based on your current risk surface.
+2. Follow the sequence without skipping steps.
+3. Stop when you reach the expected outcome.
+4. Move to the next level only when the "level up" signal is true in your app.
+
+## Path 1: Contract-first
+
+### When to choose it
+
+- Your first problem is semantic consistency across app layers.
+- You need stable shared models for tracks, snapshots, events, errors, and capabilities.
+- Runtime plugin wiring is not your immediate blocker.
+
+### Recommended sequence
+
+<Steps>
+
+1. Read [Why Contract-First](/packages/contract/explanation/why-contract-first/) to align on boundaries.
+2. Read [Snapshot Model](/packages/contract/explanation/snapshot-model/) to avoid nullability mistakes.
+3. Implement one track using [Model a Track](/packages/contract/how-to/model-a-track/).
+4. Add typed event handling with [Consume Events and Payloads](/packages/contract/how-to/consume-events-and-payloads/).
+5. Add defensive checks with [Validate Runtime Invariants](/packages/contract/how-to/validate-runtime-invariants/).
+
+</Steps>
+
+### Expected outcome
+
+You have contract-aligned app logic that can evolve independently from runtime transport details.
+
+### Level up when
+
+- You now need real device playback controls or media-session integration.
+- Your app team is blocked by runtime behavior rather than model semantics.
+
+## Path 2: Capacitor runtime-first
+
+### When to choose it
+
+- You already need runtime playback commands and listener wiring on device.
+- You need `audioPlayer` and `mediaSession` behavior validated in a real host app.
+- Your immediate risk is setup/order, queue lifecycle, and remote event handling.
+
+### Recommended sequence
+
+<Steps>
+
+1. Start with [Set Up Legato Capacitor](/packages/capacitor/how-to/set-up/).
+2. Run [Play a Track](/packages/capacitor/how-to/play-track/) to validate queue + playback flow.
+3. Add listeners with [Listen to Events](/packages/capacitor/how-to/listen-events/).
+4. Add UI gating with [Build Capability-Driven Controls](/packages/capacitor/how-to/capability-driven-controls/).
+5. Align local state with [Use Sync Controllers](/packages/capacitor/how-to/use-sync/).
+
+</Steps>
+
+### Expected outcome
+
+You have a runtime-integrated flow with explicit setup, event handling, and capability-gated controls.
+
+### Level up when
+
+- You are preparing rollout and upgrade safety checks.
+- You need repeatable production confidence across app and CI.
+
+## Path 3: Production hardening
+
+### When to choose it
+
+- You already have an integration and need safer rollout confidence.
+- Your main risk is hidden assumptions during upgrades or capability handling.
+- You need explicit compatibility and migration checks before production promotion.
+
+### Recommended sequence
+
+<Steps>
+
+1. Execute [Production Quickstart (Capacitor)](/how-to/production-quickstart-capacitor/) as a baseline flow.
+2. Review [Compatibility](/reference/compatibility/) and validate your package line assumptions.
+3. Run [Migration and Versioning](/how-to/migration-and-versioning/) checklists for your consumer profile.
+4. Keep [Troubleshooting](/how-to/troubleshooting/) open while validating error and event paths.
+5. Review [Releases](/releases/) before every upgrade rollout.
+
+</Steps>
+
+### Expected outcome
+
+You operate with explicit rollout gates: capability checks, stable literal branching, and release-aware validation.
+
+### Level up when
+
+- Your team can validate upgrades with clear pass/fail criteria on CI and real devices.
+- Regressions are diagnosed via stable `error.code` and documented event/capability surfaces.
+
+## Common onboarding anti-patterns
+
+- Starting with runtime commands before agreeing on shared contract semantics.
+- Treating contract types as runtime execution APIs.
+- Assuming capabilities (for example `seek`) from media metadata instead of `getCapabilities()`.
+- Branching behavior on `error.message` text instead of stable `error.code` literals.
+- Reading release notes after dependency upgrades instead of before rollout planning.
+
+## Choose and continue
+
+<CardGrid>
+  <Card title="Need help choosing?" icon="rocket" href="/getting-started/">
+    Return to the decision hub and use the quick chooser.
+  </Card>
+  <Card title="Contract package guide" icon="puzzle" href="/packages/contract/">
+    Jump to contract documentation sections.
+  </Card>
+  <Card title="Capacitor package guide" icon="play" href="/packages/capacitor/">
+    Jump to Capacitor runtime documentation sections.
+  </Card>
+</CardGrid>

--- a/apps/docs-site/src/content/docs/getting-started/index.mdx
+++ b/apps/docs-site/src/content/docs/getting-started/index.mdx
@@ -1,13 +1,17 @@
 ---
 title: Getting Started
-description: Install Legato packages, choose the right surface, and complete your first integration.
+description: Decision hub to choose your first Legato path and execute a practical onboarding flow.
 ---
 
 import { Card, CardGrid, Steps } from '@astrojs/starlight/components';
 
-Legato provides two public packages for continuous audio playback integrations.
+Use this page as a decision hub. In a few minutes you should know which path to run first:
 
-## Start with the problem, not the package
+- Contract-first
+- Capacitor runtime-first
+- Production confidence hardening
+
+## Start with the risk, not the package
 
 Pick a package based on where your integration risk lives:
 
@@ -16,20 +20,37 @@ Pick a package based on where your integration risk lives:
 
 Legato is intentionally layered: `legato-contract` gives the vocabulary, `legato-capacitor` gives a concrete runtime integration.
 
-## Package decision matrix
+## Decision matrix
 
 | If you need... | Install | Why this is the fit |
 |---|---|---|
 | Shared playback events, snapshots, and invariants across multiple runtimes or app layers | `@ddgutierrezc/legato-contract` | You can stabilize app logic first without coupling it to Capacitor runtime APIs. |
 | Hybrid app playback with Capacitor runtime integration (`audioPlayer`, `mediaSession`) | `@ddgutierrezc/legato-capacitor` + `@ddgutierrezc/legato-contract` | You need runtime commands/listeners, while still reusing the same shared contract semantics. |
+| Rollout safety and upgrade confidence for existing integrations | Usually both packages + your app validation layer | Your main risk is release behavior drift, capability assumptions, and non-explicit compatibility decisions. |
 
-## Decision aid
+## Quick chooser
 
-Use this quick checklist:
+Choose the first path that is true:
 
-- Are you designing a playback domain model shared by frontend, services, or tests? Start with `@ddgutierrezc/legato-contract`.
-- Do you need native runtime control surfaces today (playback commands, media-session events)? Add `@ddgutierrezc/legato-capacitor`.
-- Do you expect to evolve from app-logic validation into native integration? Start contract-first, then add Capacitor when runtime concerns become real.
+1. You are defining shared playback semantics first (types, events, invariants) -> start with `@ddgutierrezc/legato-contract`.
+2. You already need device/runtime controls now (play, pause, remote events, media session) -> start with `@ddgutierrezc/legato-capacitor` and `@ddgutierrezc/legato-contract`.
+3. You already run in production and your main concern is safe upgrades and confidence gates -> start with the production confidence path.
+
+## Next 15 minutes
+
+<CardGrid>
+  <Card title="Contract-first" icon="puzzle" href="/getting-started/golden-paths/#path-1-contract-first">
+    Read the contract rationale, model one track, and validate invariant usage.
+  </Card>
+  <Card title="Capacitor runtime-first" icon="play" href="/getting-started/golden-paths/#path-2-capacitor-runtime-first">
+    Set up the plugin, run first queue playback, and attach essential listeners.
+  </Card>
+  <Card title="Production confidence" icon="lock" href="/getting-started/golden-paths/#path-3-production-hardening">
+    Execute compatibility and migration checks before broad rollout.
+  </Card>
+</CardGrid>
+
+- Full guided sequences: [Golden Paths](/getting-started/golden-paths/)
 
 ## Typical scenarios and tradeoffs
 
@@ -59,6 +80,8 @@ You can start by making your app logic consume contract snapshots/events, then p
 - Picking `@ddgutierrezc/legato-capacitor` only because "we might need native later" while no runtime integration exists yet.
 - Treating `@ddgutierrezc/legato-contract` as a full runtime solution; it does not provide playback execution APIs.
 - Delaying contract modeling until after runtime wiring, then retrofitting app logic to shared types under time pressure.
+- Treating a finite `duration` as seek support; seek is capability-projected at runtime.
+- Upgrading dependencies without validating `error.code`, capability literals, and setup lifecycle assumptions.
 
 ## Install
 
@@ -82,18 +105,18 @@ You can start by making your app logic consume contract snapshots/events, then p
 
 </Steps>
 
-## Next steps
+## Recommended follow-up
 
 <CardGrid>
-  <Card title="Contract-first rationale" icon="puzzle">Read why Legato separates shared semantics from runtime implementation details.</Card>
-  <Card title="Snapshot mental model" icon="open-book">Understand how to interpret nullable and projected playback state before building UI.</Card>
-  <Card title="Capability projection" icon="lightbulb">Learn why runtime-supported controls must come from capability projections.</Card>
-  <Card title="Join community channels" icon="star">Get contribution and support links in the Community section.</Card>
+  <Card title="Golden Paths" icon="open-book" href="/getting-started/golden-paths/">Run a profile-based onboarding sequence with explicit outcomes.</Card>
+  <Card title="Contract-first rationale" icon="puzzle" href="/packages/contract/explanation/why-contract-first/">Understand why shared semantics come before runtime specifics.</Card>
+  <Card title="Capability projection" icon="lightbulb" href="/packages/capacitor/explanation/capability-projection/">Avoid static runtime assumptions when enabling controls.</Card>
+  <Card title="Production quickstart" icon="lock" href="/how-to/production-quickstart-capacitor/">Validate a realistic production-oriented integration flow.</Card>
 </CardGrid>
 
-- [Why Contract-First](../packages/contract/explanation/why-contract-first/)
 - [Snapshot Model](../packages/contract/explanation/snapshot-model/)
-- [Capability Projection](../packages/capacitor/explanation/capability-projection/)
+- [Migration and Versioning](../how-to/migration-and-versioning/)
+- [Compatibility](../reference/compatibility/)
 
 ## Support and community
 

--- a/apps/docs-site/src/content/docs/index.mdx
+++ b/apps/docs-site/src/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: Legato Documentation
 description: Canonical public documentation for Legato package consumers.
 template: splash
 hero:
-  tagline: Build continuous audio playback with a clear first decision: contract-first modeling, Capacitor runtime integration, or production hardening confidence.
+  tagline: "Build continuous audio playback with a clear first decision: contract-first modeling, Capacitor runtime integration, or production hardening confidence."
   actions:
     - text: Choose your path
       link: /getting-started/

--- a/apps/docs-site/src/content/docs/index.mdx
+++ b/apps/docs-site/src/content/docs/index.mdx
@@ -3,15 +3,19 @@ title: Legato Documentation
 description: Canonical public documentation for Legato package consumers.
 template: splash
 hero:
-  tagline: Build continuous audio playback integrations with clear package guidance, reference entrypoints, and release-safe public documentation.
+  tagline: Build continuous audio playback with a clear first decision: contract-first modeling, Capacitor runtime integration, or production hardening confidence.
   actions:
-    - text: Start here
+    - text: Choose your path
       link: /getting-started/
       icon: right-arrow
+    - text: Open golden paths
+      link: /getting-started/golden-paths/
+      icon: open-book
+      variant: secondary
     - text: View source on GitHub
       link: https://github.com/ddgutierrezc/legato
       icon: github
-      variant: secondary
+      variant: minimal
 ---
 
 import { Aside, Card, CardGrid } from "@astrojs/starlight/components";
@@ -29,15 +33,40 @@ import { Aside, Card, CardGrid } from "@astrojs/starlight/components";
 This site is the **canonical public surface** for Legato documentation.
 If guidance in a README conflicts with content here, this docs site is authoritative.
 
+Legato gives you two layers with one goal: predictable playback integrations.
+
+- `@ddgutierrezc/legato-contract` defines shared semantics (tracks, snapshots, events, errors, capabilities, invariants).
+- `@ddgutierrezc/legato-capacitor` adds runtime integration (`audioPlayer`, `mediaSession`, listeners, sync helpers).
+- Production confidence comes from capability-gated UI, release-aware upgrades, and explicit compatibility checks.
+
 <Aside type="note">
   Maintainer operations, release evidence, and architecture spikes remain in
   root `docs/` and are intentionally not exposed in this public navigation.
 </Aside>
 
+## Choose your path
+
+<CardGrid stagger>
+  <Card title="Start with the contract" icon="puzzle" href="/packages/contract/">
+    Choose this when your first risk is shared semantics across app layers.
+    Stabilize events, snapshots, and invariants before wiring runtime details.
+  </Card>
+  <Card title="Integrate with Capacitor" icon="play" href="/packages/capacitor/">
+    Choose this when your first risk is native runtime behavior. Set up plugin
+    surfaces, playback commands, and media-session listeners with contract
+    semantics already aligned.
+  </Card>
+  <Card title="Harden for production" icon="lock" href="/how-to/production-quickstart-capacitor/">
+    Choose this when you need rollout confidence: capability-gated controls,
+    upgrade checklists, and compatibility boundaries validated in your CI.
+  </Card>
+</CardGrid>
+
+If you want an opinionated sequence, use [Golden Paths](/getting-started/golden-paths/).
+
 <CardGrid stagger>
   <Card title="Getting Started" icon="rocket" href="/getting-started/">
-    Choose the right package, install quickly, and complete your first
-    integration flow.
+    Use the decision hub to pick your path and plan your first 15 minutes.
   </Card>
   <Card title="Concepts" icon="puzzle" href="/concepts/">
     Learn the public boundary, canonical authority rules, and where maintainer
@@ -56,6 +85,8 @@ If guidance in a README conflicts with content here, this docs site is authorita
 
 ## Need help or want to connect?
 
+- Decision hub: [Getting Started](/getting-started/)
+- Guided flows: [Golden Paths](/getting-started/golden-paths/)
 - Community hub: [Community](./community/)
 - Discord: [https://discord.com/invite/Hhnumyk2N](https://discord.com/invite/Hhnumyk2N)
 - LinkedIn: [https://www.linkedin.com/in/ddgutierrezc](https://www.linkedin.com/in/ddgutierrezc)


### PR DESCRIPTION
## Summary

- turn the landing and getting-started pages into clearer decision surfaces
- add a new Golden Paths page with closed onboarding routes for contract-first, Capacitor runtime-first, and production hardening flows
- reduce onboarding friction with faster path selection and better next-step guidance

## Linked issue

Refs #136

## Validation

- [x] Relevant tests/checks were run
- [x] No unrelated workflows were changed

## Policy checks

- [x] Exactly one `type:*` label added
- [x] Approved issue linked when required (`status:approved`)
