### PR TITLE
docs(site): add architecture overview section

### DIFF
--- a/apps/docs-site/astro.config.mjs
+++ b/apps/docs-site/astro.config.mjs
@@ -28,7 +28,10 @@ export default defineConfig({
 				},
 				{
 					label: 'Concepts',
-					items: [{ label: 'Public vs Maintainer Boundaries', slug: 'concepts' }],
+					items: [
+						{ label: 'Public vs Maintainer Boundaries', slug: 'concepts' },
+						{ label: 'Architecture', slug: 'explanation/architecture' },
+					],
 				},
 				{
 					label: 'Package Guides',

--- a/apps/docs-site/src/content/docs/concepts/index.mdx
+++ b/apps/docs-site/src/content/docs/concepts/index.mdx
@@ -23,3 +23,12 @@ Legato documentation follows three audience classes:
 Do not import or link maintainer runbook files into public docs pages.
 Public pages should stay consumer-safe and avoid operational internals.
 </Aside>
+
+## System architecture concepts
+
+Use the architecture explanation set when you need system-level reasoning across contract semantics and runtime integration:
+
+- [Architecture](../explanation/architecture/)
+- [System Overview](../explanation/architecture/system-overview/)
+- [Contract and Runtime Boundaries](../explanation/architecture/contract-and-runtime-boundaries/)
+- [Guarantees and Non-Guarantees](../explanation/architecture/guarantees-and-non-guarantees/)

--- a/apps/docs-site/src/content/docs/explanation/architecture/contract-and-runtime-boundaries.mdx
+++ b/apps/docs-site/src/content/docs/explanation/architecture/contract-and-runtime-boundaries.mdx
@@ -1,0 +1,67 @@
+---
+title: Contract and Runtime Boundaries
+description: Why Legato separates shared semantics from runtime integration, and what this separation protects.
+---
+
+Legato separates semantic authority from runtime execution authority on purpose.
+
+This is not a packaging preference. It is an architectural control that keeps product behavior stable while runtime integration evolves.
+
+## Why the separation exists
+
+Playback systems fail at interpretation seams:
+
+- one layer calls something "seekable" because duration is finite,
+- another layer treats seek as unavailable at runtime,
+- and product logic silently drifts into contradictory assumptions.
+
+Legato addresses this by fixing shared meaning in the contract package and keeping runtime adaptation in the integration package.
+
+## What lives on the contract side
+
+`@ddgutierrezc/legato-contract` defines cross-layer meaning:
+
+- event-name literals and payload maps,
+- snapshot and queue read-model shapes,
+- playback-state literals,
+- error-code literals,
+- capability vocabulary and invariant expectations.
+
+Contract scope answers: "What does this value mean everywhere?"
+
+## What lives on the runtime side
+
+`@ddgutierrezc/legato-capacitor` and the native plugin boundary define runtime integration behavior:
+
+- command execution (`play`, `pause`, `seekTo`, queue operations),
+- listener transport from native to app,
+- capability projection at the moment of observation,
+- and platform-dependent playback outcomes.
+
+Runtime scope answers: "What happens now on this platform/session/context?"
+
+## Problems this boundary avoids
+
+This split reduces common architectural failures:
+
+- **Semantic drift**: app modules interpreting the same event/snapshot differently.
+- **Runtime leakage**: domain rules coupled to plugin quirks instead of contract semantics.
+- **Refactor blast radius**: runtime changes forcing unrelated business-policy rewrites.
+- **False entitlement assumptions**: treating capability names as permanently available features.
+
+## Design consequence
+
+The boundary encourages a durable pattern:
+
+- branch app logic on contract-stable literals and shapes,
+- branch availability on runtime projection (`getCapabilities()`),
+- and keep transport/native details behind the integration layer.
+
+That pattern is what lets Legato remain portable without flattening real runtime differences.
+
+## Related pages
+
+- [Architecture](./)
+- [System Overview](./system-overview/)
+- [Guarantees and Non-Guarantees](./guarantees-and-non-guarantees/)
+- [Why Contract-First](../../packages/contract/explanation/why-contract-first/)

--- a/apps/docs-site/src/content/docs/explanation/architecture/guarantees-and-non-guarantees.mdx
+++ b/apps/docs-site/src/content/docs/explanation/architecture/guarantees-and-non-guarantees.mdx
@@ -1,0 +1,55 @@
+---
+title: Guarantees and Non-Guarantees
+description: Stable guarantees versus runtime-dependent behavior in Legato integrations.
+---
+
+This page is a mental safety boundary.
+
+Use it to decide what you can rely on as stable contract behavior and what you must treat as runtime-dependent.
+
+## Stable guarantees (contract-safe assumptions)
+
+These are documented public contract anchors:
+
+- **Stable event-name vocabulary** via `LEGATO_EVENT_NAMES` (`playback-*`, `remote-*`).
+- **Stable event payload shapes** via `LegatoEventPayloadMap` (for example `playback-progress`, `playback-error`, `remote-seek`).
+- **Stable error-code literals** via `LEGATO_ERROR_CODES` for machine-readable branching.
+- **Stable snapshot structural model** via `PlaybackSnapshot` / `QueueSnapshot` fields and nullability semantics.
+- **Stable capability vocabulary** via `CAPABILITIES` as allowed names.
+
+In practice: treat these symbols and shapes as compatibility keys across app layers.
+
+## Non-guarantees (runtime-dependent behavior)
+
+These are explicitly NOT guaranteed by contract semantics alone:
+
+- **Event ordering guarantees across all runtimes**: event names and payload types are stable; global ordering guarantees are not documented as universal.
+- **Retry policy guarantees**: no public contract promise defines automatic retry behavior for runtime failures.
+- **Permanent capability support**: capability names are stable, but support is projected dynamically by `getCapabilities().supported`.
+- **Seek entitlement from duration alone**: finite `duration` indicates media length evidence, not seek permission by itself.
+- **Universal platform parity**: native/runtime behavior can differ while still projecting into the same contract model.
+
+In practice: runtime observation is authoritative for availability and timing behavior.
+
+## Safe reasoning model
+
+Use a two-key model when designing product logic:
+
+1. **Meaning key**: contract literals/types define what values mean.
+2. **Availability key**: runtime projection defines what operations are possible now.
+
+If these keys are mixed, false assumptions appear quickly (for example enabling seek from timeline metadata only).
+
+## Examples
+
+- Handle errors by `error.code`, not by parsing `error.message` text.
+- Subscribe using known event names and typed payloads, but do not hardcode a global event sequencing assumption.
+- Enable seek controls only when `supported.includes('seek')` is true, even if `duration` is finite.
+
+## Related pages
+
+- [Architecture](./)
+- [System Overview](./system-overview/)
+- [Contract and Runtime Boundaries](./contract-and-runtime-boundaries/)
+- [Capability Projection](../../packages/capacitor/explanation/capability-projection/)
+- [Snapshots Reference](../../packages/contract/reference/snapshots/)

--- a/apps/docs-site/src/content/docs/explanation/architecture/index.mdx
+++ b/apps/docs-site/src/content/docs/explanation/architecture/index.mdx
@@ -1,0 +1,34 @@
+---
+title: Architecture
+description: System-level architecture explanation for Legato as a contract-plus-runtime platform.
+---
+
+This section explains Legato as a system, not as an isolated package API.
+
+Use it to understand:
+
+- how responsibility is split between app code, shared contract semantics, Capacitor integration, and native runtime execution,
+- why those boundaries exist,
+- and which behaviors are stable guarantees versus runtime-dependent outcomes.
+
+## Architecture map
+
+| Page | Focus |
+|------|-------|
+| **[System Overview](./system-overview/)** | High-level layer model and responsibility split across consumer app, contract package, Capacitor package, and runtime/native layer. |
+| **[Contract and Runtime Boundaries](./contract-and-runtime-boundaries/)** | Why Legato separates shared semantics from integration mechanics, and which failure modes that boundary prevents. |
+| **[Guarantees and Non-Guarantees](./guarantees-and-non-guarantees/)** | Mental safety model for what is stable by contract and what remains runtime-dependent. |
+
+## When to read this first
+
+Read this architecture section before large integrations if you need to:
+
+- align product and platform teams on stable semantics,
+- avoid coupling UI policy to runtime quirks,
+- or make explicit risk decisions around capability projection and event handling.
+
+## Related pages
+
+- [Concepts](../../concepts/)
+- [Why Contract-First](../../packages/contract/explanation/why-contract-first/)
+- [Capability Projection](../../packages/capacitor/explanation/capability-projection/)

--- a/apps/docs-site/src/content/docs/explanation/architecture/system-overview.mdx
+++ b/apps/docs-site/src/content/docs/explanation/architecture/system-overview.mdx
@@ -1,0 +1,78 @@
+---
+title: System Overview
+description: High-level architecture view of Legato across consumer app logic, shared contract semantics, Capacitor integration, and runtime execution.
+---
+
+Legato is a layered playback system with explicit semantic and runtime boundaries.
+
+At a high level, the consumer app reads and reacts to shared semantics, while runtime-specific code executes playback and projects runtime state back into those semantics.
+
+## Layer model
+
+```mermaid
+flowchart TD
+  A[Consumer App\nUI + product policy] --> B[@ddgutierrezc/legato-contract\nshared semantics]
+  A --> C[@ddgutierrezc/legato-capacitor\nruntime facade]
+  C --> D[Capacitor plugin boundary\nLegato registerPlugin]
+  D --> E[Native runtime layer\nplatform media stack]
+  E --> D
+  D --> C
+  C --> A
+```
+
+## Responsibilities by layer
+
+### Consumer app
+
+The application owns product policy and user experience decisions:
+
+- deciding how to render controls and state,
+- deciding fallback behavior on errors,
+- and deciding how often to read runtime capability projection.
+
+The app SHOULD treat contract-level literals and payload shapes as compatibility anchors.
+
+### `@ddgutierrezc/legato-contract`
+
+The contract package defines shared semantics without transport/runtime execution:
+
+- stable event-name vocabulary (`LEGATO_EVENT_NAMES`),
+- stable payload maps (`LegatoEventPayloadMap`),
+- stable error-code literals (`LEGATO_ERROR_CODES`),
+- stable capability vocabulary (`CAPABILITIES`),
+- and snapshot/state/queue type semantics (`PlaybackSnapshot`, `QueueSnapshot`, `PlaybackState`).
+
+This is the semantic source of truth for cross-layer interpretation.
+
+### `@ddgutierrezc/legato-capacitor`
+
+The Capacitor package is the runtime integration facade:
+
+- it re-exports contract types for typed consumption,
+- exposes command/query surfaces (`audioPlayer`, `mediaSession`, `Legato`),
+- and forwards typed listener registration to the plugin boundary.
+
+It does not redefine contract meaning; it projects runtime behavior into the contract model.
+
+### Runtime/native layer
+
+The runtime/native layer executes playback and media-session behavior through the Capacitor plugin.
+
+It owns dynamic outcomes such as:
+
+- whether a capability is currently supported,
+- when specific runtime events are emitted,
+- and platform-specific execution details hidden behind the plugin API.
+
+## Read/write direction
+
+- Write direction: app issues commands through the Capacitor surface.
+- Read direction: app consumes snapshots/events/error payloads shaped by contract semantics.
+
+This split lets product code stay anchored to stable meaning while runtime execution remains replaceable.
+
+## Related pages
+
+- [Architecture](./)
+- [Contract and Runtime Boundaries](./contract-and-runtime-boundaries/)
+- [Guarantees and Non-Guarantees](./guarantees-and-non-guarantees/)


### PR DESCRIPTION
## Summary

- add a new architecture explanation section for Legato as a system
- explain the layer model, contract/runtime boundaries, and stable guarantees versus runtime-dependent behavior
- expose the architecture section from concepts and navigation for better discoverability

## Linked issue

Resolves #144

## Validation

- [x] Relevant tests/checks were run
- [x] No unrelated workflows were changed

## Policy checks

- [x] Exactly one `type:*` label added
- [x] Approved issue linked when required (`status:approved`)
