### PR TITLE
docs(site): improve package and support entrypoints

### DIFF
--- a/apps/docs-site/src/content/docs/getting-started/index.mdx
+++ b/apps/docs-site/src/content/docs/getting-started/index.mdx
@@ -11,6 +11,8 @@ Use this page as a decision hub. In a few minutes you should know which path to 
 - Capacitor runtime-first
 - Production confidence hardening
 
+Before choosing a package path, review the public [Compatibility and Support Matrix](/reference/compatibility/) for supported lines and peer ranges.
+
 ## Start with the risk, not the package
 
 Pick a package based on where your integration risk lives:
@@ -116,7 +118,7 @@ You can start by making your app logic consume contract snapshots/events, then p
 
 - [Snapshot Model](../packages/contract/explanation/snapshot-model/)
 - [Migration and Versioning](../how-to/migration-and-versioning/)
-- [Compatibility](../reference/compatibility/)
+- [Compatibility and Support Matrix](../reference/compatibility/)
 
 ## Support and community
 

--- a/apps/docs-site/src/content/docs/packages/capacitor/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/index.mdx
@@ -7,6 +7,8 @@ import { Aside, Card, CardGrid } from '@astrojs/starlight/components';
 
 Use `@ddgutierrezc/legato-capacitor` when you need Capacitor runtime integration for audio playback on iOS and Android.
 
+For package-line support and peer dependency compatibility, use the public [Compatibility and Support Matrix](/reference/compatibility/).
+
 ## What is legato-capacitor?
 
 A Capacitor plugin that exposes Legato playback APIs to web and hybrid JavaScript runtimes. It provides:

--- a/apps/docs-site/src/content/docs/packages/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/index.mdx
@@ -1,0 +1,37 @@
+---
+title: Packages
+description: Public package hub to choose the right Legato package path for your integration risk.
+---
+
+import { Card, CardGrid } from '@astrojs/starlight/components';
+
+Use this hub when you need to decide which Legato package to adopt first.
+
+For the canonical package support view, use the [Compatibility and Support Matrix](/reference/compatibility/).
+
+## Package chooser
+
+| If your first risk is... | Start with | Why |
+|---|---|---|
+| Shared playback semantics across layers (events, snapshots, invariants) | [`@ddgutierrezc/legato-contract`](/packages/contract/) | You stabilize app vocabulary and behavior assumptions before runtime wiring. |
+| Native playback runtime integration in a Capacitor app (commands, media session, listeners) | [`@ddgutierrezc/legato-capacitor`](/packages/capacitor/) + `@ddgutierrezc/legato-contract` | You get runtime APIs while keeping the same shared contract model across app layers. |
+
+## Package guides
+
+<CardGrid>
+  <Card title="Contract package" icon="puzzle" href="/packages/contract/">
+    Contract-only surface for tracks, snapshots, events, errors, capabilities, and invariants.
+  </Card>
+  <Card title="Capacitor package" icon="play" href="/packages/capacitor/">
+    Capacitor runtime integration for `audioPlayer`, `mediaSession`, listeners, and sync helpers.
+  </Card>
+</CardGrid>
+
+## Before you install
+
+1. Pick the package from your integration risk, not from future guesses.
+2. If you choose Capacitor, keep `@ddgutierrezc/legato-contract` aligned to the same supported line.
+3. Review [Releases](/releases/) before upgrades so you can validate version matrix and user impact in your CI.
+4. Confirm final compatibility assumptions in the [Compatibility and Support Matrix](/reference/compatibility/).
+
+If you want an opinionated onboarding sequence, continue with [Golden Paths](/getting-started/golden-paths/).

--- a/apps/docs-site/src/content/docs/reference/compatibility.mdx
+++ b/apps/docs-site/src/content/docs/reference/compatibility.mdx
@@ -1,9 +1,11 @@
 ---
-title: Compatibility
-description: Public compatibility expectations and support boundaries for Legato consumers.
+title: Compatibility and Support Matrix
+description: Public compatibility matrix and support boundaries for Legato packages and consumers.
 ---
 
