### PR TITLE
docs(shared-playback-headers): expand 1.1.0 public guides

### DIFF
--- a/apps/docs-site/src/content/docs/how-to/migration-and-versioning.mdx
+++ b/apps/docs-site/src/content/docs/how-to/migration-and-versioning.mdx
@@ -50,6 +50,20 @@ Primary risk surface:
 - Verify event listeners are attached/removed correctly across component lifecycles.
 - Verify error handling uses `error.code` and logs `details` for diagnostics.
 
+## Additional checklist for 1.1.0 shared playback headers
+
+Apply this checklist when adopting `HeaderGroup` / `headerGroupId` in the 1.1.0 line:
+
+- Align both packages to `1.1.0` (`@ddgutierrezc/legato-contract` and `@ddgutierrezc/legato-capacitor`).
+- Confirm setup registration path exists and is awaited before queue admission:
+  - `audioPlayer.setup({ headerGroups })` or
+  - `Legato.setup({ headerGroups })`
+- Keep existing `Track.headers` entries where one-off overrides are still required.
+- Add an explicit validation case for unknown `headerGroupId` (must fail fast at `add()`).
+- Add an explicit validation case for precedence (`track.headers` overrides shared-group keys).
+- Add one mixed-token queue scenario (some tracks use `headerGroupId`, others use per-track `headers`).
+- Verify your diagnostics/logging pipeline does not rely on internal merged effective header state.
+
 ## Breaking-change review checklist
 
 For each release, answer these questions before production rollout:
@@ -77,3 +91,5 @@ This guide does not assume automated migration tooling. Treat each upgrade as an
 - [Compatibility](../../reference/compatibility/)
 - [Troubleshooting](../troubleshooting/)
 - [Set Up Legato Capacitor](../../packages/capacitor/how-to/set-up/)
+- [Send Secure Track Headers](../../packages/capacitor/how-to/secure-track-headers/)
+- [Track reference](../../packages/contract/reference/track/)

--- a/apps/docs-site/src/content/docs/packages/capacitor/how-to/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/how-to/index.mdx
@@ -30,6 +30,6 @@ This section provides step-by-step guides for the most common integration tasks.
   </Card>
   <Card title="Secure Track Headers" icon="lock">
     **[Send Secure Track Headers](./secure-track-headers/)**
-    Configure static per-track HTTP headers for protected media URLs.
+    Configure per-track headers, shared `HeaderGroup` setup, and secure precedence for protected media URLs.
   </Card>
 </CardGrid>

--- a/apps/docs-site/src/content/docs/packages/capacitor/how-to/secure-track-headers.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/how-to/secure-track-headers.mdx
@@ -1,13 +1,53 @@
 ---
 title: Send Secure Track Headers
-description: Use Track.headers for static per-track HTTP headers in protected media integrations.
+description: Configure per-track and shared playback headers with setup-scoped HeaderGroup values in Legato 1.1.0.
 ---
 
-Use this guide when your media URLs require static request headers (for example, bearer tokens or client identifiers).
+Use this guide when your media URLs require static request headers (for example bearer tokens or tenant keys) and you need to reduce header duplication across a queue.
 
-## 1) Model each protected track with `headers`
+In `1.1.0`, you can keep using `Track.headers` and optionally introduce `Track.headerGroupId` + `setup({ headerGroups })` for shared declarations.
 
