### PR TITLE
fix(docs): quote golden paths frontmatter

### DIFF
--- a/apps/docs-site/src/content/docs/getting-started/golden-paths.mdx
+++ b/apps/docs-site/src/content/docs/getting-started/golden-paths.mdx
@@ -1,6 +1,6 @@
 ---
 title: Golden Paths
-description: Prescriptive onboarding paths by risk profile: contract-first, runtime-first, or production hardening.
+description: "Prescriptive onboarding paths by risk profile: contract-first, runtime-first, or production hardening."
 ---
 
 import { Card, CardGrid, Steps } from '@astrojs/starlight/components';


### PR DESCRIPTION
## Linked Issue

Closes #155

## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- quote the `golden-paths.mdx` frontmatter description so Astro can parse the page again.
- unblock Netlify/docs preview checks that were failing on `main` and unrelated feature branches.

## Changes Table

| File | Change |
|------|--------|
| `apps/docs-site/src/content/docs/getting-started/golden-paths.mdx` | Quoted the YAML description string containing colon-separated prose |

## Test Plan

- [x] `npm ci && npm run build` in `apps/docs-site`
- [x] Manually verified the previous YAML/frontmatter parse error no longer reproduces
- [x] Confirmed the failing content matched `main` before the fix

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts (no shell scripts changed)
- [x] Skills tested in at least one agent
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
