### PR TITLE
docs(react-native): add exhaustive package guides

### DIFF
--- a/apps/docs-site/src/content/docs/packages/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/index.mdx
@@ -15,6 +15,7 @@ For the canonical package support view, use the [Compatibility and Support Matri
 |---|---|---|
 | Shared playback semantics across layers (events, snapshots, invariants) | [`@ddgutierrezc/legato-contract`](contract/) | You stabilize app vocabulary and behavior assumptions before runtime wiring. |
 | Native playback runtime integration in a Capacitor app (commands, media session, listeners) | [`@ddgutierrezc/legato-capacitor`](capacitor/) + `@ddgutierrezc/legato-contract` | You get runtime APIs while keeping the same shared contract model across app layers. |
+| Native playback runtime integration in an Expo React Native app | [`@ddgutierrezc/legato-react-native`](react-native/) + `@ddgutierrezc/legato-contract` | You get Expo Modules runtime bindings plus explicit host and parity evidence boundaries. |
 
 ## Package guides
 
@@ -24,6 +25,9 @@ For the canonical package support view, use the [Compatibility and Support Matri
   </Card>
   <Card title="Capacitor package" icon="play" href="/packages/capacitor/">
     Capacitor runtime integration for `audioPlayer`, `mediaSession`, listeners, and sync helpers.
+  </Card>
+  <Card title="React Native package" icon="smartphone" href="/packages/react-native/">
+    Expo Modules runtime binding with parity-scoped API, host boundaries, and evidence-guided validation.
   </Card>
 </CardGrid>
 

--- a/apps/docs-site/src/content/docs/packages/react-native/explanation/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/react-native/explanation/index.mdx
@@ -1,0 +1,18 @@
+---
+title: Explanation
+description: Conceptual boundaries for parity claims, host validation, and ownership split.
+---
+
+## Conceptual pages
+
+| Page | Focus |
+|---|---|
+| **[Parity Boundaries](./parity-boundaries/)** | What is in scope vs out of scope for `expo-react-native-parity-v1`. |
+| **[Runtime Host Boundaries](./runtime-host-boundaries/)** | Why Expo dev build is required for native behavior claims. |
+| **[Plugin vs App Responsibilities](./plugin-vs-app-responsibilities/)** | Build-time plugin automation versus runtime app-owned orchestration. |
+
+## Related sections
+
+- [React Native package overview](../)
+- [Reference](../reference/)
+- [How-to Guides](../how-to/)

--- a/apps/docs-site/src/content/docs/packages/react-native/explanation/parity-boundaries.mdx
+++ b/apps/docs-site/src/content/docs/packages/react-native/explanation/parity-boundaries.mdx
@@ -1,6 +1,6 @@
 ---
 title: Parity Boundaries
-description: Scope guardrails for React Native baseline parity claims.
+description: In-scope and out-of-scope guardrails for React Native parity claims.
 ---
 
 This page defines what counts as parity progress for `expo-react-native-parity-v1`.
@@ -18,5 +18,15 @@ This page defines what counts as parity progress for `expo-react-native-parity-v
 - Product expansion work framed as “parity”.
 - Expo Go claims for native runtime parity.
 - Device/OEM reliability guarantees beyond validated baseline scenarios.
+
+## Why this boundary exists
+
+The package has separate layers with separate evidence types:
+
+- JS surface parity tests validate exports and helper contracts.
+- Runtime behavior claims require native host execution evidence.
+- Plugin behavior is prebuild-time and cannot prove runtime app orchestration.
+
+Combining those layers into one claim without evidence per layer would overstate what source currently guarantees.
 
 If a request falls in out-of-scope, it must be deferred into a separate change proposal.

--- a/apps/docs-site/src/content/docs/packages/react-native/explanation/plugin-vs-app-responsibilities.mdx
+++ b/apps/docs-site/src/content/docs/packages/react-native/explanation/plugin-vs-app-responsibilities.mdx
@@ -1,0 +1,36 @@
+---
+title: Plugin vs App Responsibilities
+description: Ownership split between Expo config plugin automation and runtime app code.
+---
+
+This package intentionally separates build-time automation from runtime behavior ownership.
+
+## Plugin-owned responsibilities
+
+From `plugin/src/index.ts`, `plugin/src/ios.ts`, and `plugin/src/android.ts`:
+
+- Apply iOS `UIBackgroundModes` baseline (`audio`).
+- Apply Android foreground media playback permissions.
+- Ensure one valid `expo.modules.legato.LegatoPlaybackService` declaration.
+
+These are prebuild-time native file transformations.
+
+## App-owned responsibilities
+
+From package README + readiness docs:
+
+- Call runtime APIs (`setup`, queue mutation, transport commands).
+- Register and remove listeners in app lifecycle.
+- Decide UX behavior for progress, remote commands, and error handling.
+- Validate your own release/device targets and preserve evidence.
+
+## Boundary enforcement signals
+
+- `plugin/src/__tests__/boundary.test.ts` guards build-time-only boundary (no runtime bridge imports).
+- `plugin/src/__tests__/docs-readiness.test.ts` asserts docs communicate this split.
+
+## Practical implication
+
+If playback behavior is incorrect in your app, plugin success alone does not prove runtime correctness. You must inspect app wiring and host validation evidence.
+
+Related: [Expo Config Plugin reference](../reference/expo-config-plugin/) and [Runtime Host Boundaries](./runtime-host-boundaries/).

--- a/apps/docs-site/src/content/docs/packages/react-native/explanation/runtime-host-boundaries.mdx
+++ b/apps/docs-site/src/content/docs/packages/react-native/explanation/runtime-host-boundaries.mdx
@@ -1,0 +1,25 @@
+---
+title: Runtime Host Boundaries
+description: Why native validation claims depend on Expo dev-build hosts, not Expo Go.
+---
+
+Runtime host boundaries define where native behavior evidence is considered valid.
+
+## Host policy
+
+Source docs in `packages/react-native/docs/milestone-1-compatibility-and-readiness.md` and package README establish:
+
+- Expo Go is excluded for native playback validation claims.
+- Supported claim host is Expo development build generated via `expo prebuild` and run with `expo run:ios` / `expo run:android`.
+
+## Why this matters
+
+The JavaScript wrapper (`src/plugin.ts`, `src/events.ts`, `src/sync.ts`) can be tested in isolation, but native playback behavior also depends on native module execution paths (`ios/LegatoModule.swift`, `android/.../LegatoModule.kt`).
+
+That native path is part of the claim, so host evidence must execute the native module in real development build hosts.
+
+## Evidence consequence
+
+A parity claim can remain blocked even if JS tests pass, when dual-platform host evidence is missing or incomplete.
+
+Related: [Parity Mapping](../reference/parity-mapping/) and [Troubleshoot Host and Parity Validation](../how-to/troubleshoot-host-and-parity-validation/).

--- a/apps/docs-site/src/content/docs/packages/react-native/how-to/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/react-native/how-to/index.mdx
@@ -1,0 +1,25 @@
+---
+title: How-to Guides
+description: Task-oriented guides for integrating @ddgutierrezc/legato-react-native.
+---
+
+import { Card, CardGrid } from '@astrojs/starlight/components';
+
+<CardGrid>
+  <Card title="Set up Expo dev build" icon="setting">
+    **[Set Up Expo Dev Build](./set-up-expo-dev-build/)**
+    Install package + plugin and validate native host boundaries.
+  </Card>
+  <Card title="Play track and events" icon="play">
+    **[Play Track and Listen Events](./play-track-and-listen-events/)**
+    Wire setup, queue, playback, and listener teardown.
+  </Card>
+  <Card title="Sync controller" icon="sync">
+    **[Use Sync Controller](./use-sync-controller/)**
+    Mirror snapshots in app state with `createLegatoSync`.
+  </Card>
+  <Card title="Troubleshoot boundaries" icon="warning">
+    **[Troubleshoot Host and Parity Validation](./troubleshoot-host-and-parity-validation/)**
+    Resolve common host/evidence/parity blocking issues.
+  </Card>
+</CardGrid>

--- a/apps/docs-site/src/content/docs/packages/react-native/how-to/play-track-and-listen-events.mdx
+++ b/apps/docs-site/src/content/docs/packages/react-native/how-to/play-track-and-listen-events.mdx
@@ -1,0 +1,54 @@
+---
+title: How to play a track and listen to events
+description: Minimal app-owned runtime wiring for playback plus listener lifecycle.
+---
+
+## Prerequisites
+
+- Package installed and Expo dev build setup completed.
+- Native host app running (`expo run:ios` or `expo run:android`).
+
+## Steps
+
+1. Call setup before playback operations.
+
+```ts
+await audioPlayer.setup();
+```
+
+2. Register listeners.
+
+```ts
+const progressHandle = onPlaybackProgress(({ position }) => {
+  console.log('position', position);
+});
+const stateHandle = onPlaybackStateChanged(({ state }) => {
+  console.log('state', state);
+});
+```
+
+3. Add a track to queue.
+
+```ts
+await audioPlayer.add({
+  tracks: [{ id: 'intro', url: 'https://example.com/intro.mp3' }],
+  startIndex: 0,
+});
+```
+
+4. Start playback.
+
+```ts
+await audioPlayer.play();
+```
+
+5. Remove listeners during teardown.
+
+```ts
+await progressHandle.remove();
+await stateHandle.remove();
+```
+
+## Expected Result
+
+Playback and event delivery are app-wired from runtime namespaces (`audioPlayer`, listener helpers), with explicit listener cleanup.

--- a/apps/docs-site/src/content/docs/packages/react-native/how-to/set-up-expo-dev-build.mdx
+++ b/apps/docs-site/src/content/docs/packages/react-native/how-to/set-up-expo-dev-build.mdx
@@ -1,0 +1,59 @@
+---
+title: How to set up Expo dev build hosts
+description: Install and configure @ddgutierrezc/legato-react-native for supported host validation.
+---
+
+## Prerequisites
+
+- Expo app project where you can run `expo prebuild`, `expo run:ios`, and `expo run:android`.
+- iOS and/or Android local build tooling already working for your Expo app.
+
+## Steps
+
+1. Install package dependencies.
+
+```bash
+npm install @ddgutierrezc/legato-react-native @ddgutierrezc/legato-contract
+```
+
+2. Register the plugin in Expo config.
+
+```json
+{
+  "expo": {
+    "plugins": ["@ddgutierrezc/legato-react-native"]
+  }
+}
+```
+
+3. Regenerate native projects.
+
+```bash
+npx expo prebuild --clean
+```
+
+4. Build and run iOS host.
+
+```bash
+npx expo run:ios
+```
+
+5. Build and run Android host.
+
+```bash
+npx expo run:android
+```
+
+## Verify plugin baseline wiring
+
+- iOS: `UIBackgroundModes` includes `audio` once.
+- Android: manifest includes required foreground-service permissions.
+- Android: one `expo.modules.legato.LegatoPlaybackService` node with `exported=false` and `foregroundServiceType=mediaPlayback`.
+
+These checks align with `packages/react-native/plugin/src/ios.ts`, `plugin/src/android.ts`, and the readiness checklist evidence contract.
+
+## Expected Result
+
+Your app runs as an Expo development build host with plugin-owned native baseline wiring applied.
+
+Native playback validation claims remain blocked until runtime evidence is recorded for both platforms.

--- a/apps/docs-site/src/content/docs/packages/react-native/how-to/troubleshoot-host-and-parity-validation.mdx
+++ b/apps/docs-site/src/content/docs/packages/react-native/how-to/troubleshoot-host-and-parity-validation.mdx
@@ -1,0 +1,53 @@
+---
+title: How to troubleshoot host and parity validation
+description: Resolve common parity blockers around host mode, plugin wiring, and evidence completeness.
+---
+
+## Prerequisites
+
+- Access to the host app used for validation.
+- Access to parity/evidence docs under `packages/react-native/docs/`.
+
+## Steps
+
+1. Verify host mode first.
+
+If validation was run in Expo Go, rerun with:
+
+```bash
+npx expo prebuild --clean
+npx expo run:ios
+npx expo run:android
+```
+
+2. Verify plugin registration.
+
+Ensure Expo config includes:
+
+```json
+{
+  "expo": {
+    "plugins": ["@ddgutierrezc/legato-react-native"]
+  }
+}
+```
+
+3. Validate Android service shape.
+
+Confirm one `expo.modules.legato.LegatoPlaybackService` declaration with:
+- `android:exported="false"`
+- `android:foregroundServiceType="mediaPlayback"`
+
+4. Resolve duplicated manual Android service edits.
+
+Follow the manual conflict steps in `packages/react-native/docs/milestone-1-readiness-checklist.md` and regenerate native projects.
+
+5. Re-check parity evidence completeness.
+
+Confirm all required entries in:
+- `packages/react-native/docs/evidence/parity-readiness-checklist.md`
+- `packages/react-native/docs/evidence/phase4-3-expo-host-validation-2026-05-02.md`
+
+## Expected Result
+
+Validation is executed in supported hosts, plugin baseline wiring is aligned with source contracts, and parity claim status can be evaluated from complete evidence artifacts.

--- a/apps/docs-site/src/content/docs/packages/react-native/how-to/use-sync-controller.mdx
+++ b/apps/docs-site/src/content/docs/packages/react-native/how-to/use-sync-controller.mdx
@@ -1,0 +1,48 @@
+---
+title: How to use sync controller
+description: Mirror playback snapshots in local state using createLegatoSync.
+---
+
+## Prerequisites
+
+- Runtime setup already integrated in app code.
+- Familiarity with `PlaybackSnapshot` projection.
+
+## Steps
+
+1. Create a controller.
+
+```ts
+const sync = createLegatoSync({
+  onSnapshot: (snapshot) => setPlaybackSnapshot(snapshot),
+  onEvent: (eventName) => console.log('event', eventName),
+});
+```
+
+2. Start sync.
+
+```ts
+await sync.start();
+```
+
+3. Read current snapshot when needed.
+
+```ts
+const current = sync.getCurrent();
+```
+
+4. Force a resync after app-specific lifecycle transitions.
+
+```ts
+await sync.resync();
+```
+
+5. Stop and cleanup.
+
+```ts
+await sync.stop();
+```
+
+## Expected Result
+
+Your app maintains a local playback snapshot that starts from `getSnapshot()` and updates from subscribed events, with deterministic cleanup on stop.

--- a/apps/docs-site/src/content/docs/packages/react-native/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/react-native/index.mdx
@@ -1,22 +1,103 @@
 ---
 title: React Native Package
-description: Expo React Native baseline parity package aligned to Capacitor semantics.
+description: Expo Modules runtime binding for Legato with parity-scoped docs and host boundaries.
 ---
 
-`@ddgutierrezc/legato-react-native` is the Expo Modules binding for Legato playback runtime APIs.
+import { Aside, Card, CardGrid } from '@astrojs/starlight/components';
 
-This package is delivered under a **Capacitor parity** objective: the baseline RN surface mirrors Capacitor namespaces, events, sync factories, and contract-first type semantics.
+`@ddgutierrezc/legato-react-native` is the Expo Modules binding for Legato playback on iOS and Android.
 
-## What parity means in this milestone
+This package line is documented with an explicit parity scope against `@ddgutierrezc/legato-capacitor`: same baseline exports, event constants, and sync semantics, with evidence-gated runtime claims.
+
+## Installation
+
+```bash
+npm install @ddgutierrezc/legato-react-native @ddgutierrezc/legato-contract
+```
+
+Add the Expo config plugin:
+
+```json
+{
+  "expo": {
+    "plugins": ["@ddgutierrezc/legato-react-native"]
+  }
+}
+```
+
+Generate and run native hosts:
+
+```bash
+npx expo prebuild --clean
+npx expo run:ios
+npx expo run:android
+```
+
+<Aside type="note">
+Expo Go is not a supported host for native playback validation claims in this package line.
+</Aside>
+
+## What this package exposes
 
 - Same baseline exports (`audioPlayer`, `mediaSession`, `Legato`)
 - Same baseline event constants and listener helpers
 - Same sync startup semantics (`start()` snapshot + subscribe)
-- Same in-scope boundaries for parity claims
 
-## Read the parity docs
+```ts
+import { audioPlayer, mediaSession, Legato } from '@ddgutierrezc/legato-react-native';
+import {
+  AUDIO_PLAYER_EVENTS,
+  MEDIA_SESSION_EVENTS,
+  LEGATO_EVENTS,
+  addAudioPlayerListener,
+  addMediaSessionListener,
+  addLegatoListener,
+  onPlaybackStateChanged,
+  onPlaybackActiveTrackChanged,
+  onPlaybackQueueChanged,
+  onPlaybackProgress,
+  onPlaybackEnded,
+  onPlaybackError,
+  onRemotePlay,
+  onRemotePause,
+  onRemoteNext,
+  onRemotePrevious,
+  onRemoteSeek,
+  createLegatoSync,
+  createAudioPlayerSync,
+} from '@ddgutierrezc/legato-react-native';
+```
 
-- [Parity Mapping](./reference/parity-mapping/) — capability-by-capability mapping and evidence links.
-- [Parity Boundaries](./explanation/parity-boundaries/) — in-scope and out-of-scope guardrails.
+## Documentation structure
 
-For command-level API usage examples, use the Capacitor reference as the baseline model while this RN parity line stabilizes.
+<CardGrid>
+  <Card title="Reference" icon="seti:api">
+    **[reference/](./reference/)**
+    API details for namespaces, events, sync, types, and plugin surface.
+  </Card>
+  <Card title="How-to" icon="list-check">
+    **[how-to/](./how-to/)**
+    Task-focused guides for Expo dev builds, event wiring, and sync usage.
+  </Card>
+  <Card title="Explanation" icon="lightbulb">
+    **[explanation/](./explanation/)**
+    Boundaries and responsibilities for host/runtime/parity decisions.
+  </Card>
+</CardGrid>
+
+## Scope reminders
+
+- Plugin automation is prebuild-time native baseline wiring only.
+- Playback orchestration and lifecycle policy stay app-owned.
+- Parity claims are gated by source-backed evidence docs and tests.
+
+## Start here
+
+- [API Reference](./reference/)
+- [How-to Guides](./how-to/)
+- [Parity Mapping](./reference/parity-mapping/)
+- [Parity Boundaries](./explanation/parity-boundaries/)
+
+<Aside type="note">
+For shared data contracts (`Track`, snapshots, event payload maps), see the [Contract package docs](../contract/).
+</Aside>

--- a/apps/docs-site/src/content/docs/packages/react-native/reference/audio-player.mdx
+++ b/apps/docs-site/src/content/docs/packages/react-native/reference/audio-player.mdx
@@ -1,0 +1,74 @@
+---
+title: Audio Player API
+description: Reference for the audioPlayer namespace in @ddgutierrezc/legato-react-native.
+---
+
+`audioPlayer` is the playback namespace exported from `plugin.ts` and typed as `AudioPlayerApi`.
+
+## Interface
+
+```ts
+interface AudioPlayerApi {
+  setup(options?: SetupOptions): Promise<void>;
+  add(options: AddOptions): Promise<PlaybackSnapshot>;
+  remove(options: RemoveOptions): Promise<PlaybackSnapshot>;
+  reset(): Promise<PlaybackSnapshot>;
+  play(): Promise<void>;
+  pause(): Promise<void>;
+  stop(): Promise<void>;
+  seekTo(options: SeekToOptions): Promise<void>;
+  skipTo(options: SkipToOptions): Promise<PlaybackSnapshot>;
+  skipToNext(): Promise<void>;
+  skipToPrevious(): Promise<void>;
+  getState(): Promise<PlaybackState>;
+  getPosition(): Promise<number>;
+  getDuration(): Promise<number | null>;
+  getCurrentTrack(): Promise<Track | null>;
+  getQueue(): Promise<QueueSnapshot>;
+  getSnapshot(): Promise<PlaybackSnapshot>;
+  getCapabilities(): Promise<BindingCapabilitiesSnapshot>;
+  addListener<E extends AudioPlayerEventName>(
+    eventName: E,
+    listener: AudioPlayerListener<E>
+  ): Promise<BindingListenerHandle>;
+  removeAllListeners(): Promise<void>;
+}
+```
+
+## Method groups
+
+| Group | Methods |
+|---|---|
+| Setup | `setup` |
+| Queue mutation | `add`, `remove`, `reset`, `skipTo`, `skipToNext`, `skipToPrevious` |
+| Transport | `play`, `pause`, `stop`, `seekTo` |
+| Queries | `getState`, `getPosition`, `getDuration`, `getCurrentTrack`, `getQueue`, `getSnapshot`, `getCapabilities` |
+| Events | `addListener`, `removeAllListeners` |
+
+## Parameters (object methods)
+
+| Method | Parameter | Type | Required | Description |
+|---|---|---|---|---|
+| `setup` | `options.headerGroups` | `HeaderGroup[]` | ❌ | Shared header groups for tracks that reference `headerGroupId`. |
+| `add` | `options.tracks` | `Track[]` | ✅ | Tracks to append. |
+| `add` | `options.startIndex` | `number` | ❌ | Initial active index after insertion. |
+| `remove` | `options.id` | `string` | ❌ | Queue item id to remove. |
+| `remove` | `options.index` | `number` | ❌ | Queue index to remove. |
+| `seekTo` | `options.position` | `number` | ✅ | Target playback position. |
+| `skipTo` | `options.index` | `number` | ✅ | Queue index to activate. |
+
+## Return normalization
+
+`plugin.ts` accepts native bridge return variants and normalizes them before returning to callers:
+
+- `add/remove/reset/skipTo/getSnapshot`: unwrap `{ snapshot }` or direct snapshot.
+- `getState`: unwrap `{ state }` or direct state.
+- `getPosition/getDuration/getCurrentTrack/getQueue`: unwrap wrapped/object responses where present.
+
+## Minimal usage
+
+```ts
+await audioPlayer.setup();
+await audioPlayer.add({ tracks: [{ id: 't1', url: 'https://example.com/t1.mp3' }] });
+await audioPlayer.play();
+```

--- a/apps/docs-site/src/content/docs/packages/react-native/reference/events.mdx
+++ b/apps/docs-site/src/content/docs/packages/react-native/reference/events.mdx
@@ -1,0 +1,55 @@
+---
+title: Events
+description: Event constants and listener helpers exported by @ddgutierrezc/legato-react-native.
+---
+
+The package exports three constant arrays and helper functions from `src/events.ts`.
+
+## Constants
+
+| Constant | Source |
+|---|---|
+| `AUDIO_PLAYER_EVENTS` | `PLAYER_EVENT_NAMES` from `@ddgutierrezc/legato-contract` |
+| `MEDIA_SESSION_EVENTS` | `MEDIA_SESSION_EVENT_NAMES` from `@ddgutierrezc/legato-contract` |
+| `LEGATO_EVENTS` | `LEGATO_EVENT_NAMES` from `@ddgutierrezc/legato-contract` |
+
+## Helper functions
+
+| Export | Purpose |
+|---|---|
+| `addAudioPlayerListener` | Bound helper to `audioPlayer.addListener`. |
+| `addMediaSessionListener` | Bound helper to `mediaSession.addListener`. |
+| `addLegatoListener` | Facade-level listener helper (`Legato.addListener`). |
+| `onPlaybackStateChanged` | Shortcut for `'playback-state-changed'`. |
+| `onPlaybackActiveTrackChanged` | Shortcut for `'playback-active-track-changed'`. |
+| `onPlaybackQueueChanged` | Shortcut for `'playback-queue-changed'`. |
+| `onPlaybackProgress` | Shortcut for `'playback-progress'`. |
+| `onPlaybackEnded` | Shortcut for `'playback-ended'`. |
+| `onPlaybackError` | Shortcut for `'playback-error'`. |
+| `onRemotePlay` | Shortcut for `'remote-play'`. |
+| `onRemotePause` | Shortcut for `'remote-pause'`. |
+| `onRemoteNext` | Shortcut for `'remote-next'`. |
+| `onRemotePrevious` | Shortcut for `'remote-previous'`. |
+| `onRemoteSeek` | Shortcut for `'remote-seek'`. |
+
+## Canonical event names
+
+`LegatoModule` (iOS and Android) declares these event names:
+
+- `playback-state-changed`
+- `playback-active-track-changed`
+- `playback-queue-changed`
+- `playback-progress`
+- `playback-ended`
+- `playback-error`
+- `remote-play`
+- `remote-pause`
+- `remote-next`
+- `remote-previous`
+- `remote-seek`
+
+```ts
+const handle = onPlaybackProgress(({ position }) => {
+  // update UI from projected progress
+});
+```

--- a/apps/docs-site/src/content/docs/packages/react-native/reference/expo-config-plugin.mdx
+++ b/apps/docs-site/src/content/docs/packages/react-native/reference/expo-config-plugin.mdx
@@ -1,0 +1,45 @@
+---
+title: Expo Config Plugin
+description: Build-time plugin behavior and boundaries for @ddgutierrezc/legato-react-native.
+---
+
+The package exports a run-once Expo config plugin from `plugin/src/index.ts`.
+
+## Plugin entry
+
+```ts
+plugins: ['@ddgutierrezc/legato-react-native']
+```
+
+`LegatoExpoConfigPluginOptions` is currently `Record<string, never>`, so milestone-1 has no public option knobs.
+
+## What the plugin modifies
+
+### iOS (`plugin/src/ios.ts`)
+
+- Ensures `UIBackgroundModes` includes `audio`.
+- Uses set semantics to avoid duplicates.
+
+### Android (`plugin/src/android.ts`)
+
+- Ensures manifest permissions:
+  - `android.permission.FOREGROUND_SERVICE`
+  - `android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK`
+  - `android.permission.WAKE_LOCK`
+- Ensures exactly one `expo.modules.legato.LegatoPlaybackService` declaration under application services with:
+  - `android:enabled="true"`
+  - `android:exported="false"`
+  - `android:foregroundServiceType="mediaPlayback"`
+
+## Boundaries
+
+| Category | In scope | Out of scope |
+|---|---|---|
+| Build-time native wiring | ✅ prebuild manifest/plist baseline | ❌ runtime playback orchestration |
+| Options | ✅ plain plugin string registration | ❌ custom channels/service-class overrides/arbitrary patch options |
+| Host claims | ✅ Expo dev build (`prebuild`, `run:ios`, `run:android`) | ❌ Expo Go native proof claims |
+
+## Test-backed guardrails
+
+- `plugin/src/__tests__/boundary.test.ts`: plugin remains build-time and avoids runtime bridge imports.
+- `plugin/src/__tests__/docs-readiness.test.ts`: docs boundary statements and readiness evidence requirements are enforced.

--- a/apps/docs-site/src/content/docs/packages/react-native/reference/index.mdx
+++ b/apps/docs-site/src/content/docs/packages/react-native/reference/index.mdx
@@ -1,0 +1,46 @@
+---
+title: API Reference
+description: Source-backed API reference for @ddgutierrezc/legato-react-native.
+---
+
+This section documents the public export surface from `packages/react-native/src/index.ts`.
+
+## Reference pages
+
+| Page | Description |
+|---|---|
+| **[Audio Player](./audio-player/)** | `audioPlayer` namespace (`AudioPlayerApi`) for setup, queue, transport, snapshot queries, capabilities, and listeners. |
+| **[Media Session](./media-session/)** | `mediaSession` namespace (`MediaSessionApi`) for remote-command listeners. |
+| **[Legato Facade](./legato/)** | `Legato` unified facade combining playback + media-session namespaces. |
+| **[Events](./events/)** | Event constants and listener helper exports from `events.ts`. |
+| **[Sync](./sync/)** | `createLegatoSync` and `createAudioPlayerSync` controller factories. |
+| **[Types](./types/)** | Public type contracts re-exported or declared by this package. |
+| **[Expo Config Plugin](./expo-config-plugin/)** | Build-time plugin behavior and boundaries (`plugin/src/*`). |
+| **[Parity Mapping](./parity-mapping/)** | Capability-by-capability parity map with evidence pointers. |
+
+## Export index
+
+```ts
+export { Legato, audioPlayer, mediaSession };
+export {
+  AUDIO_PLAYER_EVENTS,
+  MEDIA_SESSION_EVENTS,
+  LEGATO_EVENTS,
+  addAudioPlayerListener,
+  addMediaSessionListener,
+  addLegatoListener,
+  onPlaybackStateChanged,
+  onPlaybackActiveTrackChanged,
+  onPlaybackQueueChanged,
+  onPlaybackProgress,
+  onPlaybackEnded,
+  onPlaybackError,
+  onRemotePlay,
+  onRemotePause,
+  onRemoteNext,
+  onRemotePrevious,
+  onRemoteSeek,
+};
+export { createAudioPlayerSync, createLegatoSync };
+export type * from './definitions';
+```

--- a/apps/docs-site/src/content/docs/packages/react-native/reference/legato.mdx
+++ b/apps/docs-site/src/content/docs/packages/react-native/reference/legato.mdx
@@ -1,0 +1,39 @@
+---
+title: Legato Facade
+description: Reference for the Legato unified namespace facade.
+---
+
+`Legato` is exported as `LegatoApi & LegatoEventApi` and combines `audioPlayer` + `mediaSession` with a single `addListener` signature over `LegatoEventName`.
+
+## Composition
+
+In `plugin.ts`, `Legato` is composed as:
+
+```ts
+export const Legato = {
+  ...audioPlayer,
+  ...mediaSession,
+  addListener: addLegatoListener,
+  removeAllListeners: sharedDelegate.removeAllListeners,
+};
+```
+
+## Interface summary
+
+| Surface | Included |
+|---|---|
+| Playback setup, queue, transport, queries, capabilities | ✅ from `audioPlayer` |
+| Media-session listener surface | ✅ from `mediaSession` |
+| Unified listener (`LegatoEventName`) | ✅ via `Legato.addListener` |
+
+## Listener behavior
+
+`Legato.addListener` delegates to `LegatoModule.addListener`, like the namespace-specific helpers.
+
+```ts
+const h = await Legato.addListener('playback-state-changed', ({ state }) => {
+  // sync your UI store
+});
+
+await h.remove();
+```

--- a/apps/docs-site/src/content/docs/packages/react-native/reference/media-session.mdx
+++ b/apps/docs-site/src/content/docs/packages/react-native/reference/media-session.mdx
@@ -1,0 +1,39 @@
+---
+title: Media Session API
+description: Reference for the mediaSession namespace in @ddgutierrezc/legato-react-native.
+---
+
+`mediaSession` is typed as `MediaSessionApi` and exposes listener-oriented remote command integration.
+
+## Interface
+
+```ts
+interface MediaSessionApi {
+  setup(): Promise<void>;
+  addListener<E extends MediaSessionEventName>(
+    eventName: E,
+    listener: MediaSessionListener<E>
+  ): Promise<BindingListenerHandle>;
+  removeAllListeners(): Promise<void>;
+}
+```
+
+## Methods
+
+| Method | Purpose |
+|---|---|
+| `setup()` | Delegates to shared setup bridge (`LegatoModule.setup`). |
+| `addListener(eventName, listener)` | Subscribes to media-session event names using native module events. |
+| `removeAllListeners()` | Clears registered listeners at the native module layer. |
+
+## Event name source
+
+The event-name set is exported from `MEDIA_SESSION_EVENTS`, which is assigned from `MEDIA_SESSION_EVENT_NAMES` in `@ddgutierrezc/legato-contract`.
+
+```ts
+const handle = await mediaSession.addListener('remote-play', () => {
+  // app decides behavior
+});
+
+await handle.remove();
+```

--- a/apps/docs-site/src/content/docs/packages/react-native/reference/parity-mapping.mdx
+++ b/apps/docs-site/src/content/docs/packages/react-native/reference/parity-mapping.mdx
@@ -1,9 +1,9 @@
 ---
 title: Parity Mapping
-description: Baseline export and semantic parity mapping from Capacitor to React Native.
+description: Baseline mapping from Capacitor surface to React Native plus evidence gates.
 ---
 
-Use this table as the auditable map for `expo-react-native-parity-v1` claims.
+Use this page as the auditable mapping for `expo-react-native-parity-v1` claims.
 
 | Capacitor baseline | React Native | Parity status | Evidence |
 |---|---|---|---|
@@ -15,6 +15,17 @@ Use this table as the auditable map for `expo-react-native-parity-v1` claims.
 | `createLegatoSync` | `createLegatoSync` | ✅ Implemented | `packages/react-native/scripts/__tests__/expo-parity-surface.test.mjs` |
 | `createAudioPlayerSync` | `createAudioPlayerSync` | ✅ Implemented | `packages/react-native/scripts/__tests__/expo-parity-surface.test.mjs` |
 
+## Semantic parity checkpoints
+
+| Checkpoint | Source |
+|---|---|
+| `start()` resync-before-subscribe behavior | `packages/react-native/src/__tests__/sync-behavior-parity.test.ts` |
+| Snapshot projection for queue/state/progress events | `packages/react-native/src/__tests__/sync-behavior-parity.test.ts` |
+| Non-projecting event behavior (`onEvent` only) | `packages/react-native/src/__tests__/sync-behavior-parity.test.ts` |
+| Listener cleanup on `stop()` | `packages/react-native/src/__tests__/sync-behavior-parity.test.ts` |
+
 ## Evidence gate reminder
 
-Passing JS/native parity assertions is necessary but not sufficient. Final parity claim is valid only when the evidence checklist in `packages/react-native/docs/evidence/parity-readiness-checklist.md` is complete for both iOS and Android dev-build hosts.
+Passing JS/native parity assertions is necessary but not sufficient.
+
+Final parity claim is valid only when all items in `packages/react-native/docs/evidence/parity-readiness-checklist.md` are complete, including dual-platform Expo dev-build host evidence.

--- a/apps/docs-site/src/content/docs/packages/react-native/reference/sync.mdx
+++ b/apps/docs-site/src/content/docs/packages/react-native/reference/sync.mdx
@@ -1,0 +1,46 @@
+---
+title: Sync Controllers
+description: Reference for createLegatoSync and createAudioPlayerSync.
+---
+
+Sync controllers are implemented in `src/sync.ts` and provide local snapshot projection from one initial snapshot plus event updates.
+
+## Factory functions
+
+| Function | Return | Notes |
+|---|---|---|
+| `createLegatoSync(options?)` | `LegatoSyncController` | Uses `options.client` or defaults to `Legato`. |
+| `createAudioPlayerSync(options?)` | `LegatoSyncController` | Alias that calls `createLegatoSync(options)`. |
+
+## Options
+
+| Option | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `client` | `AudioPlayerApi` | ❌ | `Legato` | API client used for `getSnapshot()` and event subscriptions. |
+| `onSnapshot` | `(snapshot) => void` | ❌ | — | Called whenever controller publishes a new current snapshot. |
+| `onEvent` | `(eventName, payload) => void` | ❌ | — | Called on each event received through subscriptions. |
+
+## Controller interface
+
+```ts
+interface LegatoSyncController {
+  start(): Promise<PlaybackSnapshot>;
+  resync(): Promise<PlaybackSnapshot>;
+  getCurrent(): PlaybackSnapshot | null;
+  stop(): Promise<void>;
+}
+```
+
+## Behavioral guarantees from tests
+
+`src/__tests__/sync-behavior-parity.test.ts` verifies:
+
+- `start()` performs `resync()` before adding listeners.
+- Queue/state/progress/active-track events project into the current snapshot.
+- Non-projecting events (for example `playback-error`, remote commands) trigger `onEvent` but do not mutate the snapshot.
+- `stop()` removes all registered listener handles.
+
+```ts
+const sync = createLegatoSync({ onSnapshot: (s) => setSnapshot(s) });
+await sync.start();
+```

--- a/apps/docs-site/src/content/docs/packages/react-native/reference/types.mdx
+++ b/apps/docs-site/src/content/docs/packages/react-native/reference/types.mdx
@@ -1,0 +1,41 @@
+---
+title: Types
+description: Public TypeScript types exposed by @ddgutierrezc/legato-react-native.
+---
+
+The package exports all types from `src/definitions.ts` (`export type * from './definitions'`).
+
+## Re-exported contract types
+
+| Type | Origin |
+|---|---|
+| `LegatoError` | `@ddgutierrezc/legato-contract` |
+| `PlaybackSnapshot` | `@ddgutierrezc/legato-contract` |
+| `PlaybackState` | `@ddgutierrezc/legato-contract` |
+| `QueueSnapshot` | `@ddgutierrezc/legato-contract` |
+| `Track` | `@ddgutierrezc/legato-contract` |
+| `HeaderGroup` | `@ddgutierrezc/legato-contract` |
+| `AudioPlayerEventName` / `MediaSessionEventName` / `LegatoEventName` | `@ddgutierrezc/legato-contract` |
+| `AudioPlayerEventPayloadMap` / `MediaSessionEventPayloadMap` / `LegatoEventPayloadMap` | `@ddgutierrezc/legato-contract` |
+
+## Package-local interfaces
+
+| Type | Purpose |
+|---|---|
+| `SetupOptions` | Setup-time header group registration. |
+| `AddOptions` | Queue add input shape. |
+| `RemoveOptions` | Queue remove by `id` or `index`. |
+| `SeekToOptions` | Seek input (`position`). |
+| `SkipToOptions` | Index-based skip input. |
+| `BindingListenerHandle` | Listener removal handle (`remove()`). |
+| `BindingCapabilitiesSnapshot` | Runtime capability projection (`supported: Capability[]`). |
+| `BindingAdapter` | Full bridge adapter contract. |
+| `AudioPlayerApi` | Playback namespace contract. |
+| `MediaSessionApi` | Remote session namespace contract. |
+| `LegatoApi` | Combined player + media-session API. |
+| `LegatoEventApi` | Unified event-listener contract. |
+
+## Notes on strictness
+
+- Event names and payload maps are tied to the contract package type exports.
+- The parity checklist records a strictness gate for public type coverage in this baseline scope.


### PR DESCRIPTION
## Summary

- Add a full React Native package documentation section in `apps/docs-site` covering overview, reference, how-to, and explanation pages from the source-backed API and plugin surface.
- Make the React Native package discoverable from the package hub and document boundaries, parity mapping, troubleshooting, and sync/event behavior in a way that is auditable from code and evidence artifacts.
- Validate the docs-site build/check so the new pages are structurally sound before merge.

## Linked issue

Resolves #168

## Validation

- [x] Relevant tests/checks were run
- [x] No unrelated workflows were changed

Validation executed:
- `cd apps/docs-site && npm run build`
- `cd apps/docs-site && npm run check`

## Policy checks

- [x] Exactly one `type:*` label added
- [x] Approved issue linked when required (`status:approved`)