### PR TITLE
docs(site): polish navigation and support guidance

### DIFF
--- a/apps/docs-site/src/content/docs/explanation/architecture/consumer-state-model.mdx
+++ b/apps/docs-site/src/content/docs/explanation/architecture/consumer-state-model.mdx
@@ -74,5 +74,5 @@ This structure minimizes coupling and makes upgrades safer because each branch d
 
 - [Playback Lifecycle](./playback-lifecycle/)
 - [Guarantees and Non-Guarantees](./guarantees-and-non-guarantees/)
-- [Snapshot Model](/packages/contract/explanation/snapshot-model/)
-- [Capability Projection](/packages/capacitor/explanation/capability-projection/)
+- [Snapshot Model](../../../packages/contract/explanation/snapshot-model/)
+- [Capability Projection](../../../packages/capacitor/explanation/capability-projection/)

--- a/apps/docs-site/src/content/docs/explanation/architecture/integration-evolution.mdx
+++ b/apps/docs-site/src/content/docs/explanation/architecture/integration-evolution.mdx
@@ -64,10 +64,10 @@ That is expected. Maturity is a capability to revisit boundaries deliberately, n
 
 The architecture view here explains the "why" behind operational pages:
 
-- [Golden Paths](/getting-started/golden-paths/) describe profile-based entry points,
-- [Production Quickstart (Capacitor)](/how-to/production-quickstart-capacitor/) demonstrates baseline runtime hardening flow,
-- [Migration and Versioning](/how-to/migration-and-versioning/) covers upgrade execution checks,
-- [Releases](/releases/) provides release-level evidence and upgrade context.
+- [Golden Paths](../../../getting-started/golden-paths/) describe profile-based entry points,
+- [Production Quickstart (Capacitor)](../../../how-to/production-quickstart-capacitor/) demonstrates baseline runtime hardening flow,
+- [Migration and Versioning](../../../how-to/migration-and-versioning/) covers upgrade execution checks,
+- [Releases](../../../releases/) provides release-level evidence and upgrade context.
 
 Use those pages for execution details; use this model to keep the long-term integration strategy coherent.
 

--- a/apps/docs-site/src/content/docs/explanation/architecture/playback-lifecycle.mdx
+++ b/apps/docs-site/src/content/docs/explanation/architecture/playback-lifecycle.mdx
@@ -88,5 +88,5 @@ Legato's public model encourages the opposite:
 
 - [Consumer State Model](./consumer-state-model/)
 - [Guarantees and Non-Guarantees](./guarantees-and-non-guarantees/)
-- [Use Sync Controllers](/packages/capacitor/how-to/use-sync/)
-- [Production Quickstart (Capacitor)](/how-to/production-quickstart-capacitor/)
+- [Use Sync Controllers](../../../packages/capacitor/how-to/use-sync/)
+- [Production Quickstart (Capacitor)](../../../how-to/production-quickstart-capacitor/)

--- a/apps/docs-site/src/content/docs/getting-started/golden-paths.mdx
+++ b/apps/docs-site/src/content/docs/getting-started/golden-paths.mdx
@@ -1,28 +1,28 @@
 ---
 title: Golden Paths
-description: Closed onboarding paths by profile for contract-first, Capacitor runtime-first, and production hardening flows.
+description: Prescriptive onboarding paths by risk profile: contract-first, runtime-first, or production hardening.
 ---
 
 import { Card, CardGrid, Steps } from '@astrojs/starlight/components';
 
-Use this guide when you want a practical path instead of browsing docs section by section.
+Use this page after choosing a path in [Getting Started](/getting-started/).
 
 ## How to use this page
 
 1. Pick one path based on your current risk surface.
-2. Follow the sequence without skipping steps.
-3. Stop when you reach the expected outcome.
-4. Move to the next level only when the "level up" signal is true in your app.
+2. Run the sequence in order.
+3. Stop at the expected outcome.
+4. Move to another path only when the level-up signal is true in your app.
 
 ## Path 1: Contract-first
 
-### When to choose it
+### Choose this when
 
 - Your first problem is semantic consistency across app layers.
 - You need stable shared models for tracks, snapshots, events, errors, and capabilities.
 - Runtime plugin wiring is not your immediate blocker.
 