-`Track` is re-exported by `@ddgutierrezc/legato-capacitor` from the contract package, including the `headers` field.
+## Before you start
+
+- `@ddgutierrezc/legato-contract@1.1.0`
+- `@ddgutierrezc/legato-capacitor@1.1.0`
+
+If you are upgrading from `1.0.0`, keep reading this page and then check [Migration and Versioning](../../../../how-to/migration-and-versioning/).
+
+## 1) Choose the right modeling strategy
+
+Use this decision table:
+
+| Situation | Recommended field(s) |
+|---|---|
+| One-off token for a single track | `Track.headers` only |
+| Many tracks share the same static headers | `headerGroupId` + `setup({ headerGroups })` |
+| Mostly shared headers, with one track-specific override | both (`headerGroupId` + `headers`) |
+| Dynamic token refresh/DRM/cookie lifecycle | Outside current Legato header contract |
+
+## 2) Declare shared groups at setup time
+
+`HeaderGroup` is immutable after setup. Declare your reusable static headers once:
+
+```ts
+import { audioPlayer, type HeaderGroup } from '@ddgutierrezc/legato-capacitor';
+
+const headerGroups: HeaderGroup[] = [
+  {
+    id: 'premium-us',
+    headers: {
+      Authorization: 'Bearer <shared-premium-token>',
+      'X-Tenant': 'us',
+    },
+  },
+];
+
+await audioPlayer.setup({ headerGroups });
+```
+
+## 3) Reference groups from tracks
+
+Tracks can reference a shared group using `headerGroupId`.
 
 ```ts
 import type { Track } from '@ddgutierrezc/legato-capacitor';
@@ -17,33 +57,49 @@ const tracks: Track[] = [
     id: 'episode-42',
     url: 'https://media.example.com/audio/episode-42.mp3',
     type: 'progressive',
+    headerGroupId: 'premium-us',
+  },
+];
+```
+
+Unknown group IDs are rejected at `add()` time, so treat group IDs as contract data and keep them stable.
+
+## 4) Override group keys per track when needed
+
+Per-track `headers` still works and takes precedence per key:
+
+```ts
+const tracks: Track[] = [
+  {
+    id: 'episode-42',
+    url: 'https://media.example.com/audio/episode-42.mp3',
+    type: 'progressive',
+    headerGroupId: 'premium-us',
     headers: {
-      Authorization: 'Bearer <static-token>',
-      'X-Client-Version': '1.0.0',
+      Authorization: 'Bearer <episode-specific-token>', // overrides group Authorization
+      'X-Experiment': 'A',
     },
   },
 ];
 ```
 
-## 2) Add tracks normally
+Precedence summary:
 
-```ts
-import { audioPlayer } from '@ddgutierrezc/legato-capacitor';
+- group only → group headers are applied
+- track only → track headers are applied
+- both → `{ ...group, ...track }` (track wins per key)
+- neither → no auth headers
 
-await audioPlayer.add({ tracks, startIndex: 0 });
-await audioPlayer.play();
-```
+## 5) Queue mixed-token playlists
 
-## 3) Apply headers per track, not globally
-
-In v1 contract scope, headers are isolated per track and are not shared across queue transitions. If different items need different auth context, set `headers` on each item.
+You can mix shared-group and per-track-only entries in one queue:
 
 ```ts
 const queue: Track[] = [
   {
     id: 'a',
     url: 'https://media.example.com/a.mp3',
-    headers: { Authorization: 'Bearer token-a' },
+    headerGroupId: 'premium-us',
   },
   {
     id: 'b',
@@ -51,11 +107,22 @@ const queue: Track[] = [
     headers: { Authorization: 'Bearer token-b' },
   },
 ];
+
+await audioPlayer.add({ tracks: queue, startIndex: 0 });
+await audioPlayer.play();
 ```
 
-## v1 scope and non-goals
+## 6) Security boundaries and what does NOT leak
 
-Backed by contract comments, v1 guarantees and non-goals are:
+Legato resolves effective request headers internally at queue admission/runtime boundaries.
+
+- Public snapshots/events remain public projections.
+- Do not assume internal merged request headers are exposed for inspection.
+- Keep secrets out of application logging pipelines, especially when logging track objects.
+
+## 7) Scope and non-goals
+
+Backed by contract comments and release notes, current guarantees and non-goals are:
 
 - Scope: headers are applied by Android/iOS runtime media requests for that track.
 - Scope: headers are isolated per track.
@@ -63,14 +130,29 @@ Backed by contract comments, v1 guarantees and non-goals are:
 - Non-goal: token refresh/rotation or dynamic auth callbacks.
 - Non-goal: cookie/session renewal orchestration.
 
-If your integration requires dynamic auth lifecycle management, implement that outside the current `Track.headers` contract and queue model.
+If your integration requires dynamic auth lifecycle management, implement that outside the current Legato track-header model.
+
+## 8) Upgrade guidance for 1.1.0
+
+1. Upgrade contract + capacitor packages to `1.1.0`.
+2. Keep existing `Track.headers` usage unchanged (fully supported).
+3. Introduce `headerGroups` only where you have repeated static headers.
+4. Add tests for:
+   - unknown `headerGroupId` fail-fast behavior
+   - track-level key override precedence
+   - mixed-token playlists
+5. Re-run device-level playback smoke tests on Android and iOS.
 
 ## Expected result
 
-Protected tracks can be queued and played with static per-track HTTP headers, while your integration keeps token refresh, DRM/license flows, and session renewal logic outside the v1 Legato track contract.
+Protected tracks can be queued and played with either per-track headers, shared setup-scoped header groups, or both, while keeping advanced auth lifecycle concerns outside the current Legato contract scope.
 
 ## Related pages
 
 - [Contract track reference](../../contract/reference/track/)
 - [Contract how-to: Model a Track](../../contract/how-to/model-a-track/)