-This reference states what can be verified from public package metadata and documented API surfaces.
+This page is the public source of truth for Legato package compatibility and support boundaries.
+
+Use this matrix before installs or upgrades to confirm supported package lines and peer dependency expectations.
 
 ## Scope of this matrix
 

--- a/apps/docs-site/src/content/docs/reference/index.mdx
+++ b/apps/docs-site/src/content/docs/reference/index.mdx
@@ -5,6 +5,8 @@ description: Public API and integration reference entrypoint for Legato package 
 
 Use this section when you already know what you need and want package-level API entrypoints.
 
+If you still need to choose the right package path, start in [Packages](/packages/) before diving into API-level pages.
+
 ## Package references
 
 - [Contract package reference](/packages/contract/)

--- a/apps/docs-site/src/content/docs/releases/index.mdx
+++ b/apps/docs-site/src/content/docs/releases/index.mdx
@@ -7,6 +7,14 @@ This page summarizes public release highlights from [`CHANGELOG.md`](https://git
 
 Use it to decide whether a release affects your runtime behavior, dependency alignment, or migration work.
 
+## Start here before any upgrade
+
+1. Open the target entry in `CHANGELOG.md` and confirm the exact package line you plan to adopt.
+2. Check whether your integration is contract-only, Capacitor runtime, or both.
+3. Validate version pairings in a branch before production rollout.
+
+If you are new to package selection, use the [Packages hub](/packages/) first.
+
 ## How to read a Legato release
 
 When you evaluate a release entry, check in this order:
@@ -18,6 +26,23 @@ When you evaluate a release entry, check in this order:
 5. **Durable evidence**: links to npm/Maven/iOS release records.
 
 If a release includes only partial evidence for your stack, treat it as informative and validate behavior in your own CI before production rollout.
+
+## What to evaluate by consumer profile
+
+### Contract-only consumers (`@ddgutierrezc/legato-contract`)
+
+- Prioritize `Changed` entries that affect semantics, events, capabilities, or error expectations.
+- Re-run compile-time checks and contract-centered tests that depend on event payloads and invariants.
+
+### Capacitor app consumers (`@ddgutierrezc/legato-capacitor` + contract)
+
+- Prioritize runtime behavior notes, native artifact alignment, and setup lifecycle expectations.
+- Re-run real-device smoke tests for playback lifecycle, queue updates, remote controls, and capability gating.
+
+### Release operators / maintainers
+
+- Prioritize evidence links and distribution parity claims across npm, Maven, and iOS release records.
+- Keep release communications aligned with factual `CHANGELOG.md` claims only.
 
 ## Who should care about which changes
 
@@ -48,6 +73,8 @@ Consumer action baseline for this line:
 
 For older entries (including `0.1.x` lines), read the root `CHANGELOG.md` history.
 
+- Changelog source of truth: [`CHANGELOG.md`](https://github.com/ddgutierrezc/legato/blob/main/CHANGELOG.md)
+
 ## Upgrade workflow before adopting any release
 
 1. Compare your current package versions against the release version matrix.
@@ -56,3 +83,5 @@ For older entries (including `0.1.x` lines), read the root `CHANGELOG.md` histor
 4. If capabilities/semantics changed, re-check UI gating logic built on `getCapabilities()` and `error.code`.
 
 For a step-by-step upgrade checklist, continue with [Migration and Versioning](/how-to/migration-and-versioning/).
+
+For package selection and role boundaries, use [Packages](/packages/) and [Getting Started](/getting-started/).


### PR DESCRIPTION
## Summary

- add a real `/packages/` hub to remove a dead-end and improve package discovery
- make the compatibility page read more clearly as a support matrix and expose it from key entrypoints
- make releases and reference entrypoints more consumer-oriented and easier to navigate

## Linked issue

Resolves #148

## Validation

- [x] Relevant tests/checks were run
- [x] No unrelated workflows were changed

## Policy checks

- [x] Exactly one `type:*` label added
- [x] Approved issue linked when required (`status:approved`)
