### PR TITLE
chore(expo): finalize react-native prepublish cleanup

### DIFF
--- a/packages/react-native/.npmignore
+++ b/packages/react-native/.npmignore
@@ -6,6 +6,7 @@
 
 # Keep publish payload limited to runtime module artifacts
 /android/app/
+/plugin/
 /src/
 /example/
 /docs/
@@ -22,3 +23,5 @@ __tests__
 /android/src/androidTest/
 /android/src/test/
 /android/build/
+/build/**/*.map
+/build/tsconfig.tsbuildinfo

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -2,6 +2,12 @@
 
 Expo Modules binding package for Legato host apps.
 
+## Status
+
+- Milestone 1 verified on iOS and Android Expo dev-build hosts.
+- Intended for Expo prebuild / development builds.
+- Expo Go is not supported for native playback validation.
+
 ## Expo config plugin (milestone 1 baseline)
 
 Add `"@ddgutierrezc/legato-react-native"` to your Expo plugins list to enable baseline native wiring during prebuild.
@@ -36,34 +42,52 @@ Add `"@ddgutierrezc/legato-react-native"` to your Expo plugins list to enable ba
 - Expo Go is not supported for native playback validation.
 - Supported host for this claim is Expo dev build generated via `expo prebuild` and run with `expo run:ios` / `expo run:android`.
 
-# API documentation
+## Installation
 
-- [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/@ddgutierrezc/legato-react-native/)
-- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/@ddgutierrezc/legato-react-native/)
+Install the package together with the published contract package:
 
-# Installation in managed Expo projects
-
-For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](#api-documentation). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.
-
-# Installation in bare React Native projects
-
-For bare React Native projects, you must ensure that you have [installed and configured the `expo` package](https://docs.expo.dev/bare/installing-expo-modules/) before continuing.
-
-### Add the package to your npm dependencies
-
-```
-npm install @ddgutierrezc/legato-react-native
+```bash
+npm install @ddgutierrezc/legato-react-native @ddgutierrezc/legato-contract
 ```
 
-### Configure for Android
+Add the Expo plugin to your app config:
 
+```json
+{
+  "expo": {
+    "plugins": ["@ddgutierrezc/legato-react-native"]
+  }
+}
+```
 
+Then regenerate native projects and run the host app:
 
+```bash
+npx expo prebuild --clean
+npx expo run:ios
+npx expo run:android
+```
 
-### Configure for iOS
+## What remains app-owned
 
-Run `npx pod-install` after installing the npm package.
+- runtime playback orchestration in app code
+- lifecycle policy and listener integration
+- app-specific UX around playback notifications and interruptions
+- validation on your target devices and OEMs
 
-# Contributing
+## Package contents
+
+- Expo config plugin export via `app.plugin.js`
+- JavaScript binding surface under `build/**`
+- iOS native module file `ios/LegatoModule.swift`
+- CocoaPods spec `legato-react-native.podspec`
+- Android native module and playback service scaffolding under `android/src/**`
+
+## Repository
+
+- Source: https://github.com/ddgutierrezc/legato/tree/main/packages/react-native
+- Issues: https://github.com/ddgutierrezc/legato/issues
+
+## Contributing
 
 Contributions are very welcome! Please refer to guidelines described in the [contributing guide]( https://github.com/expo/expo#contributing).

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -45,9 +45,9 @@
     "plugin": "./app.plugin.js"
   },
   "files": [
-    "build",
+    "build/**/*.js",
+    "build/**/*.d.ts",
     "app.plugin.js",
-    "plugin",
     "ios/LegatoModule.swift",
     "legato-react-native.podspec",
     "android/src",

--- a/packages/react-native/plugin/src/android.ts
+++ b/packages/react-native/plugin/src/android.ts
@@ -1,5 +1,5 @@
 import configPlugins from 'expo/config-plugins.js';
-import type { AndroidConfig, ConfigPlugin } from 'expo/config-plugins';
+import type { AndroidConfig as ExpoAndroidConfig, ConfigPlugin } from 'expo/config-plugins';
 
 const { AndroidConfig, withAndroidManifest } = configPlugins;
 
@@ -11,7 +11,7 @@ const REQUIRED_PERMISSIONS = [
 
 const SERVICE_CLASS = 'expo.modules.legato.LegatoPlaybackService';
 
-type AndroidManifest = AndroidConfig.Manifest.AndroidManifest;
+type AndroidManifest = ExpoAndroidConfig.Manifest.AndroidManifest;
 
 function ensurePermission(manifest: AndroidManifest, permission: string): void {
   const permissions = manifest.manifest['uses-permission'] ?? [];

--- a/packages/react-native/plugin/src/index.ts
+++ b/packages/react-native/plugin/src/index.ts
@@ -4,6 +4,8 @@ import type { ConfigPlugin } from 'expo/config-plugins';
 import { withLegatoAndroidManifest } from './android';
 import { withLegatoIosBackgroundAudio } from './ios';
 
+const { createRunOncePlugin } = configPlugins;
+
 export type LegatoExpoConfigPluginOptions = Record<string, never>;
 
 const withLegatoExpoConfig: ConfigPlugin<LegatoExpoConfigPluginOptions> = (config) => {
@@ -15,4 +17,3 @@ const withLegatoExpoConfig: ConfigPlugin<LegatoExpoConfigPluginOptions> = (confi
 const pkg = require('../../package.json');
 
 export default createRunOncePlugin(withLegatoExpoConfig, pkg.name, pkg.version);
-const { createRunOncePlugin } = configPlugins;

--- a/packages/react-native/plugin/tsconfig.json
+++ b/packages/react-native/plugin/tsconfig.json
@@ -1,15 +1,9 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "expo-module-scripts/tsconfig.plugin",
   "compilerOptions": {
     "outDir": "../build/plugin",
-    "rootDir": "./src",
-    "module": "commonjs",
-    "target": "ES2020",
-    "declaration": true,
-    "declarationMap": false,
-    "sourceMap": false,
-    "types": ["node"]
+    "rootDir": "./src"
   },
-  "include": ["./src/**/*.ts"],
-  "exclude": ["./src/**/__tests__/**"]
+  "include": ["./src"],
+  "exclude": ["**/__tests__/*"]
 }


### PR DESCRIPTION
## Summary

- Fix the final prepublish issues for `@ddgutierrezc/legato-react-native` so the package can be published from a clean `main` state instead of from ad-hoc local smoke-check edits.
- Tighten the npm tarball payload and plugin build wiring so `npm pack --dry-run` matches the intended published package shape.
- Improve the npm-facing README so installation, host boundaries, and package responsibilities are clear on the package page.

## Linked issue

Resolves #164

## Validation

- [x] Relevant tests/checks were run
- [x] No unrelated workflows were changed

Validation executed:
- `cd packages/react-native && npm pack --dry-run`
- `cd packages/react-native && npm run readiness:phase4.3`
- `cd packages/react-native && npx tsc --build plugin`

## Policy checks

- [x] Exactly one `type:*` label added
- [x] Approved issue linked when required (`status:approved`)