-### Recommended sequence
+### Sequence
 
 <Steps>
 
@@ -38,20 +38,20 @@ Use this guide when you want a practical path instead of browsing docs section b
 
 You have contract-aligned app logic that can evolve independently from runtime transport details.
 
-### Level up when
+### Level up signal
 
 - You now need real device playback controls or media-session integration.
 - Your app team is blocked by runtime behavior rather than model semantics.
 
 ## Path 2: Capacitor runtime-first
 
-### When to choose it
+### Choose this when
 
 - You already need runtime playback commands and listener wiring on device.
 - You need `audioPlayer` and `mediaSession` behavior validated in a real host app.
 - Your immediate risk is setup/order, queue lifecycle, and remote event handling.
 
-### Recommended sequence
+### Sequence
 
 <Steps>
 
@@ -67,20 +67,20 @@ You have contract-aligned app logic that can evolve independently from runtime t
 
 You have a runtime-integrated flow with explicit setup, event handling, and capability-gated controls.
 
-### Level up when
+### Level up signal
 
 - You are preparing rollout and upgrade safety checks.
 - You need repeatable production confidence across app and CI.
 
 ## Path 3: Production hardening
 
-### When to choose it
+### Choose this when
 
 - You already have an integration and need safer rollout confidence.
 - Your main risk is hidden assumptions during upgrades or capability handling.
 - You need explicit compatibility and migration checks before production promotion.
 
-### Recommended sequence
+### Sequence
 
 <Steps>
 
@@ -96,12 +96,12 @@ You have a runtime-integrated flow with explicit setup, event handling, and capa
 
 You operate with explicit rollout gates: capability checks, stable literal branching, and release-aware validation.
 
-### Level up when
+### Level up signal
 
 - Your team can validate upgrades with clear pass/fail criteria on CI and real devices.
 - Regressions are diagnosed via stable `error.code` and documented event/capability surfaces.
 
-## Common onboarding anti-patterns
+## Cross-path anti-patterns
 
 - Starting with runtime commands before agreeing on shared contract semantics.
 - Treating contract types as runtime execution APIs.
@@ -109,7 +109,7 @@ You operate with explicit rollout gates: capability checks, stable literal branc
 - Branching behavior on `error.message` text instead of stable `error.code` literals.
 - Reading release notes after dependency upgrades instead of before rollout planning.
 
-## Choose and continue
+## Need to re-route?
 
 <CardGrid>
   <Card title="Need help choosing?" icon="rocket" href="/getting-started/">

--- a/apps/docs-site/src/content/docs/getting-started/index.mdx
+++ b/apps/docs-site/src/content/docs/getting-started/index.mdx
@@ -1,26 +1,26 @@
 ---
 title: Getting Started
-description: Decision hub to choose your first Legato path and execute a practical onboarding flow.
+description: Decision hub to choose your first Legato onboarding path based on integration risk.
 ---
 
-import { Card, CardGrid, Steps } from '@astrojs/starlight/components';
+import { Card, CardGrid } from '@astrojs/starlight/components';
 
-Use this page as a decision hub. In a few minutes you should know which path to run first:
+Use this page to make one decision: which onboarding path to start first.
 
 - Contract-first
 - Capacitor runtime-first
 - Production confidence hardening
 
-Before choosing a package path, review the public [Compatibility and Support Matrix](/reference/compatibility/) for supported lines and peer ranges.
+Before choosing, review [Compatibility and Support Matrix](/reference/compatibility/) to confirm supported lines and peer ranges.
 
-## Start with the risk, not the package
+## Decide by risk, not by package name
 
-Pick a package based on where your integration risk lives:
+Pick the first path based on where your integration risk lives:
 
 - If your main risk is **shared semantics across app layers** (events, snapshots, track model, invariants), start with `@ddgutierrezc/legato-contract`.
 - If your main risk is **runtime integration with native playback surfaces** (commands, media session, listeners), use `@ddgutierrezc/legato-capacitor` and keep `@ddgutierrezc/legato-contract` as the shared model.
 
-Legato is intentionally layered: `legato-contract` gives the vocabulary, `legato-capacitor` gives a concrete runtime integration.
+Legato is intentionally layered: `legato-contract` defines shared semantics, and `legato-capacitor` integrates those semantics with Capacitor runtime behavior.
 
 ## Decision matrix
 
