### PR TITLE
fix(release): unblock react-native trusted publish

### DIFF
--- a/apps/capacitor-demo/scripts/release-control-contract.mjs
+++ b/apps/capacitor-demo/scripts/release-control-contract.mjs
@@ -1,5 +1,7 @@
 const TARGETS = ['android', 'ios', 'npm'];
 import { buildCanonicalRefs } from './release-paths.mjs';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 // Governance v1 note:
 // - target/mode validation is a preflight contract gate for release-control.yml.
@@ -44,7 +46,7 @@ export const validateReleaseControlContract = ({
   repoRoot = '.',
   npmPackageTarget = 'capacitor',
   releaseChannel = 'stable',
-  releaseVersion = '0.1.1',
+  releaseVersion,
   releaseKey = '',
 } = {}) => {
   const errors = [];
@@ -98,10 +100,29 @@ export const validateReleaseControlContract = ({
     }
   }
 
+  const normalizedRepoRoot = String(repoRoot ?? '.').trim() || '.';
+  const normalizedNpmPackageTarget = String(npmPackageTarget ?? '').trim() || 'capacitor';
+
+  const deriveDefaultReleaseVersion = () => {
+    if (normalizedNpmPackageTarget === 'react-native') {
+      try {
+        const packageJson = JSON.parse(
+          readFileSync(resolve(normalizedRepoRoot, 'packages/react-native/package.json'), 'utf8'),
+        );
+        return String(packageJson?.version ?? '1.0.0').trim() || '1.0.0';
+      } catch {
+        return '1.0.0';
+      }
+    }
+    return '0.1.1';
+  };
+
+  const derivedDefaultReleaseVersion = deriveDefaultReleaseVersion();
+
   const releaseIdentity = {
     channel: String(releaseChannel ?? 'stable').trim() || 'stable',
-    version: String(releaseVersion ?? '0.1.1').trim() || '0.1.1',
-    package_target: String(npmPackageTarget ?? '').trim() || 'capacitor',
+    version: String(releaseVersion ?? derivedDefaultReleaseVersion).trim() || derivedDefaultReleaseVersion,
+    package_target: normalizedNpmPackageTarget,
   };
   releaseIdentity.release_key = `${releaseIdentity.channel}/v${releaseIdentity.version.replace(/^v/i, '')}/${releaseIdentity.package_target}`;
   const explicitReleaseKey = String(releaseKey ?? '').trim();
@@ -127,7 +148,7 @@ export const validateReleaseControlContract = ({
         release_id: normalizedReleaseId,
         release_identity: releaseIdentity,
         phase: normalizePhase(phase),
-        repo_root: String(repoRoot ?? '.').trim() || '.',
+        repo_root: normalizedRepoRoot,
         selected_targets: normalizedTargets,
         target_modes: Object.fromEntries(
           normalizedTargets.map((target) => [target, String(targetModes[target] ?? '').trim()]),
@@ -135,7 +156,7 @@ export const validateReleaseControlContract = ({
         inputs: {
           canonical_refs: refs.canonical,
           compatibility_refs: refs.compatibility,
-          npm_package_target: String(npmPackageTarget ?? '').trim() || 'capacitor',
+          npm_package_target: normalizedNpmPackageTarget,
         },
         artifacts: buildPacketRefs(normalizedReleaseId),
       },

--- a/apps/capacitor-demo/scripts/release-control-contract.test.mjs
+++ b/apps/capacitor-demo/scripts/release-control-contract.test.mjs
@@ -65,6 +65,21 @@ test('release control contract normalizes a valid cross-platform request with on
   assert.equal(result.value.packet.inputs.compatibility_refs.narrative_ref, 'docs/releases/notes/R-2026.04.24.1.json');
 });
 
+test('release control contract derives react-native release identity from published package line', () => {
+  const result = validateReleaseControlContract({
+    releaseId: 'react-native-publish-1-0-0-001',
+    targets: 'npm',
+    targetModes: { npm: 'protected-publish' },
+    repoRoot: '../..',
+    npmPackageTarget: 'react-native',
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.packet.release_identity.version, '1.0.0');
+  assert.equal(result.value.packet.release_identity.release_key, 'stable/v1.0.0/react-native');
+  assert.equal(result.value.packet.inputs.canonical_refs.narrative_ref, 'docs/releases/notes/stable-v1.0.0-react-native.json');
+});
+
 test('release control contract keeps release identity stable across reruns while release id changes', () => {
   const first = validateReleaseControlContract({
     releaseId: 'R-2026.04.24.1',

--- a/apps/capacitor-demo/scripts/release-preflight-completeness.mjs
+++ b/apps/capacitor-demo/scripts/release-preflight-completeness.mjs
@@ -261,13 +261,13 @@ export const evaluateReleasePreflightCompleteness = async ({
 
   if (targets.includes('npm')) {
     const normalizedPackageTarget = effectiveNpmPackageTarget;
-    if (!['capacitor', 'contract'].includes(normalizedPackageTarget)) {
+    if (!['capacitor', 'contract', 'react-native'].includes(normalizedPackageTarget)) {
       addMissing(missing, diagnostics, {
         field: 'npm_package_target',
         target: 'npm',
-        expected: 'capacitor|contract',
+        expected: 'capacitor|contract|react-native',
         reason_code: 'PACKAGE_TARGET_SCOPE',
-        message: 'npm_package_target must be capacitor or contract when npm lane is selected.',
+        message: 'npm_package_target must be capacitor, contract, or react-native when npm lane is selected.',
         release_id: effectiveReleaseId,
       });
     }

--- a/apps/capacitor-demo/scripts/release-preflight-completeness.test.mjs
+++ b/apps/capacitor-demo/scripts/release-preflight-completeness.test.mjs
@@ -145,6 +145,53 @@ test('release preflight reports package target scope violations with canonical r
   assert.equal(result.diagnostics.some((d) => d.code === 'PACKAGE_TARGET_SCOPE'), true);
 });
 
+test('release preflight accepts react-native as npm package target when canonical narrative exists', async () => {
+  const releaseId = 'react-native-publish-1-0-0-001';
+  const repoRoot = await setupRepo({ releaseId, withNarrative: true, withDerivative: false });
+  await writeFile(resolve(repoRoot, 'docs/releases/notes/stable-v1.0.0-react-native.json'), JSON.stringify({ summary: 'RN release' }, null, 2));
+  await writeFile(resolve(repoRoot, `apps/capacitor-demo/artifacts/release-control/${releaseId}/release-execution-packet.json`), JSON.stringify({
+    schema_version: 'release-execution-packet/v2',
+    release_id: releaseId,
+    phase: 'preflight',
+    repo_root: repoRoot,
+    release_identity: {
+      channel: 'stable',
+      version: '1.0.0',
+      package_target: 'react-native',
+      release_key: 'stable/v1.0.0/react-native',
+    },
+    selected_targets: ['npm'],
+    target_modes: { npm: 'protected-publish' },
+    inputs: {
+      canonical_refs: {
+        narrative_ref: 'docs/releases/notes/stable-v1.0.0-react-native.json',
+        ios_derivative_ref: 'docs/releases/notes/stable-v1.0.0-react-native-ios-derivative.md',
+        changelog_anchor: 'CHANGELOG.md#release-stable-v1.0.0-react-native',
+      },
+      compatibility_refs: {
+        narrative_ref: `docs/releases/notes/${releaseId}.json`,
+        ios_derivative_ref: `docs/releases/notes/${releaseId}-ios-derivative.md`,
+        changelog_anchor: `CHANGELOG.md#r-${releaseId.toLowerCase()}`,
+      },
+      npm_package_target: 'react-native',
+    },
+    artifacts: {
+      summary_ref: `apps/capacitor-demo/artifacts/release-control/${releaseId}/summary.json`,
+      facts_ref: `apps/capacitor-demo/artifacts/release-control/${releaseId}/release-facts.json`,
+      reconciliation_ref: `apps/capacitor-demo/artifacts/release-control/${releaseId}/reconciliation-report.json`,
+      closure_bundle_ref: `apps/capacitor-demo/artifacts/release-control/${releaseId}/closure-bundle.json`,
+    },
+  }, null, 2));
+
+  const result = await evaluateReleasePreflightCompleteness({
+    repoRoot,
+    releasePacketPath: resolve(repoRoot, `apps/capacitor-demo/artifacts/release-control/${releaseId}/release-execution-packet.json`),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.missing.length, 0);
+});
+
 test('release preflight fails closed with IDENTITY_AMBIGUOUS for conflicting release identity key', async () => {
   const releaseId = 'R-2026.04.27.12';
   const repoRoot = await setupRepo({ releaseId, withNarrative: true, withDerivative: true });

--- a/docs/releases/notes/stable-v1.0.0-react-native.json
+++ b/docs/releases/notes/stable-v1.0.0-react-native.json
@@ -1,0 +1,17 @@
+{
+  "why_it_matters": "Legato now publishes a first stable React Native/Expo package line with baseline parity against the Capacitor package for the supported playback scope.",
+  "user_impact": "Expo and React Native consumers can now install a stable `@ddgutierrezc/legato-react-native@1.0.0` package with baseline playback surface parity, config-plugin wiring, and exhaustive package documentation.",
+  "upgrade_notes": "Install `@ddgutierrezc/legato-react-native@1.0.0` together with `@ddgutierrezc/legato-contract@1.1.0`, enable the Expo plugin in app config, then regenerate native projects with `expo prebuild --clean` before running iOS or Android hosts.",
+  "breaking_changes": "None. This is the first stable release line for the React Native package.",
+  "affected_platforms": "npm, ios, android",
+  "highlights": [
+    "Publishes the first stable React Native/Expo package line for Legato.",
+    "Provides baseline parity with the Capacitor package across the supported playback surface.",
+    "Includes a minimal Expo config plugin for iOS background audio and Android foreground playback service wiring.",
+    "Ships exhaustive public documentation for React Native package setup, API reference, parity boundaries, and troubleshooting."
+  ],
+  "known_limitations": [
+    "Expo Go remains out of scope for native playback validation.",
+    "Broader event-semantic coverage depth and tooling hygiene follow-ups remain tracked separately and do not block the stable baseline claim."
+  ]
+}


### PR DESCRIPTION
## Summary

- Fix the real `release-control` path for React Native npm releases so Trusted Publisher runs can prepare the release packet successfully instead of failing in preflight.
- Derive the React Native release identity from the package line itself, allow `react-native` as a valid npm preflight target, and add the canonical narrative file expected by release-control.
- Update targeted release-control/preflight tests so this exact path is covered in automation.

## Linked issue

Resolves #172

## Validation

- [x] Relevant tests/checks were run
- [x] No unrelated workflows were changed

Validation executed:
- `cd apps/capacitor-demo && node --test ./scripts/release-control-contract.test.mjs ./scripts/release-preflight-completeness.test.mjs`
- `cd apps/capacitor-demo && npm run release:prepare -- --release-id react-native-publish-1-0-0-001 --targets npm --target-modes npm=protected-publish --repo-root ../.. --npm-package-target react-native`

## Policy checks

- [x] Exactly one `type:*` label added
- [x] Approved issue linked when required (`status:approved`)