+- [Audio Player API (`setup(options?)`)](../reference/audio-player/)
+- [Legato Facade API (`setup(options?)`)](../reference/legato/)
+- [Migration and Versioning](../../../../how-to/migration-and-versioning/)
+- [Releases](../../../../releases/)
 - [How-to: Play a Track](./play-track/)

--- a/apps/docs-site/src/content/docs/packages/capacitor/reference/audio-player.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/reference/audio-player.mdx
@@ -11,7 +11,7 @@ The `audioPlayer` namespace provides playback commands, queue operations, state 
 
 ```ts
 interface AudioPlayerApi {
-  setup(): Promise<void>;
+  setup(options?: SetupOptions): Promise<void>;
   add(options: AddOptions): Promise<PlaybackSnapshot>;
   remove(options: RemoveOptions): Promise<PlaybackSnapshot>;
   reset(): Promise<PlaybackSnapshot>;
@@ -39,13 +39,28 @@ interface AudioPlayerApi {
 
 ## Methods
 
-### `setup()`
+### `setup(options?)`
 
 Initializes the native plugin. MUST be called before any other playback operations.
 
 ```ts
-await audioPlayer.setup();
+await audioPlayer.setup({
+  headerGroups: [
+    {
+      id: 'premium-us',
+      headers: { Authorization: 'Bearer shared-token' },
+    },
+  ],
+});
 ```
+
+`options` is optional. If omitted, setup runs without shared header-group registration.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `headerGroups` | `HeaderGroup[]` | No | Setup-scoped shared static headers referenced later by `Track.headerGroupId`. |
 
 **Returns:** `Promise<void>`
 
@@ -352,6 +367,23 @@ await audioPlayer.removeAllListeners();
 interface AddOptions {
   tracks: Track[];
   startIndex?: number;
+}
+```
+
+### `SetupOptions`
+
+```ts
+interface SetupOptions {
+  headerGroups?: HeaderGroup[];
+}
+```
+
+### `HeaderGroup`
+
+```ts
+interface HeaderGroup {
+  id: string;
+  headers: Record<string, string>;
 }
 ```
 

--- a/apps/docs-site/src/content/docs/packages/capacitor/reference/legato.mdx
+++ b/apps/docs-site/src/content/docs/packages/capacitor/reference/legato.mdx
@@ -63,7 +63,7 @@ await Legato.addListener('remote-play', () => { ... });
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `setup()` | `Promise<void>` | Initializes the native plugin. |
+| `setup(options?)` | `Promise<void>` | Initializes the native plugin and optionally registers shared header groups. |
 | `add(options)` | `Promise<PlaybackSnapshot>` | Appends tracks to the queue. |
 | `remove(options)` | `Promise<PlaybackSnapshot>` | Removes queue entries by ID or index. |
 | `reset()` | `Promise<PlaybackSnapshot>` | Clears the queue and stops playback. |
@@ -108,7 +108,14 @@ await Legato.removeAllListeners();
 import { Legato } from '@ddgutierrezc/legato-capacitor';
 
 // Initialize (setup is idempotent via the shared native plugin)