@@ -32,27 +32,28 @@ Legato is intentionally layered: `legato-contract` gives the vocabulary, `legato
 
 ## Quick chooser
 
-Choose the first path that is true:
+Choose the first statement that is true:
 
 1. You are defining shared playback semantics first (types, events, invariants) -> start with `@ddgutierrezc/legato-contract`.
 2. You already need device/runtime controls now (play, pause, remote events, media session) -> start with `@ddgutierrezc/legato-capacitor` and `@ddgutierrezc/legato-contract`.
 3. You already run in production and your main concern is safe upgrades and confidence gates -> start with the production confidence path.
 
-## Next 15 minutes
+## Start here
 
 <CardGrid>
   <Card title="Contract-first" icon="puzzle" href="/getting-started/golden-paths/#path-1-contract-first">
-    Read the contract rationale, model one track, and validate invariant usage.
+    Route to the contract-first path and execute the sequence.
   </Card>
   <Card title="Capacitor runtime-first" icon="play" href="/getting-started/golden-paths/#path-2-capacitor-runtime-first">
-    Set up the plugin, run first queue playback, and attach essential listeners.
+    Route to the runtime-first path and validate device playback flow.
   </Card>
   <Card title="Production confidence" icon="lock" href="/getting-started/golden-paths/#path-3-production-hardening">
-    Execute compatibility and migration checks before broad rollout.
+    Route to hardening checks before rollout or upgrade.
   </Card>
 </CardGrid>
 
-- Full guided sequences: [Golden Paths](/getting-started/golden-paths/)
+
+Then continue with [Golden Paths](/getting-started/golden-paths/) for the prescriptive sequence.
 
 ## Typical scenarios and tradeoffs
 
@@ -82,30 +83,8 @@ You can start by making your app logic consume contract snapshots/events, then p
 - Picking `@ddgutierrezc/legato-capacitor` only because "we might need native later" while no runtime integration exists yet.
 - Treating `@ddgutierrezc/legato-contract` as a full runtime solution; it does not provide playback execution APIs.
 - Delaying contract modeling until after runtime wiring, then retrofitting app logic to shared types under time pressure.
-- Treating a finite `duration` as seek support; seek is capability-projected at runtime.
+- Treating finite `duration` as seek support; seek is capability-projected at runtime.
 - Upgrading dependencies without validating `error.code`, capability literals, and setup lifecycle assumptions.
-
-## Install
-
-<Steps>
-
-1. Install the package set that matches your integration.
-
-   ```bash
-   npm install @ddgutierrezc/legato-contract
-   ```
-
-   or
-
-   ```bash
-   npm install @ddgutierrezc/legato-capacitor @ddgutierrezc/legato-contract
-   ```
-
-2. Verify your package manager resolved the dependencies without peer warnings.
-
-3. Continue with package-specific guides.
-
-</Steps>
 
 ## Recommended follow-up
 

--- a/apps/docs-site/src/content/docs/how-to/migration-and-versioning.mdx
+++ b/apps/docs-site/src/content/docs/how-to/migration-and-versioning.mdx
@@ -29,8 +29,8 @@ Primary risk surface:
 
 ## Upgrade flow
 
-1. Read the target release entry in [Releases](/releases/) and the root changelog.
-2. Confirm version alignment expectations from [Compatibility](/reference/compatibility/).
+1. Read the target release entry in [Releases](../../releases/) and the root changelog.
+2. Confirm version alignment expectations from [Compatibility](../../reference/compatibility/).
 3. Update dependencies in a branch.
 4. Run consumer-specific validation (contract-only or runtime).
 5. Roll forward only after passing your app-level checks.
@@ -73,7 +73,7 @@ This guide does not assume automated migration tooling. Treat each upgrade as an
 
 ## Related pages
 
-- [Releases](/releases/)
-- [Compatibility](/reference/compatibility/)
-- [Troubleshooting](/how-to/troubleshooting/)
-- [Set Up Legato Capacitor](/packages/capacitor/how-to/set-up/)
+- [Releases](../../releases/)
+- [Compatibility](../../reference/compatibility/)
+- [Troubleshooting](../troubleshooting/)
+- [Set Up Legato Capacitor](../../packages/capacitor/how-to/set-up/)

--- a/apps/docs-site/src/content/docs/how-to/production-quickstart-capacitor.mdx
+++ b/apps/docs-site/src/content/docs/how-to/production-quickstart-capacitor.mdx
@@ -18,7 +18,7 @@ npm install @ddgutierrezc/legato-capacitor @ddgutierrezc/legato-contract
 npx cap sync
 ```
 
-Then confirm dependency alignment with [Compatibility](/reference/compatibility/).
+Then confirm dependency alignment with [Compatibility](../../reference/compatibility/).
 
 ## Step 2: Initialize playback and media session early
 
@@ -144,7 +144,7 @@ legato native configure --dry-run
 
 ## Related pages
 
-- [Set Up Legato Capacitor](/packages/capacitor/how-to/set-up/)
-- [Listen to Events](/packages/capacitor/how-to/listen-events/)
-- [Use Sync](/packages/capacitor/how-to/use-sync/)
-- [Troubleshooting](/how-to/troubleshooting/)
+- [Set Up Legato Capacitor](../../packages/capacitor/how-to/set-up/)
+- [Listen to Events](../../packages/capacitor/how-to/listen-events/)
+- [Use Sync](../../packages/capacitor/how-to/use-sync/)
+- [Troubleshooting](../troubleshooting/)

--- a/apps/docs-site/src/content/docs/how-to/troubleshooting.mdx
+++ b/apps/docs-site/src/content/docs/how-to/troubleshooting.mdx
@@ -19,11 +19,11 @@ Use `error.code` as the machine-stable branch key.
 
 | `error.code` | Most likely category | Next action |
 |---|---|---|
-| `player_not_setup` | Initialization order | Ensure `await audioPlayer.setup()` ran before playback commands. See [Set Up Legato Capacitor](/packages/capacitor/how-to/set-up/). |
+| `player_not_setup` | Initialization order | Ensure `await audioPlayer.setup()` ran before playback commands. See [Set Up Legato Capacitor](../../packages/capacitor/how-to/set-up/). |
 | `empty_queue` | Queue preconditions | Verify `add({ tracks: [...] })` succeeds before `play()`. Then inspect `getSnapshot().queue`. |
 | `invalid_index` | Queue addressing | Validate `skipTo({ index })`, `remove({ index })`, or `startIndex` against current queue length. |
 | `no_active_track` | Active-track selection | Re-check `startIndex` and `currentIndex` in snapshot after queue insertion. |
-| `unsupported_operation` | Capability projection | Gate UI/action on `getCapabilities().supported`. See [Capabilities](/packages/contract/reference/capabilities/). |
+| `unsupported_operation` | Capability projection | Gate UI/action on `getCapabilities().supported`. See [Capabilities](../../packages/contract/reference/capabilities/). |
 | `seek_failed` | Seek runtime path | Confirm seek capability is currently supported before calling `seekTo`. |
 | `invalid_url` | Track input validity | Re-check `Track.url` value and transport-level accessibility in your environment. |
 | `load_failed` | Media loading | Re-check media URL reachability and track metadata assumptions; inspect `error.details` for adapter context. |
@@ -92,7 +92,7 @@ console.log('[capabilities]', await audioPlayer.getCapabilities());
 
 ## Related pages
 
-- [Errors Reference](/packages/capacitor/reference/errors/)
-- [Native CLI](/packages/capacitor/reference/cli-native/)
-- [Use Sync](/packages/capacitor/how-to/use-sync/)
-- [Migration and Versioning](/how-to/migration-and-versioning/)
+- [Errors Reference](../../packages/capacitor/reference/errors/)
+- [Native CLI](../../packages/capacitor/reference/cli-native/)
+- [Use Sync](../../packages/capacitor/how-to/use-sync/)
+- [Migration and Versioning](../migration-and-versioning/)

--- a/apps/docs-site/src/content/docs/index.mdx
+++ b/apps/docs-site/src/content/docs/index.mdx
@@ -62,7 +62,7 @@ Legato gives you two layers with one goal: predictable playback integrations.
   </Card>
 </CardGrid>
 