-await Legato.setup();
+await Legato.setup({
+  headerGroups: [
+    {
+      id: 'premium-us',
+      headers: { Authorization: 'Bearer shared-token' },
+    },
+  ],
+});
 
 // Add tracks and start playback
 await Legato.add({

--- a/apps/docs-site/src/content/docs/packages/contract/how-to/model-a-track.mdx
+++ b/apps/docs-site/src/content/docs/packages/contract/how-to/model-a-track.mdx
@@ -1,6 +1,6 @@
 ---
 title: Model a Track
-description: Build a valid Track payload with required fields, optional metadata, type, and headers.
+description: Build a valid Track payload with required fields, optional metadata, type, headers, and shared header-group references.
 ---
 
 This guide shows how to model a `Track` object that matches the shared contract.
@@ -62,11 +62,27 @@ const protectedTrack: Track = {
 };
 ```
 
+## 5) Reference setup-scoped shared headers when reuse is needed
+
+Use `headerGroupId` when many tracks share static headers registered during setup.
+
+```ts
+const groupedTrack: Track = {
+  id: 'episode-002',
+  url: 'https://cdn.example.com/audio/episode-002.mp3',
+  type: 'progressive',
+  headerGroupId: 'premium-us',
+};
+```
+
+If you include both fields, `headers` overrides group keys per header name.
+
 ## Expected result
 
-You can now construct `Track` values that satisfy the contract using required fields first, then optional metadata, `type`, and `headers` as consumer needs evolve.
+You can now construct `Track` values that satisfy the contract using required fields first, then optional metadata, `type`, and either per-track headers, shared group references, or both.
 
 ## Related pages
 
 - [Track reference](../../reference/track/)
+- [Send Secure Track Headers (Capacitor)](../../../capacitor/how-to/secure-track-headers/)
 - [Validate Runtime Invariants](../validate-runtime-invariants/)

--- a/apps/docs-site/src/content/docs/packages/contract/reference/track.mdx
+++ b/apps/docs-site/src/content/docs/packages/contract/reference/track.mdx
@@ -1,6 +1,6 @@
 ---
 title: Track
-description: Reference for Track and TrackType in @ddgutierrezc/legato-contract.
+description: Reference for Track, HeaderGroup, and TrackType in @ddgutierrezc/legato-contract.
 ---
 
 `Track` is the queue item shape shared across adapter and consumer boundaries.
@@ -16,6 +16,22 @@ const TRACK_TYPES = ['file', 'progressive', 'hls', 'dash'] as const;
 type TrackType = (typeof TRACK_TYPES)[number];
 ```
 
+## HeaderGroup
+
+`HeaderGroup` defines setup-scoped shared HTTP headers that tracks can reference through `headerGroupId`.
+
+```ts
+interface HeaderGroup {
+  id: string;
+  headers: Record<string, string>;
+}
+```
+
+| Field | Type | Required | Notes |
+|------|------|----------|-------|
+| `id` | `string` | Yes | Stable identifier referenced by `Track.headerGroupId`. |
+| `headers` | `Record<string, string>` | Yes | Static headers reused by tracks that reference this group. |
+
 ## Track fields
 
 | Field | Type | Required | Notes |
@@ -28,7 +44,19 @@ type TrackType = (typeof TRACK_TYPES)[number];
 | `artwork` | `string` | No | Optional artwork URL for lockscreen/notification surfaces. |
 | `duration` | `number` | No | Optional duration in seconds when known. |
 | `type` | `TrackType` | No | Declared media semantics used by native capability projectors. |
+| `headerGroupId` | `string` | No | Optional reference to a setup-scoped `HeaderGroup`. Unknown IDs fail fast at `add()` time. |
 | `headers` | `Record<string, string>` | No | Static per-track HTTP headers used by native playback transport. |
+
+## Header resolution precedence
+
+When `headerGroupId` and `headers` are both present, resolution happens at queue admission time:
+
+- group only → effective headers = group headers
+- track only → effective headers = track headers
+- both → effective headers = `{ ...group, ...track }` (track wins per key)
+- neither → no auth headers
+
+Important boundary: merged effective headers are runtime-internal. Consumers should treat snapshots/events as public projections and avoid relying on internal merged-request state.
 
 ## What `type` means (and does NOT mean)
 
@@ -42,6 +70,8 @@ Based on the contract comments, v1 support scope is intentionally narrow:
 
 - Applied by Android/iOS runtime media requests for that specific track.
 - Isolated per track, not shared across queue transitions.
+
+Shared groups do not replace per-track support. `headers` remains fully supported and is the per-track override path when both are present.
 
 v1 non-goals explicitly documented in the contract:
 
@@ -107,14 +137,42 @@ const track: Track = {
 };
 ```
 
+### 5) Shared header group reference
+
+```ts
+const track: Track = {
+  id: 'song-43',
+  url: 'https://cdn.example.com/song-43.mp3',
+  type: 'progressive',
+  headerGroupId: 'premium-us',
+};
+```
+
+### 6) Group + per-track override
+
+```ts
+const track: Track = {
+  id: 'song-44',
+  url: 'https://cdn.example.com/song-44.mp3',
+  type: 'progressive',
+  headerGroupId: 'premium-us',
+  headers: {
+    Authorization: 'Bearer one-off-override',
+  },
+};
+```
+
 ## Anti-patterns
 
 - Setting `type: 'hls'` or `type: 'dash'` and assuming seek is always available. Seek remains runtime-capability-dependent.
 - Omitting stable `id` values (for example randomizing per render). Queue operations (`remove`, `skip`) depend on stable identifiers and indexes.
 - Treating `headers` as shared global auth state across all queue items. Header scope is per track.
+- Assuming `headerGroupId` replaces per-track `headers`. It does not; both can coexist, with per-track keys taking precedence.
+- Expecting unknown `headerGroupId` values to be ignored. Admission fails fast at `add()` time.
 - Expecting `headers` to solve token refresh, cookie renewal, or DRM license workflows. Those are out of contract v1 scope.
 
 ## Related pages
 
 - [Snapshots](../snapshots/)
 - [Events](../events/)
+- [Capacitor setup + secure headers guide](../../../capacitor/how-to/secure-track-headers/)

--- a/apps/docs-site/src/content/docs/releases/index.mdx
+++ b/apps/docs-site/src/content/docs/releases/index.mdx
@@ -86,20 +86,27 @@ Fast triage path:
 
 ## Latest stable highlight
 
-### [1.0.0]
+### [1.1.0]
 
-- First stable **Capacitor-first** Legato release line.
+- Shared playback headers are now part of the stable public package line.
 - Stable package line:
-  - `@ddgutierrezc/legato-contract@1.0.0`
-  - `@ddgutierrezc/legato-capacitor@1.0.0`
-- Stable native distribution line called out in changelog: `dev.dgutierrez:legato-android-core:1.0.0` and `legato-ios-core v1.0.0`.
-- Runtime parity and authenticated media request scope called out as supported baseline.
+  - `@ddgutierrezc/legato-contract@1.1.0`
+  - `@ddgutierrezc/legato-capacitor@1.1.0`
+- Stable native distribution line called out in changelog: `dev.dgutierrez:legato-android-core:1.1.0` and `legato-ios-core v1.1.0`.
+- Public contract additions: `HeaderGroup` and `Track.headerGroupId`.
+- Compatibility preserved: `Track.headers` remains supported as the per-track override path.
 
 Consumer action baseline for this line:
 
-- Keep `@ddgutierrezc/legato-contract` and `@ddgutierrezc/legato-capacitor` aligned in the `1.x` line.
-- For Capacitor apps, validate queue/playback/capabilities/remote controls on real target devices.
-- For contract-only users, validate event/error/capability assumptions against your adapters.
+- Keep `@ddgutierrezc/legato-contract` and `@ddgutierrezc/legato-capacitor` aligned to `1.1.0` when adopting shared groups.
+- For Capacitor apps, validate `setup({ headerGroups })`, unknown-group fail-fast behavior, and mixed-token playlists on real devices.
+- For contract-only users, update your track modeling rules to include `headerGroupId` semantics and precedence expectations.
+
+For implementation guidance, use:
+
+- [Send Secure Track Headers](/packages/capacitor/how-to/secure-track-headers/)
+- [Track reference](/packages/contract/reference/track/)
+- [Migration and Versioning](/how-to/migration-and-versioning/)
 
 ## Previous release notes
 


### PR DESCRIPTION
## Linked Issue

Closes #157

## PR Type

- [ ] Bug fix
- [ ] New feature
- [x] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- document shared playback headers across contract, Capacitor how-to, reference, migration, and releases with 1.1.0 guidance.
- explain setup-scoped `headerGroups`, `Track.headerGroupId`, precedence rules, mixed-token playlists, and public security boundaries.
- align docs references with the shipped `setup(options?: SetupOptions)` API surface.

## Changes Table

| File | Change |
|------|--------|
| `apps/docs-site/src/content/docs/packages/capacitor/how-to/secure-track-headers.mdx` | Reworked the how-to with shared header groups, precedence rules, edge cases, and production-minded examples |
| `apps/docs-site/src/content/docs/packages/contract/reference/track.mdx` | Added `HeaderGroup`, `headerGroupId`, and authoritative precedence/security behavior |
| `apps/docs-site/src/content/docs/packages/capacitor/reference/audio-player.mdx` | Updated `setup(options?: SetupOptions)` reference and header-group usage |
| `apps/docs-site/src/content/docs/packages/capacitor/reference/legato.mdx` | Clarified unified facade usage around shared playback header setup |
| `apps/docs-site/src/content/docs/how-to/migration-and-versioning.mdx` | Added 1.1.0 upgrade guidance for shared playback headers |
| `apps/docs-site/src/content/docs/releases/index.mdx` | Added public-facing 1.1.0 release context |
| `apps/docs-site/src/content/docs/packages/capacitor/how-to/index.mdx` | Improved discoverability of secure/shared header guidance |
| `apps/docs-site/src/content/docs/packages/contract/how-to/model-a-track.mdx` | Linked contract modeling guidance to shared header-group usage |

## Test Plan

- [x] Scripts run without errors: no shell scripts changed
- [x] Manually tested the affected functionality
- [x] Skills load correctly in target agent

Validation performed:
- `npm run check` (workdir: `apps/docs-site`)
- `npm run build` (workdir: `apps/docs-site`)

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts
- [x] Skills tested in at least one agent
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