-If you want an opinionated sequence, use [Golden Paths](/getting-started/golden-paths/).
+If you want an opinionated sequence, use [Golden Paths](getting-started/golden-paths/).
 
 <CardGrid stagger>
   <Card title="Getting Started" icon="rocket" href="/getting-started/">
@@ -85,8 +85,8 @@ If you want an opinionated sequence, use [Golden Paths](/getting-started/golden-
 
 ## Need help or want to connect?
 
-- Decision hub: [Getting Started](/getting-started/)
-- Guided flows: [Golden Paths](/getting-started/golden-paths/)
+- Decision hub: [Getting Started](getting-started/)
+- Guided flows: [Golden Paths](getting-started/golden-paths/)
 - Community hub: [Community](./community/)
 - Discord: [https://discord.com/invite/Hhnumyk2N](https://discord.com/invite/Hhnumyk2N)
 - LinkedIn: [https://www.linkedin.com/in/ddgutierrezc](https://www.linkedin.com/in/ddgutierrezc)

--- a/apps/docs-site/src/content/docs/packages/capacitor/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/index.mdx
@@ -7,7 +7,7 @@ import { Aside, Card, CardGrid } from '@astrojs/starlight/components';
 
 Use `@ddgutierrezc/legato-capacitor` when you need Capacitor runtime integration for audio playback on iOS and Android.
 
-For package-line support and peer dependency compatibility, use the public [Compatibility and Support Matrix](/reference/compatibility/).
+For package-line support and peer dependency compatibility, use the public [Compatibility and Support Matrix](../../reference/compatibility/).
 
 ## What is legato-capacitor?
 
@@ -84,6 +84,6 @@ Start with [Capability Projection](explanation/capability-projection/) and [Snap
 
 ## Support and community
 
-- Community hub: [Community](/community/)
+- Community hub: [Community](../../community/)
 - Discord: [https://discord.com/invite/Hhnumyk2N](https://discord.com/invite/Hhnumyk2N)
 - LinkedIn: [https://www.linkedin.com/in/ddgutierrezc](https://www.linkedin.com/in/ddgutierrezc)

--- a/apps/docs-site/src/content/docs/packages/contract/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/contract/index.mdx
@@ -36,7 +36,7 @@ Use `@ddgutierrezc/legato-contract` when you need shared contract primitives wit
 
 ## Learn by path
 
-- Start with [First contract integration](/tutorials/first-contract-integration/) for onboarding without Capacitor runtime dependencies.
+- Start with [First contract integration](../../tutorials/first-contract-integration/) for onboarding without Capacitor runtime dependencies.
 - Use [How-To Guides](how-to/) for task-oriented implementation patterns.
 - Read [Explanation](explanation/) for contract architecture and snapshot model rationale.
 - Continue with the [Contract reference](reference/) for core type and event semantics.
@@ -52,6 +52,6 @@ This page summarizes consumer-safe guidance only. Maintainer verification maps a
 
 ## Support and community
 
-- Community hub: [Community](/community/)
+- Community hub: [Community](../../community/)
 - Discord: [https://discord.com/invite/Hhnumyk2N](https://discord.com/invite/Hhnumyk2N)
 - LinkedIn: [https://www.linkedin.com/in/ddgutierrezc](https://www.linkedin.com/in/ddgutierrezc)

--- a/apps/docs-site/src/content/docs/packages/contract/reference/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/contract/reference/index.mdx
@@ -23,4 +23,4 @@ Use this section as the source of truth for transport-neutral types, event names
 ## Related pages
 
 - [Contract package overview](../)
-- [First contract integration tutorial](/tutorials/first-contract-integration/)
+- [First contract integration tutorial](../../../tutorials/first-contract-integration/)

--- a/apps/docs-site/src/content/docs/packages/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/index.mdx
@@ -7,14 +7,14 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
 Use this hub when you need to decide which Legato package to adopt first.
 
-For the canonical package support view, use the [Compatibility and Support Matrix](/reference/compatibility/).
+For the canonical package support view, use the [Compatibility and Support Matrix](../reference/compatibility/).
 
 ## Package chooser
 
 | If your first risk is... | Start with | Why |
 |---|---|---|
-| Shared playback semantics across layers (events, snapshots, invariants) | [`@ddgutierrezc/legato-contract`](/packages/contract/) | You stabilize app vocabulary and behavior assumptions before runtime wiring. |
-| Native playback runtime integration in a Capacitor app (commands, media session, listeners) | [`@ddgutierrezc/legato-capacitor`](/packages/capacitor/) + `@ddgutierrezc/legato-contract` | You get runtime APIs while keeping the same shared contract model across app layers. |
+| Shared playback semantics across layers (events, snapshots, invariants) | [`@ddgutierrezc/legato-contract`](contract/) | You stabilize app vocabulary and behavior assumptions before runtime wiring. |
+| Native playback runtime integration in a Capacitor app (commands, media session, listeners) | [`@ddgutierrezc/legato-capacitor`](capacitor/) + `@ddgutierrezc/legato-contract` | You get runtime APIs while keeping the same shared contract model across app layers. |
 
 ## Package guides
 
@@ -31,7 +31,7 @@ For the canonical package support view, use the [Compatibility and Support Matri
 
 1. Pick the package from your integration risk, not from future guesses.
 2. If you choose Capacitor, keep `@ddgutierrezc/legato-contract` aligned to the same supported line.
-3. Review [Releases](/releases/) before upgrades so you can validate version matrix and user impact in your CI.
-4. Confirm final compatibility assumptions in the [Compatibility and Support Matrix](/reference/compatibility/).
+3. Review [Releases](../releases/) before upgrades so you can validate version matrix and user impact in your CI.
+4. Confirm final compatibility assumptions in the [Compatibility and Support Matrix](../reference/compatibility/).
 
-If you want an opinionated onboarding sequence, continue with [Golden Paths](/getting-started/golden-paths/).
+If you want an opinionated onboarding sequence, continue with [Golden Paths](../getting-started/golden-paths/).

--- a/apps/docs-site/src/content/docs/reference/compatibility.mdx
+++ b/apps/docs-site/src/content/docs/reference/compatibility.mdx
@@ -5,7 +5,17 @@ description: Public compatibility matrix and support boundaries for Legato packa
 
 This page is the public source of truth for Legato package compatibility and support boundaries.
 
-Use this matrix before installs or upgrades to confirm supported package lines and peer dependency expectations.
+Use this matrix before any install or upgrade decision. It tells you which package lines are expected to work together, what is explicitly supported, and what must still be validated in your own app.
+
+If your team needs one rule: do not approve a rollout until your selected package line, peer dependencies, and capability assumptions all pass this page and your CI checks.
+
+## How to use this page before install or upgrade
+
+1. Identify your consumer profile: contract-only or Capacitor runtime.
+2. Confirm package major-line alignment and peer dependency requirements.
+3. Check support boundaries and known limitations on this page.
+4. Validate runtime behavior in your app CI/device smoke tests.
+5. Read the target release notes in [Releases](/releases/) before promoting to production.
 
 ## Scope of this matrix
 
@@ -21,6 +31,11 @@ This page does not cover:
 - Runtime behavior promises beyond the documented contract/error/capability surfaces
 - Native artifact version matrices not explicitly published in public release notes
 
+Read this section as a support boundary contract:
+
+- Items listed as covered are within the public compatibility commitment.
+- Items listed as not covered require consumer-owned verification before production rollout.
+
 ## Current package line (source-backed)
 
 | Package | Source | Public version observed |
@@ -29,6 +44,8 @@ This page does not cover:
 | `@ddgutierrezc/legato-capacitor` | `packages/capacitor/package.json` | `1.0.0` |
 
 These values reflect repository metadata at the time this documentation snapshot was written.
+
+Enterprise note: treat this as a documentation snapshot, then verify your exact lockfile/runtime state in CI before rollout.
 
 ## Declared dependency compatibility
 
@@ -43,6 +60,10 @@ Interpretation:
 - Capacitor host apps are expected to satisfy the `@capacitor/core` `^8.0.0` peer range.
 - Exact host-platform/version permutations are not fully enumerated here; validate in your app CI.
 
+Decision rule:
+
+- If your app does not satisfy the peer ranges, do not treat the integration as supported.
+
 ## Contract package expectations
 
 `@ddgutierrezc/legato-contract` is library-only and defines:
@@ -55,6 +76,10 @@ Compatibility expectation for contract-only consumers:
 
 - Branch behavior on stable literals (`error.code`, capability names, event names).
 - Treat human-readable text (`error.message`) as diagnostic, not compatibility key.
+
+Known limitation:
+
+- This matrix does not guarantee compatibility for custom adapters that depend on undocumented fields or message text.
 
 ## Capacitor package expectations
 
@@ -69,6 +94,10 @@ Compatibility expectation for runtime consumers:
 
 - Capability-dependent operations (for example seek) MUST be gated by `getCapabilities()`.
 - Event payload handling SHOULD use the documented payload maps and stable event names.
+
+Known limitation:
+
+- This matrix does not certify every OEM/device/background-policy permutation; production readiness still depends on your own device matrix tests.
 
 ## `legato native` CLI scope compatibility
 
@@ -89,6 +118,12 @@ Compatibility boundary:
 2. Satisfy `@capacitor/core` peer range required by `@ddgutierrezc/legato-capacitor`.
 3. Validate event/capability assumptions in-device using your own CI smoke tests.
 4. Read release notes before upgrades: [Releases](/releases/).
+
+## Known limitations and expectations
+
+- No implicit promise is made for undocumented APIs, private internals, or inferred behavior not stated in official docs and changelog.
+- Native distribution parity statements are authoritative only when explicitly recorded in release evidence.
+- This page defines compatibility intent; final rollout confidence comes from your app-specific validation.
 
 ## Related pages
 

--- a/apps/docs-site/src/content/docs/reference/index.mdx
+++ b/apps/docs-site/src/content/docs/reference/index.mdx
@@ -5,16 +5,16 @@ description: Public API and integration reference entrypoint for Legato package 
 
 Use this section when you already know what you need and want package-level API entrypoints.
 
-If you still need to choose the right package path, start in [Packages](/packages/) before diving into API-level pages.
+If you still need to choose the right package path, start in [Packages](../packages/) before diving into API-level pages.
 
 ## Package references
 
-- [Contract package reference](/packages/contract/)
-- [Capacitor package reference](/packages/capacitor/)
+- [Contract package reference](../packages/contract/)
+- [Capacitor package reference](../packages/capacitor/)
 
 ## Operational reference
 
-- [Compatibility](/reference/compatibility/)
+- [Compatibility](compatibility/)
 
 ## Scope boundary
 

--- a/apps/docs-site/src/content/docs/releases/index.mdx
+++ b/apps/docs-site/src/content/docs/releases/index.mdx
@@ -7,11 +7,19 @@ This page summarizes public release highlights from [`CHANGELOG.md`](https://git
 
 Use it to decide whether a release affects your runtime behavior, dependency alignment, or migration work.
 
+This page is consumer-facing guidance, not a second changelog. If there is any doubt, `CHANGELOG.md` is authoritative.
+
 ## Start here before any upgrade
 
 1. Open the target entry in `CHANGELOG.md` and confirm the exact package line you plan to adopt.
 2. Check whether your integration is contract-only, Capacitor runtime, or both.
 3. Validate version pairings in a branch before production rollout.
+
+Minimum release-read discipline for production teams:
+
+- Do not upgrade from tag/version name alone; read `Changed`, `Fixed`, and `Security` first.
+- Do not assume platform parity unless the entry explicitly states it.
+- Do not skip device-level validation for Capacitor integrations.
 
 If you are new to package selection, use the [Packages hub](/packages/) first.
 
@@ -26,6 +34,12 @@ When you evaluate a release entry, check in this order:
 5. **Durable evidence**: links to npm/Maven/iOS release records.
 
 If a release includes only partial evidence for your stack, treat it as informative and validate behavior in your own CI before production rollout.
+
+Fast triage path:
+
+1. Confirm whether your current version and target version are in the same major line.
+2. Read user-impact and upgrade-notes bullets before implementation details.
+3. Decide rollout type: safe patch, controlled minor, or migration-required.
 
 ## What to evaluate by consumer profile
 
@@ -44,6 +58,23 @@ If a release includes only partial evidence for your stack, treat it as informat
 - Prioritize evidence links and distribution parity claims across npm, Maven, and iOS release records.
 - Keep release communications aligned with factual `CHANGELOG.md` claims only.
 
+## Upgrade checks by risk profile
+
+### Low-risk consumers (contract compile-time only)
+
+- Verify no contract semantic shift affects your event/error/capability assumptions.
+- Run type-check and contract-focused tests before merging.
+
+### Runtime-critical consumers (playback in production)
+
+- Verify release notes for runtime parity and authenticated media behavior changes.
+- Run real-device smoke tests across queue, lifecycle, remote controls, and capability-gated actions.
+
+### Regulated/enterprise consumers
+
+- Require durable evidence links for the artifacts you must audit (npm/Maven/iOS as applicable).
+- Record changelog section references used for approval in your internal release ticket.
+
 ## Who should care about which changes
 
 | Change type in notes | Most affected consumers | Typical action |
@@ -61,6 +92,7 @@ If a release includes only partial evidence for your stack, treat it as informat
 - Stable package line:
   - `@ddgutierrezc/legato-contract@1.0.0`
   - `@ddgutierrezc/legato-capacitor@1.0.0`
+- Stable native distribution line called out in changelog: `dev.dgutierrez:legato-android-core:1.0.0` and `legato-ios-core v1.0.0`.
 - Runtime parity and authenticated media request scope called out as supported baseline.
 
 Consumer action baseline for this line:
@@ -71,7 +103,7 @@ Consumer action baseline for this line:
 
 ## Previous release notes
 
-For older entries (including `0.1.x` lines), read the root `CHANGELOG.md` history.
+For older entries (including `0.1.x` lines and release-specific tags such as `contract-publish-*` and `capacitor-publish-*`), read the root `CHANGELOG.md` history.
 
 - Changelog source of truth: [`CHANGELOG.md`](https://github.com/ddgutierrezc/legato/blob/main/CHANGELOG.md)
 
@@ -81,6 +113,7 @@ For older entries (including `0.1.x` lines), read the root `CHANGELOG.md` histor
 2. Read `Changed`, `Fixed`, and `Security` sections for behavior-impacting changes.
 3. Apply update in a branch and run your app-level playback regression checklist.
 4. If capabilities/semantics changed, re-check UI gating logic built on `getCapabilities()` and `error.code`.
+5. For enterprise rollouts, attach durable evidence links from the changelog to your approval/change record.
 
 For a step-by-step upgrade checklist, continue with [Migration and Versioning](/how-to/migration-and-versioning/).
 

--- a/apps/docs-site/src/content/docs/tutorials/first-contract-integration.mdx
+++ b/apps/docs-site/src/content/docs/tutorials/first-contract-integration.mdx
@@ -203,7 +203,7 @@ Move to runtime integration when you need:
 
 ## Next steps
 
-- Read the [Contract reference index](/packages/contract/reference/) for the canonical API surface.
-- Deep dive into [Track fields](/packages/contract/reference/track/).
-- Review [Snapshots](/packages/contract/reference/snapshots/), [Events](/packages/contract/reference/events/), and [Errors](/packages/contract/reference/errors/).
-- Continue with [Set Up Legato Capacitor](/packages/capacitor/how-to/set-up/) for runtime integration.
+- Read the [Contract reference index](../../packages/contract/reference/) for the canonical API surface.
+- Deep dive into [Track fields](../../packages/contract/reference/track/).
+- Review [Snapshots](../../packages/contract/reference/snapshots/), [Events](../../packages/contract/reference/events/), and [Errors](../../packages/contract/reference/errors/).
+- Continue with [Set Up Legato Capacitor](../../packages/capacitor/how-to/set-up/) for runtime integration.


### PR DESCRIPTION
## Summary

- normalize internal docs links across the public docs-site where safe
- sharpen onboarding so getting started is more clearly a decision hub and golden paths is more clearly a routed execution guide
- improve compatibility/support matrix and releases guidance for consumer-facing decision-making

## Linked issue

Resolves #150

## Validation

- [x] Relevant tests/checks were run
- [x] No unrelated workflows were changed

## Policy checks

- [x] Exactly one `type:*` label added
- [x] Approved issue linked when required (`status:approved`)
